### PR TITLE
POC-T-02: OANDA v20 REST client

### DIFF
--- a/.claude/context/data.md
+++ b/.claude/context/data.md
@@ -1,0 +1,46 @@
+# Data context
+
+## POC-T-02 — 2026-05-28 (feat/poc-t-02)
+
+**What was done:**
+- Created `data/__init__.py` (empty package marker).
+- Created `data/oanda_client.py` with:
+  - `OandaAPIError(status_code, message)` — typed exception for HTTP 4xx/5xx.
+  - `CandleRow` pydantic v2 model with all bid/ask/mid price fields (float), `volume: int`,
+    `complete: bool`, and `time: datetime` (UTC-aware, INV-03).
+  - `_parse_utc(iso_string)` — strips nanosecond precision and trailing "Z", then attaches
+    `timezone.utc` explicitly. Handles both `T14:00:00Z` and `T14:00:00.000000000Z` forms.
+  - `OandaClient(settings: Settings)` — uses `oandapyV20.API(environment=...)` where
+    environment is derived from `settings.env` via `_ENV_MAP` (demo→"practice", live→"live")
+    exclusively (INV-09). Token read via `settings.oanda_api_token.get_secret_value()` (INV-08).
+  - `get_candles(instrument, granularity, count, from_time=None) -> list[CandleRow]`:
+    auto-paginates when `count > 500`; each page beyond the first requests `page_size + 1`
+    candles anchored at the last known time and drops the first (duplicate) result.
+    Stops early if OANDA returns fewer candles than requested.
+
+**Key oandapyV20 API notes (D-01):**
+- Class is `oandapyV20.endpoints.instruments.InstrumentsCandles`, NOT `InstrumentsCandlesRequest`.
+- Environment keys for `oandapyV20.API(environment=...)`: `"practice"` (demo) and `"live"`,
+  as defined in `TRADING_ENVIRONMENTS` in `oandapyV20/oandapyV20.py`.
+- Library raises `V20Error(code, msg)` on HTTP ≥ 400; we wrap it in `OandaAPIError`.
+- `price="BAM"` in params returns bid, ask, and mid sub-dicts in each candle.
+
+**pyproject.toml fix:**
+- Build backend was `setuptools.backends.legacy:build` (T-01), but `setuptools.backends`
+  subpackage does not exist in setuptools 82.x. Changed to `setuptools.build_meta`.
+- Added `responses>=0.25` to `[project.optional-dependencies] dev` for HTTP mocking in tests.
+
+**Patterns established:**
+- All timestamps parsed immediately to UTC-aware `datetime` via `_parse_utc()` — never store
+  naive datetimes (INV-03).
+- `_ENV_MAP` is the single place that translates `settings.env` → oandapyV20 env string; no
+  `if env == "live":` branches in logic (INV-09).
+- Tests use `responses` library (`@responses.activate`) to mock HTTP without any live calls.
+- `_make_settings()` helper in tests uses `SecretStr(...)` for the token field to satisfy mypy.
+
+**AC verification results:**
+- `pytest tests/test_oanda_client.py -v` → 22 passed, exit 0
+- `pytest -v` (full suite) → 25 passed, exit 0
+- `mypy data/ tests/test_oanda_client.py` → "Success: no issues found in 3 source files", exit 0
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 
 Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · custom event-driven backtest engine · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
 
+**Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests)
+
 ---
 
 ## Common Commands

--- a/data/oanda_client.py
+++ b/data/oanda_client.py
@@ -18,7 +18,7 @@ from typing import Any
 import oandapyV20
 import oandapyV20.endpoints.instruments as oanda_instruments
 from oandapyV20.exceptions import V20Error
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel
 
 from config.settings import Settings
 
@@ -58,7 +58,7 @@ class CandleRow(BaseModel):
 
     instrument: str
     granularity: str
-    time: datetime          # UTC-aware
+    time: AwareDatetime     # UTC-aware (INV-03: naive datetime rejected by pydantic)
     # bid prices
     open_bid: float
     high_bid: float
@@ -189,7 +189,7 @@ class OandaClient:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        oanda_env = _ENV_MAP[settings.env]  # "practice" or "fxtrade" (INV-09)
+        oanda_env = _ENV_MAP[settings.env]  # "practice" or "live" (INV-09)
         self._api = oandapyV20.API(
             access_token=settings.oanda_api_token.get_secret_value(),
             environment=oanda_env,
@@ -279,12 +279,15 @@ class OandaClient:
                 for c in raw_candles
             ]
             rows.extend(page_rows)
-            first_page = False
 
-            # If OANDA returned fewer candles than the page_size (accounting
-            # for the extra +1 anchor), there is no more data to fetch.
-            # "request_count - (0 if first_page else 1)" is the usable slots.
+            # If OANDA returned fewer candles than the usable page slots, there
+            # is no more data to fetch.  Evaluate this BEFORE clearing
+            # first_page so that the first-page slot count (no anchor deduction)
+            # is used correctly.  "usable_slots" on the first page equals
+            # request_count; on subsequent pages it is request_count - 1
+            # (the +1 anchor candle is not a net-new slot).
             usable_slots = request_count if first_page else request_count - 1
+            first_page = False
             if len(raw_candles) < usable_slots:
                 break
 

--- a/data/oanda_client.py
+++ b/data/oanda_client.py
@@ -1,0 +1,294 @@
+"""OANDA v20 REST client — candle endpoint only.
+
+Scope: PoC (POC-T-02). No streaming, no order methods.
+
+INV-03 compliance: all timestamps are UTC-aware datetime from first touch.
+INV-08 compliance: token is read via SecretStr.get_secret_value(); never logged.
+INV-09 compliance: environment (practice/live) is derived exclusively from
+    settings.env — no stray env-var override.
+
+D-01: uses oandapyV20 as the HTTP transport.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import oandapyV20
+import oandapyV20.endpoints.instruments as oanda_instruments
+from oandapyV20.exceptions import V20Error
+from pydantic import BaseModel
+
+from config.settings import Settings
+
+# OANDA hard cap: maximum candles returned per single request.
+_OANDA_MAX_PER_REQUEST: int = 500
+
+# Map settings.env values to oandapyV20 environment identifiers (INV-09).
+# oandapyV20 recognises "practice" and "live" — not "fxtrade".
+_ENV_MAP: dict[str, str] = {
+    "demo": "practice",
+    "live": "live",
+}
+
+
+class OandaAPIError(Exception):
+    """Raised when the OANDA v20 API returns an HTTP 4xx or 5xx response.
+
+    Attributes
+    ----------
+    status_code : int
+        The HTTP status code returned by OANDA.
+    message : str
+        The error message / body returned by OANDA.
+    """
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"OANDA API error {status_code}: {message}")
+
+
+class CandleRow(BaseModel):
+    """A single OANDA candle bar with bid, ask, and mid prices.
+
+    All price fields are floats. ``time`` is always UTC-aware (INV-03).
+    """
+
+    instrument: str
+    granularity: str
+    time: datetime          # UTC-aware
+    # bid prices
+    open_bid: float
+    high_bid: float
+    low_bid: float
+    close_bid: float
+    # ask prices
+    open_ask: float
+    high_ask: float
+    low_ask: float
+    close_ask: float
+    # mid prices
+    open_mid: float
+    high_mid: float
+    low_mid: float
+    close_mid: float
+    # metadata
+    volume: int
+    complete: bool
+
+
+def _parse_utc(iso_string: str) -> datetime:
+    """Parse an ISO 8601 UTC string from OANDA into a UTC-aware datetime.
+
+    OANDA returns strings like ``"2024-01-15T14:00:00.000000000Z"``.
+    Python's ``fromisoformat`` does not handle nanosecond precision or
+    the trailing ``Z`` on all Python versions, so sub-second precision
+    is truncated to microseconds before parsing, then UTC is attached
+    explicitly.
+
+    Args:
+        iso_string: ISO 8601 UTC timestamp string from OANDA.
+
+    Returns:
+        A UTC-aware ``datetime`` object.
+    """
+    # Strip trailing "Z" and trim fractional seconds to at most 6 digits.
+    # e.g. "2024-01-15T14:00:00.000000000Z" -> "2024-01-15T14:00:00.000000"
+    # e.g. "2024-01-15T14:00:00Z"           -> "2024-01-15T14:00:00"
+    s = iso_string.rstrip("Z")
+    if "." in s:
+        date_part, frac = s.split(".", 1)
+        frac = frac[:6].ljust(6, "0")
+        s = f"{date_part}.{frac}"
+
+    dt = datetime.fromisoformat(s)
+    # OANDA always returns UTC; the string carries no offset, so attach it.
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def _candle_to_row(
+    instrument: str,
+    granularity: str,
+    candle: dict[str, Any],
+) -> CandleRow:
+    """Convert a single raw OANDA candle dict to a ``CandleRow``.
+
+    Requires the candle to carry bid, ask, and mid sub-dicts (i.e. the
+    request was issued with ``price="BAM"``).
+
+    Args:
+        instrument: The OANDA instrument identifier (e.g. ``"EUR_USD"``).
+        granularity: The candle granularity (e.g. ``"H1"``).
+        candle: A single candle dict from the OANDA response.
+
+    Returns:
+        A validated ``CandleRow`` instance with UTC-aware timestamp.
+    """
+    bid = candle["bid"]
+    ask = candle["ask"]
+    mid = candle["mid"]
+
+    return CandleRow(
+        instrument=instrument,
+        granularity=granularity,
+        time=_parse_utc(candle["time"]),
+        open_bid=float(bid["o"]),
+        high_bid=float(bid["h"]),
+        low_bid=float(bid["l"]),
+        close_bid=float(bid["c"]),
+        open_ask=float(ask["o"]),
+        high_ask=float(ask["h"]),
+        low_ask=float(ask["l"]),
+        close_ask=float(ask["c"]),
+        open_mid=float(mid["o"]),
+        high_mid=float(mid["h"]),
+        low_mid=float(mid["l"]),
+        close_mid=float(mid["c"]),
+        volume=int(candle["volume"]),
+        complete=bool(candle["complete"]),
+    )
+
+
+def _request_page(
+    api: oandapyV20.API,
+    instrument: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Issue a single ``InstrumentsCandles`` request and return the raw response.
+
+    Args:
+        api: An initialised ``oandapyV20.API`` instance.
+        instrument: OANDA instrument identifier.
+        params: Query parameters dict for ``InstrumentsCandles``.
+
+    Returns:
+        The raw response dict from OANDA.
+
+    Raises:
+        OandaAPIError: If OANDA returns HTTP 4xx or 5xx.
+    """
+    try:
+        req = oanda_instruments.InstrumentsCandles(instrument, params=params)
+        return api.request(req)  # type: ignore[no-any-return]
+    except V20Error as exc:
+        raise OandaAPIError(exc.code, exc.msg) from exc
+
+
+class OandaClient:
+    """OANDA v20 REST client — candle data only.
+
+    Wraps ``oandapyV20`` to provide a typed, paginated interface.
+    Authentication and environment selection are taken exclusively from
+    ``settings`` (INV-09); the token is never logged (INV-08).
+
+    Args:
+        settings: A fully-initialised ``Settings`` instance.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        oanda_env = _ENV_MAP[settings.env]  # "practice" or "fxtrade" (INV-09)
+        self._api = oandapyV20.API(
+            access_token=settings.oanda_api_token.get_secret_value(),
+            environment=oanda_env,
+        )
+
+    def get_candles(
+        self,
+        instrument: str,
+        granularity: str,
+        count: int,
+        from_time: datetime | None = None,
+    ) -> list[CandleRow]:
+        """Fetch candle bars for an instrument, auto-paginating if needed.
+
+        OANDA caps responses at 500 candles per request.  When ``count``
+        exceeds 500 this method issues multiple sequential requests and
+        concatenates the results.  Pagination advances via the ``from``
+        query parameter: each subsequent page starts from the timestamp
+        immediately after the last received candle, achieved by requesting
+        ``page_size + 1`` candles anchored at the last candle's time and
+        dropping the first (duplicate) result.
+
+        Args:
+            instrument: OANDA instrument identifier, e.g. ``"EUR_USD"``.
+            granularity: OANDA granularity string, e.g. ``"H1"`` or ``"D"``.
+            count: Total number of candles to retrieve (>= 1).
+            from_time: Optional UTC-aware datetime for the start of the
+                range.  If ``None``, OANDA returns the most recent candles.
+
+        Returns:
+            A list of ``CandleRow`` instances in ascending chronological
+            order.  May be shorter than ``count`` if OANDA has exhausted
+            the available data.
+
+        Raises:
+            OandaAPIError: If OANDA returns an HTTP 4xx or 5xx status.
+            ValueError: If ``from_time`` is provided but is not UTC-aware.
+        """
+        if from_time is not None and from_time.tzinfo is None:
+            raise ValueError(
+                "from_time must be a UTC-aware datetime (INV-03). "
+                "Use datetime(..., tzinfo=timezone.utc)."
+            )
+
+        rows: list[CandleRow] = []
+        current_from = from_time
+        first_page = True
+
+        while len(rows) < count:
+            needed = count - len(rows)
+
+            # On pages after the first, we request one extra candle anchored
+            # at the last received time.  OANDA "from" is inclusive, so the
+            # first returned candle is the duplicate of the previous page's
+            # last entry — we skip it below.
+            request_count = min(
+                needed if first_page else needed + 1,
+                _OANDA_MAX_PER_REQUEST,
+            )
+
+            params: dict[str, Any] = {
+                "granularity": granularity,
+                "count": request_count,
+                "price": "BAM",  # bid + ask + mid in a single call (D-01)
+            }
+            if current_from is not None:
+                params["from"] = current_from.strftime(
+                    "%Y-%m-%dT%H:%M:%S.000000000Z"
+                )
+
+            response = _request_page(self._api, instrument, params)
+            raw_candles: list[dict[str, Any]] = response.get("candles", [])
+
+            if not raw_candles:
+                break  # OANDA returned nothing; no more data available.
+
+            # On pages 2+: drop the first candle (duplicate of previous last).
+            if not first_page:
+                raw_candles = raw_candles[1:]
+
+            if not raw_candles:
+                # All we got back was the duplicate anchor candle — exhausted.
+                break
+
+            page_rows = [
+                _candle_to_row(instrument, granularity, c)
+                for c in raw_candles
+            ]
+            rows.extend(page_rows)
+            first_page = False
+
+            # If OANDA returned fewer candles than the page_size (accounting
+            # for the extra +1 anchor), there is no more data to fetch.
+            # "request_count - (0 if first_page else 1)" is the usable slots.
+            usable_slots = request_count if first_page else request_count - 1
+            if len(raw_candles) < usable_slots:
+                break
+
+            # Advance the anchor to the last received candle's time.
+            current_from = rows[-1].time
+
+        return rows[:count]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 dev = [
     "pytest>=7.4",
     "mypy>=1.8",
+    "responses>=0.25",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_oanda_client.py
+++ b/tests/test_oanda_client.py
@@ -1,0 +1,406 @@
+"""Unit tests for data.oanda_client.
+
+Mocks the OANDA v20 candle endpoint using the ``responses`` library.
+No live HTTP calls are made.
+
+Covers:
+- Single-page success (count <= 500)
+- Multi-page pagination (count > 500)
+- 401 Unauthorised error -> OandaAPIError
+- 400 Bad instrument error -> OandaAPIError
+- UTC-aware timestamps on all returned CandleRow instances
+- price="BAM" is sent in every request
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses as resp_lib
+from pydantic import SecretStr
+from responses import matchers
+
+from config.settings import Settings
+from data.oanda_client import CandleRow, OandaAPIError, OandaClient, _parse_utc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PRACTICE_BASE = "https://api-fxpractice.oanda.com"
+CANDLES_URL = f"{PRACTICE_BASE}/v3/instruments/EUR_USD/candles"
+
+
+def _make_candle(
+    time: str = "2024-01-15T14:00:00.000000000Z",
+    volume: int = 100,
+    complete: bool = True,
+    o: str = "1.08500",
+    h: str = "1.08600",
+    lo: str = "1.08400",
+    c: str = "1.08550",
+) -> dict[str, Any]:
+    """Build a single OANDA candle dict with bid, ask, and mid prices."""
+    return {
+        "time": time,
+        "volume": volume,
+        "complete": complete,
+        "bid": {"o": o, "h": h, "l": lo, "c": c},
+        "ask": {"o": str(float(o) + 0.0001), "h": str(float(h) + 0.0001),
+                "l": str(float(lo) + 0.0001), "c": str(float(c) + 0.0001)},
+        "mid": {"o": str(float(o) + 0.00005), "h": str(float(h) + 0.00005),
+                "l": str(float(lo) + 0.00005), "c": str(float(c) + 0.00005)},
+    }
+
+
+def _make_candles_response(candles: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap candles in an OANDA-style top-level response dict."""
+    return {
+        "instrument": "EUR_USD",
+        "granularity": "H1",
+        "candles": candles,
+    }
+
+
+def _make_settings(env: str = "demo") -> Settings:
+    """Construct a Settings instance with dummy credentials."""
+    return Settings(
+        env=env,  # type: ignore[arg-type]
+        oanda_api_token=SecretStr("dummy-token-never-used-in-tests"),
+        oanda_account_id="001-001-1234567-001",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_utc helper tests
+# ---------------------------------------------------------------------------
+
+class TestParseUtc:
+    def test_nanosecond_precision_string(self) -> None:
+        dt = _parse_utc("2024-01-15T14:00:00.000000000Z")
+        assert dt.tzinfo is not None
+        assert dt.tzinfo == timezone.utc
+        assert dt.year == 2024
+        assert dt.month == 1
+        assert dt.day == 15
+        assert dt.hour == 14
+
+    def test_no_fractional_seconds(self) -> None:
+        dt = _parse_utc("2024-06-30T00:00:00Z")
+        assert dt.tzinfo == timezone.utc
+        assert dt.second == 0
+
+    def test_microsecond_precision(self) -> None:
+        dt = _parse_utc("2024-01-15T14:00:00.123456Z")
+        assert dt.microsecond == 123456
+        assert dt.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Single-page success
+# ---------------------------------------------------------------------------
+
+class TestSinglePage:
+    @resp_lib.activate
+    def test_returns_correct_number_of_rows(self) -> None:
+        candles = [_make_candle(f"2024-01-15T{14 + i:02d}:00:00.000000000Z") for i in range(3)]
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            json=_make_candles_response(candles),
+            status=200,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 3)
+        assert len(rows) == 3
+
+    @resp_lib.activate
+    def test_returns_candle_row_instances(self) -> None:
+        candles = [_make_candle()]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert isinstance(rows[0], CandleRow)
+
+    @resp_lib.activate
+    def test_timestamps_are_utc_aware(self) -> None:
+        candles = [_make_candle("2024-03-20T10:00:00.000000000Z")]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert rows[0].time.tzinfo is not None
+        assert rows[0].time.tzinfo == timezone.utc
+        assert rows[0].time == datetime(2024, 3, 20, 10, 0, 0, tzinfo=timezone.utc)
+
+    @resp_lib.activate
+    def test_price_BAM_sent_in_request(self) -> None:
+        """Verify that price=BAM is included in the query string."""
+        candles = [_make_candle()]
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            match=[matchers.query_param_matcher(
+                {"granularity": "H1", "count": "1", "price": "BAM"},
+                strict_match=False,
+            )],
+            json=_make_candles_response(candles),
+            status=200,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert len(rows) == 1
+
+    @resp_lib.activate
+    def test_bid_ask_mid_prices_parsed(self) -> None:
+        # _make_candle adds 0.0001 for ask and 0.00005 for mid relative to bid.
+        candle = _make_candle(o="1.08500", h="1.08600", lo="1.08400", c="1.08550")
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response([candle]), status=200)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        row = rows[0]
+        assert row.open_bid == pytest.approx(1.08500)
+        # ask high = 1.08600 + 0.0001 = 1.0861
+        assert row.high_ask == pytest.approx(1.08600 + 0.0001)
+        # mid open = 1.08500 + 0.00005 = 1.08505
+        assert row.open_mid == pytest.approx(1.08500 + 0.00005)
+
+    @resp_lib.activate
+    def test_instrument_and_granularity_set_on_row(self) -> None:
+        candles = [_make_candle()]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert rows[0].instrument == "EUR_USD"
+        assert rows[0].granularity == "H1"
+
+    @resp_lib.activate
+    def test_volume_and_complete_flags(self) -> None:
+        candles = [_make_candle(volume=250, complete=True)]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert rows[0].volume == 250
+        assert rows[0].complete is True
+
+    @resp_lib.activate
+    def test_from_time_included_in_request(self) -> None:
+        from_dt = datetime(2024, 1, 10, 0, 0, 0, tzinfo=timezone.utc)
+        candles = [_make_candle()]
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            match=[matchers.query_param_matcher(
+                {"granularity": "H1", "count": "1", "price": "BAM",
+                 "from": "2024-01-10T00:00:00.000000000Z"},
+                strict_match=True,
+            )],
+            json=_make_candles_response(candles),
+            status=200,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1, from_time=from_dt)
+        assert len(rows) == 1
+
+    def test_naive_from_time_raises_value_error(self) -> None:
+        settings = _make_settings()
+        client = OandaClient(settings)
+        naive_dt = datetime(2024, 1, 1, 0, 0, 0)  # no tzinfo
+        with pytest.raises(ValueError, match="UTC-aware"):
+            client.get_candles("EUR_USD", "H1", 10, from_time=naive_dt)
+
+
+# ---------------------------------------------------------------------------
+# Multi-page pagination
+# ---------------------------------------------------------------------------
+
+class TestPagination:
+    @resp_lib.activate
+    def test_issues_two_requests_when_count_exceeds_500(self) -> None:
+        """count=600 should trigger exactly two HTTP requests."""
+        def _ts1(idx: int) -> str:
+            day = 1 + idx // 24
+            hour = idx % 24
+            return f"2024-01-{day:02d}T{hour:02d}:00:00.000000000Z"
+
+        # First page: 500 candles
+        page1_candles = [_make_candle(_ts1(i)) for i in range(500)]
+
+        # Second page: 101 candles (first is duplicate of last in page1, so 100 net)
+        page2_candles = [
+            _make_candle(f"2024-02-{1 + j // 24:02d}T{j % 24:02d}:00:00.000000000Z")
+            for j in range(101)
+        ]
+        # Match all GET requests to the candles URL, return pages in order
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(page1_candles), status=200)
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(page2_candles), status=200)
+
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 600)
+
+        # Two requests made
+        assert len(resp_lib.calls) == 2
+        # Total rows should be <= 600
+        assert len(rows) <= 600
+
+    @resp_lib.activate
+    def test_pagination_concatenates_results(self) -> None:
+        """Rows from page1 and page2 are all present in output."""
+        # Build 500 candles with valid timestamps using day+hour combinations.
+        # 500 hours = ~20 days * 24 + 20 hours; iterate over day 1-21.
+        def _ts(idx: int) -> str:
+            day = 1 + idx // 24
+            hour = idx % 24
+            return f"2024-01-{day:02d}T{hour:02d}:00:00.000000000Z"
+
+        page1 = [_make_candle(_ts(i)) for i in range(500)]
+        # Page2: first candle is duplicate of page1's last, followed by 100 new
+        last_of_page1 = page1[-1]
+        new_candles = [_make_candle(f"2024-02-{1 + j // 24:02d}T{j % 24:02d}:00:00.000000000Z")
+                       for j in range(100)]
+        page2 = [last_of_page1] + new_candles
+
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(page1), status=200)
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(page2), status=200)
+
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 600)
+
+        # Should have combined 500 + 100 = 600 rows (duplicate dropped)
+        assert len(rows) == 600
+
+    @resp_lib.activate
+    def test_stops_when_oanda_returns_less_than_requested(self) -> None:
+        """If OANDA returns fewer candles than asked, do not issue more requests."""
+        candles = [_make_candle(f"2024-01-01T{i:02d}:00:00.000000000Z") for i in range(10)]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 500)
+
+        assert len(resp_lib.calls) == 1
+        assert len(rows) == 10
+
+    @resp_lib.activate
+    def test_returns_at_most_count_rows(self) -> None:
+        """Even if OANDA returns more, output is capped at count."""
+        candles = [_make_candle(f"2024-01-01T{i:02d}:00:00.000000000Z") for i in range(20)]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 5)
+        assert len(rows) == 5
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    @resp_lib.activate
+    def test_401_raises_oanda_api_error(self) -> None:
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            json={"errorMessage": "Unauthorised"},
+            status=401,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        with pytest.raises(OandaAPIError) as exc_info:
+            client.get_candles("EUR_USD", "H1", 10)
+        assert exc_info.value.status_code == 401
+
+    @resp_lib.activate
+    def test_400_bad_instrument_raises_oanda_api_error(self) -> None:
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            json={"errorMessage": "Invalid instrument: EUR_USD_BAD"},
+            status=400,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        with pytest.raises(OandaAPIError) as exc_info:
+            client.get_candles("EUR_USD", "H1", 10)
+        assert exc_info.value.status_code == 400
+
+    @resp_lib.activate
+    def test_oanda_api_error_is_not_v20error(self) -> None:
+        """The raised error must be OandaAPIError, not the raw V20Error."""
+        from oandapyV20.exceptions import V20Error
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json={"errorMessage": "Server error"}, status=500)
+        settings = _make_settings()
+        client = OandaClient(settings)
+        with pytest.raises(OandaAPIError):
+            client.get_candles("EUR_USD", "H1", 10)
+
+    @resp_lib.activate
+    def test_oanda_api_error_message_accessible(self) -> None:
+        resp_lib.add(
+            resp_lib.GET,
+            CANDLES_URL,
+            json={"errorMessage": "Account not found"},
+            status=403,
+        )
+        settings = _make_settings()
+        client = OandaClient(settings)
+        with pytest.raises(OandaAPIError) as exc_info:
+            client.get_candles("EUR_USD", "H1", 10)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.message  # non-empty message
+
+
+# ---------------------------------------------------------------------------
+# Environment / settings wiring
+# ---------------------------------------------------------------------------
+
+class TestEnvironmentWiring:
+    @resp_lib.activate
+    def test_demo_env_uses_practice_url(self) -> None:
+        """demo settings -> requests go to api-fxpractice.oanda.com."""
+        candles = [_make_candle()]
+        resp_lib.add(
+            resp_lib.GET,
+            f"{PRACTICE_BASE}/v3/instruments/EUR_USD/candles",
+            json=_make_candles_response(candles),
+            status=200,
+        )
+        settings = _make_settings(env="demo")
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert len(rows) == 1
+        # The call must have hit the practice base URL.
+        called_url = resp_lib.calls[0].request.url
+        assert called_url is not None
+        assert PRACTICE_BASE in called_url
+
+    @resp_lib.activate
+    def test_live_env_uses_live_url(self) -> None:
+        """live settings -> requests go to api-fxtrade.oanda.com."""
+        live_url = "https://api-fxtrade.oanda.com/v3/instruments/EUR_USD/candles"
+        candles = [_make_candle()]
+        resp_lib.add(resp_lib.GET, live_url, json=_make_candles_response(candles), status=200)
+        settings = _make_settings(env="live")
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 1)
+        assert len(rows) == 1
+        called_url = resp_lib.calls[0].request.url
+        assert called_url is not None
+        assert "api-fxtrade.oanda.com" in called_url

--- a/tests/test_oanda_client.py
+++ b/tests/test_oanda_client.py
@@ -24,6 +24,8 @@ import responses as resp_lib
 from pydantic import SecretStr
 from responses import matchers
 
+import pydantic
+
 from config.settings import Settings
 from data.oanda_client import CandleRow, OandaAPIError, OandaClient, _parse_utc
 
@@ -99,6 +101,40 @@ class TestParseUtc:
         dt = _parse_utc("2024-01-15T14:00:00.123456Z")
         assert dt.microsecond == 123456
         assert dt.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# INV-03: CandleRow rejects naive datetime (AwareDatetime enforcement)
+# ---------------------------------------------------------------------------
+
+class TestCandleRowInv03:
+    def test_naive_time_raises_validation_error(self) -> None:
+        """CandleRow must reject a naive (tz-unaware) datetime for time (INV-03)."""
+        with pytest.raises(pydantic.ValidationError):
+            CandleRow(
+                instrument="EUR_USD",
+                granularity="H1",
+                time=datetime(2024, 1, 1),  # naive — no tzinfo
+                open_bid=1.0, high_bid=1.0, low_bid=1.0, close_bid=1.0,
+                open_ask=1.0, high_ask=1.0, low_ask=1.0, close_ask=1.0,
+                open_mid=1.0, high_mid=1.0, low_mid=1.0, close_mid=1.0,
+                volume=100,
+                complete=True,
+            )
+
+    def test_utc_aware_time_accepted(self) -> None:
+        """CandleRow must accept a UTC-aware datetime for time (INV-03)."""
+        row = CandleRow(
+            instrument="EUR_USD",
+            granularity="H1",
+            time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            open_bid=1.0, high_bid=1.0, low_bid=1.0, close_bid=1.0,
+            open_ask=1.0, high_ask=1.0, low_ask=1.0, close_ask=1.0,
+            open_mid=1.0, high_mid=1.0, low_mid=1.0, close_mid=1.0,
+            volume=100,
+            complete=True,
+        )
+        assert row.time.tzinfo is not None
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +342,29 @@ class TestPagination:
         client = OandaClient(settings)
         rows = client.get_candles("EUR_USD", "H1", 5)
         assert len(rows) == 5
+
+    @resp_lib.activate
+    def test_first_page_returns_499_of_500_requested_issues_only_one_request(self) -> None:
+        """Boundary: count=500, OANDA returns 499 on first page → no second request.
+
+        Regression test for the off-by-one where first_page was cleared before
+        the usable_slots early-exit check, causing a spurious extra request when
+        OANDA returns exactly request_count - 1 candles on the first page.
+        """
+        candles = [
+            _make_candle(f"2024-01-{1 + i // 24:02d}T{i % 24:02d}:00:00.000000000Z")
+            for i in range(499)
+        ]
+        resp_lib.add(resp_lib.GET, CANDLES_URL, json=_make_candles_response(candles), status=200)
+
+        settings = _make_settings()
+        client = OandaClient(settings)
+        rows = client.get_candles("EUR_USD", "H1", 500)
+
+        assert len(resp_lib.calls) == 1, (
+            "Expected exactly one HTTP request when OANDA returns 499 of 500 candles"
+        )
+        assert len(rows) == 499
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3.

## Summary

Implements the OANDA v20 REST candle client (POC-T-02):

- `data/oanda_client.py`: `OandaClient(settings)` with `get_candles(instrument, granularity, count, from_time) -> list[CandleRow]`
- `CandleRow` pydantic v2 model with all bid/ask/mid price fields, UTC-aware `time`, `volume`, and `complete`
- Auto-pagination: issues multiple requests when `count > 500`, dropping the duplicate anchor candle on pages 2+
- `OandaAPIError(status_code, message)` wraps all OANDA HTTP 4xx/5xx responses
- `price="BAM"` on every request to retrieve bid + ask + mid in one call (D-01)
- INV-03: `_parse_utc()` strips nanoseconds and attaches `timezone.utc` immediately at parse time
- INV-09: environment (`practice`/`live`) derived exclusively from `settings.env` via `_ENV_MAP`
- INV-08: token accessed only via `get_secret_value()`, never logged

Also fixes `pyproject.toml` build-backend (`setuptools.backends.legacy:build` → `setuptools.build_meta`) which failed on setuptools 82.x, and adds `responses>=0.25` as a dev dep.

## Test plan

- [ ] `pytest tests/test_oanda_client.py -v` — 22 tests: single-page, pagination, 401, 400, env wiring
- [ ] `pytest -v` — 25 passed (includes T-01 config tests)
- [ ] `mypy data/ tests/test_oanda_client.py` — no issues