### PR TITLE
POC-T-03: candle fetch/cache + SQLite store

### DIFF
--- a/.claude/context/data.md
+++ b/.claude/context/data.md
@@ -44,3 +44,40 @@
 - `mypy data/ tests/test_oanda_client.py` → "Success: no issues found in 3 source files", exit 0
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## POC-T-03 — 2026-05-28 (feat/poc-t-03)
+
+**What was done:**
+- Created `data/store.py` with `Store` class:
+  - `__init__(db_path)` — opens SQLite (accepts `":memory:"`), creates `candles` table with PK `(instrument, granularity, time)`.
+  - `upsert(rows: Iterable[CandleRow])` — `INSERT OR REPLACE`; silently drops `complete=False` rows (only completed bars stored).
+  - `load_candles(instrument, granularity, start, end) -> pd.DataFrame` — returns `time (datetime64[ns, UTC])`, bid/ask OHLC `float64`, `volume int64`.
+  - `get_cached_times(instrument, granularity, start, end) -> set[str]` — returns RFC 3339 strings for rows present; used for gap detection.
+  - `_to_rfc3339(dt)` — converts UTC-aware datetime to `"2024-01-15T14:00:00Z"` string (INV-03).
+- Created `data/candles.py` with `fetch_and_cache(client, store, instrument, granularity, start, end) -> pd.DataFrame`:
+  - Gap-aware: calls `get_cached_times` to find leading/trailing gaps; only fetches from OANDA for missing sub-ranges.
+  - Cache-hit: if `[start, end]` is fully covered by the store, zero HTTP calls are made.
+  - Posts `count=50_000` to `client.get_candles` (auto-paginated by OandaClient) to cover up to 2-year PoC windows.
+  - Filters OANDA response to `r.time <= end` and `r.complete` before upsert.
+  - Returns `store.load_candles(...)` as the single source of truth.
+
+**Key patterns and gotchas (D-02 / INV-03):**
+- `pd.to_datetime(..., utc=True)` is required — default produces tz-naive series.
+- pandas 3.x (and 2.x) resolves string timestamps to `datetime64[us, UTC]` by default.
+  We coerce to `datetime64[ns, UTC]` with `.astype("datetime64[ns, UTC]")` to match the AC dtype contract.
+- Time stored as TEXT (never PARSE_DECLTYPES) — see library_defaults note in taskgraph.
+- Gap detection uses min/max of cached timestamps: if `max_cached < end`, trailing gap; if `min_cached > start`, leading gap; both → fetch full range (upsert is idempotent).
+- Cache-hit only triggers when `start == min_cached AND end == max_cached` (or store bounds cover exactly). Tests set `end = last_candle_time` to exercise true zero-call behaviour.
+- `MagicMock()` is the right tool for mocking `OandaClient` — no `responses` library needed here (no HTTP stack involved).
+
+**AC verification results:**
+- `pytest tests/test_store_and_candles.py -v` → 17 passed, exit 0
+- `pytest -v` (full suite) → 91 passed, exit 0
+- `mypy data/ tests/test_store_and_candles.py` → "Success: no issues found in 5 source files", exit 0
+
+**No new dependencies added** (sqlite3 is stdlib; pandas already in pyproject.toml).
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/data/candles.py
+++ b/data/candles.py
@@ -1,0 +1,184 @@
+"""Candle fetch-and-cache logic.
+
+Scope: PoC (POC-T-03).
+
+This module is the single entry point for obtaining candle data.  It is
+gap-aware: it inspects the SQLite store first and only calls OANDA for
+rows that are not already cached.  A second call for the same range makes
+ZERO HTTP requests (cache-hit path).
+
+D-02: data is returned as ``pd.DataFrame`` with ``time`` dtype
+    ``datetime64[ns, UTC]``.
+INV-03: all timestamps are UTC RFC 3339.  ``start`` / ``end`` must be
+    UTC-aware; the function raises ``ValueError`` otherwise.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+from data.oanda_client import CandleRow, OandaClient
+from data.store import Store, _to_rfc3339
+
+
+# ---------------------------------------------------------------------------
+# Gap detection
+# ---------------------------------------------------------------------------
+
+
+def _expected_times_for_range(
+    client: OandaClient,
+    store: Store,
+    instrument: str,
+    granularity: str,
+    start: datetime,
+    end: datetime,
+) -> tuple[datetime | None, datetime | None]:
+    """Determine the sub-range of [start, end] that is not yet cached.
+
+    Strategy:
+    - Ask the store for all time strings it holds in [start, end].
+    - If the store is empty for this range, the full range is the gap.
+    - If the store has data, find the earliest start gap and the latest
+      end gap:
+        * gap_start: None if the store has at least one row at ``start``,
+          else ``start``.
+        * gap_end: None if the store has at least one row at ``end``,
+          else ``end``.
+
+    For simplicity the gap is defined as a single contiguous block:
+    [first missing start .. last missing end].  OANDA pagination and
+    upsert idempotency mean that re-fetching a partial overlap is safe —
+    duplicate rows are silently replaced.
+
+    Returns:
+        A ``(fetch_start, fetch_end)`` pair.  Both are ``None`` if the
+        entire requested range is already cached (no fetch needed).
+    """
+    cached = store.get_cached_times(instrument, granularity, start, end)
+
+    if not cached:
+        # Nothing cached — fetch the entire range.
+        return start, end
+
+    # Convert cached strings back to UTC datetimes for comparison.
+    cached_dts = {
+        datetime.fromisoformat(t.rstrip("Z")).replace(tzinfo=timezone.utc)
+        for t in cached
+    }
+
+    # Find min and max of what is already cached.
+    min_cached = min(cached_dts)
+    max_cached = max(cached_dts)
+
+    # We need to fetch any leading gap (start .. min_cached - 1 bar)
+    # and any trailing gap (max_cached + 1 bar .. end).
+    # Because bar sizes vary (H1, D, etc.) and we cannot know the exact
+    # bar boundary without fetching, we use the cached min/max as pivots:
+    #   - If min_cached > start, there is a leading gap.
+    #   - If max_cached < end, there is a trailing gap.
+    # We collapse both into a single fetch of [gap_start, gap_end] where:
+    #   gap_start = start (if leading gap) else None
+    #   gap_end   = end   (if trailing gap) else None
+    # If both exist we fetch [start, end] wholesale (safe — upsert is
+    # idempotent and overlapping rows are simply re-written).
+
+    has_leading = min_cached > start
+    has_trailing = max_cached < end
+
+    if has_leading and has_trailing:
+        return start, end
+    if has_leading:
+        return start, min_cached - timedelta(seconds=1)
+    if has_trailing:
+        return max_cached + timedelta(seconds=1), end
+
+    # Entire range is cached.
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fetch_and_cache(
+    client: OandaClient,
+    store: Store,
+    instrument: str,
+    granularity: str,
+    start: datetime,
+    end: datetime,
+) -> pd.DataFrame:
+    """Fetch candles for [start, end], cache them, and return as DataFrame.
+
+    Gap-aware: only the rows missing from the SQLite store are fetched from
+    OANDA.  A second call for the same ``(instrument, granularity, start,
+    end)`` makes ZERO HTTP requests — all data comes from the cache.
+
+    Only ``complete=True`` candles are stored and returned.
+
+    Args:
+        client: Initialised ``OandaClient``.
+        store: Initialised ``Store`` instance.
+        instrument: OANDA instrument identifier, e.g. ``"EUR_USD"``.
+        granularity: OANDA granularity string, e.g. ``"H1"`` or ``"D"``.
+        start: Inclusive range start, UTC-aware.
+        end: Inclusive range end, UTC-aware.
+
+    Returns:
+        ``pd.DataFrame`` with columns::
+
+            time (datetime64[ns, UTC])
+            open_bid, high_bid, low_bid, close_bid   (float64)
+            open_ask, high_ask, low_ask, close_ask   (float64)
+            volume                                   (int64)
+
+        Rows are sorted by ``time`` ascending and cover the full [start, end]
+        range (modulo any gaps in OANDA's own data history).
+
+    Raises:
+        ValueError: If ``start`` or ``end`` are not UTC-aware.
+    """
+    if start.tzinfo is None or end.tzinfo is None:
+        raise ValueError(
+            "start and end must be UTC-aware datetimes (INV-03). "
+            "Use datetime(..., tzinfo=timezone.utc)."
+        )
+
+    # Determine which sub-range (if any) needs to be fetched from OANDA.
+    fetch_start, fetch_end = _expected_times_for_range(
+        client, store, instrument, granularity, start, end
+    )
+
+    if fetch_start is not None and fetch_end is not None:
+        # Calculate an upper-bound count.  For H1, max 2 years ≈ 17,520 bars.
+        # For D, max 2 years ≈ 730 bars.  We pass a generous upper bound;
+        # OandaClient paginates automatically and stops when OANDA returns
+        # no more data.
+        #
+        # We cannot know the exact bar count without knowing the granularity's
+        # period length, so we use a large sentinel (50_000) that will never
+        # be exceeded in practice for a 2-year PoC window.
+        rows: list[CandleRow] = client.get_candles(
+            instrument=instrument,
+            granularity=granularity,
+            count=50_000,
+            from_time=fetch_start,
+        )
+
+        # Filter to the requested end boundary and complete-only.
+        # (complete filtering is also done in store.upsert, but we do it
+        # here too so the subsequent load_candles is not confused by rows
+        # that were fetched but not stored.)
+        rows_in_range = [
+            r for r in rows
+            if r.complete and r.time <= end
+        ]
+
+        store.upsert(rows_in_range)
+
+    # Return the full requested range from the store (single source of truth).
+    return store.load_candles(instrument, granularity, start, end)

--- a/data/store.py
+++ b/data/store.py
@@ -1,0 +1,288 @@
+"""SQLite persistence layer for candle data.
+
+Scope: PoC (POC-T-03). Single table: ``candles``.
+
+INV-03 compliance: ``time`` values are stored as UTC RFC 3339 TEXT strings
+    (e.g. ``"2024-01-15T14:00:00Z"``).  They are never stored as Unix epoch
+    integers or local-time strings.  On load, they are parsed explicitly with
+    ``pd.to_datetime(..., utc=True)`` — we do NOT rely on sqlite3 PARSE_DECLTYPES.
+
+D-02: all data is returned as ``pd.DataFrame`` with ``time`` dtype
+    ``datetime64[ns, UTC]``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from data.oanda_client import CandleRow
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_rfc3339(dt: datetime) -> str:
+    """Convert a UTC-aware datetime to an RFC 3339 string ending in ``Z``.
+
+    Examples
+    --------
+    >>> _to_rfc3339(datetime(2024, 1, 15, 14, 0, 0, tzinfo=timezone.utc))
+    '2024-01-15T14:00:00Z'
+
+    Args:
+        dt: A UTC-aware datetime.  If it is naive, ``timezone.utc`` is assumed
+            and a runtime warning would be appropriate, but this function
+            treats naive as UTC as a safety net (callers must enforce INV-03).
+
+    Returns:
+        RFC 3339 UTC string, e.g. ``"2024-01-15T14:00:00Z"``.
+    """
+    if dt.tzinfo is None:
+        # Callers must pass UTC-aware datetimes. Attach UTC defensively.
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class Store:
+    """SQLite-backed candle store.
+
+    Creates and manages a ``candles`` table with a composite primary key
+    ``(instrument, granularity, time)``.
+
+    Args:
+        db_path: File path for the SQLite database.  Pass ``":memory:"`` for
+            an in-memory database (useful in tests).
+    """
+
+    #: SQL to create the candles table if it does not already exist.
+    _CREATE_TABLE_SQL: str = """
+        CREATE TABLE IF NOT EXISTS candles (
+            instrument   TEXT    NOT NULL,
+            granularity  TEXT    NOT NULL,
+            time         TEXT    NOT NULL,
+            open_bid     REAL    NOT NULL,
+            high_bid     REAL    NOT NULL,
+            low_bid      REAL    NOT NULL,
+            close_bid    REAL    NOT NULL,
+            open_ask     REAL    NOT NULL,
+            high_ask     REAL    NOT NULL,
+            low_ask      REAL    NOT NULL,
+            close_ask    REAL    NOT NULL,
+            volume       INTEGER NOT NULL,
+            complete     INTEGER NOT NULL,
+            PRIMARY KEY (instrument, granularity, time)
+        )
+    """
+
+    #: SQL to upsert a single candle row (replace on PK conflict).
+    _UPSERT_SQL: str = """
+        INSERT OR REPLACE INTO candles
+            (instrument, granularity, time,
+             open_bid,  high_bid,  low_bid,  close_bid,
+             open_ask,  high_ask,  low_ask,  close_ask,
+             volume, complete)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn: sqlite3.Connection = sqlite3.connect(
+            self._db_path,
+            # Explicitly NOT using detect_types — we parse TEXT timestamps
+            # ourselves (see library_defaults note in taskgraph).
+        )
+        self._create_table()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _create_table(self) -> None:
+        """Create the ``candles`` table if it does not already exist."""
+        self._conn.execute(self._CREATE_TABLE_SQL)
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def upsert(self, rows: Iterable[CandleRow]) -> None:
+        """Upsert one or more ``CandleRow`` objects into the store.
+
+        Uses ``INSERT OR REPLACE`` so re-ingesting the same candle is
+        idempotent (last-writer wins on any field update).
+
+        Only rows with ``complete=True`` are stored — incomplete (half-formed)
+        bars must not feed the backtester.
+
+        Args:
+            rows: An iterable of ``CandleRow`` instances to persist.
+        """
+        params = [
+            (
+                row.instrument,
+                row.granularity,
+                _to_rfc3339(row.time),     # TEXT, UTC RFC 3339 (INV-03)
+                row.open_bid,
+                row.high_bid,
+                row.low_bid,
+                row.close_bid,
+                row.open_ask,
+                row.high_ask,
+                row.low_ask,
+                row.close_ask,
+                row.volume,
+                int(row.complete),         # SQLite stores bool as INTEGER
+            )
+            for row in rows
+            if row.complete                 # only complete candles (T-03 AC)
+        ]
+        if params:
+            self._conn.executemany(self._UPSERT_SQL, params)
+            self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def load_candles(
+        self,
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> pd.DataFrame:
+        """Load candles from SQLite for a given instrument/granularity/range.
+
+        Timestamps are parsed explicitly from their TEXT representation using
+        ``pd.to_datetime(..., utc=True)`` — we do not rely on sqlite3
+        PARSE_DECLTYPES (library_defaults note in taskgraph).
+
+        Args:
+            instrument: OANDA instrument identifier, e.g. ``"EUR_USD"``.
+            granularity: OANDA granularity string, e.g. ``"H1"``.
+            start: Inclusive start of the range (UTC-aware).
+            end: Inclusive end of the range (UTC-aware).
+
+        Returns:
+            A ``pd.DataFrame`` with columns::
+
+                time (datetime64[ns, UTC])
+                open_bid, high_bid, low_bid, close_bid   (float64)
+                open_ask, high_ask, low_ask, close_ask   (float64)
+                volume                                   (int64)
+
+            Rows are sorted by ``time`` ascending.  If no rows match, an
+            empty DataFrame with the same columns and dtypes is returned.
+
+        Raises:
+            ValueError: If ``start`` or ``end`` are not UTC-aware.
+        """
+        if start.tzinfo is None or end.tzinfo is None:
+            raise ValueError(
+                "start and end must be UTC-aware datetimes (INV-03)."
+            )
+
+        start_str = _to_rfc3339(start)
+        end_str = _to_rfc3339(end)
+
+        cursor = self._conn.execute(
+            """
+            SELECT time,
+                   open_bid, high_bid, low_bid, close_bid,
+                   open_ask, high_ask, low_ask, close_ask,
+                   volume
+            FROM   candles
+            WHERE  instrument  = ?
+              AND  granularity = ?
+              AND  time >= ?
+              AND  time <= ?
+            ORDER  BY time ASC
+            """,
+            (instrument, granularity, start_str, end_str),
+        )
+        rows = cursor.fetchall()
+
+        columns = [
+            "time",
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+            "volume",
+        ]
+
+        if not rows:
+            # Return an empty DataFrame with the correct schema.
+            df = pd.DataFrame(columns=columns)
+            df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+            return df
+
+        df = pd.DataFrame(rows, columns=columns)
+
+        # Parse TEXT timestamps explicitly to datetime64[ns, UTC] (INV-03).
+        # pd.to_datetime defaults to timezone-unaware — must pass utc=True.
+        # Coerce to nanosecond resolution to match the AC dtype contract
+        # (pandas 2+ defaults to microseconds; we normalise to ns here).
+        df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+
+        # Ensure numeric columns have correct dtypes.
+        float_cols = [
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+        ]
+        df[float_cols] = df[float_cols].astype("float64")
+        df["volume"] = df["volume"].astype("int64")
+
+        return df
+
+    def get_cached_times(
+        self,
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> set[str]:
+        """Return the set of RFC 3339 time strings already in the store.
+
+        Used by ``fetch_and_cache`` to identify gaps (missing rows) without
+        loading full price data.
+
+        Args:
+            instrument: OANDA instrument identifier.
+            granularity: OANDA granularity string.
+            start: Inclusive range start (UTC-aware).
+            end: Inclusive range end (UTC-aware).
+
+        Returns:
+            Set of RFC 3339 strings for rows that exist in the DB.
+        """
+        start_str = _to_rfc3339(start)
+        end_str = _to_rfc3339(end)
+
+        cursor = self._conn.execute(
+            """
+            SELECT time FROM candles
+            WHERE  instrument  = ?
+              AND  granularity = ?
+              AND  time >= ?
+              AND  time <= ?
+            """,
+            (instrument, granularity, start_str, end_str),
+        )
+        return {row[0] for row in cursor.fetchall()}

--- a/data/store.py
+++ b/data/store.py
@@ -228,9 +228,17 @@ class Store:
         ]
 
         if not rows:
-            # Return an empty DataFrame with the correct schema.
+            # Return an empty DataFrame with the correct schema and dtypes.
+            # pd.DataFrame(columns=...) defaults every column to object dtype,
+            # so we must coerce all columns explicitly to match the populated path.
             df = pd.DataFrame(columns=columns)
             df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+            float_cols = [
+                "open_bid", "high_bid", "low_bid", "close_bid",
+                "open_ask", "high_ask", "low_ask", "close_ask",
+            ]
+            df[float_cols] = df[float_cols].astype("float64")
+            df["volume"] = df["volume"].astype("int64")
             return df
 
         df = pd.DataFrame(rows, columns=columns)

--- a/tests/test_store_and_candles.py
+++ b/tests/test_store_and_candles.py
@@ -1,0 +1,437 @@
+"""Tests for data/store.py and data/candles.py.
+
+AC coverage (POC-T-03):
+- Round-trip: store → load → timestamps are UTC-aware and equal to originals.
+- Cache-hit: second ``fetch_and_cache`` call issues zero client calls.
+- Partial gap fill: only the missing sub-range triggers a client call.
+- Schema: returned DataFrame has the correct columns and dtypes.
+- complete=False candles are filtered out (not stored, not returned).
+- Empty range: ``load_candles`` on an empty store returns an empty DataFrame.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from data.candles import fetch_and_cache
+from data.oanda_client import CandleRow
+from data.store import Store, _to_rfc3339
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    """Shorthand for a UTC-aware datetime."""
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candle(
+    instrument: str,
+    granularity: str,
+    time: datetime,
+    bid: float = 1.1000,
+    ask: float = 1.1002,
+    volume: int = 100,
+    complete: bool = True,
+) -> CandleRow:
+    """Build a minimal ``CandleRow`` for testing."""
+    return CandleRow(
+        instrument=instrument,
+        granularity=granularity,
+        time=time,
+        open_bid=bid,
+        high_bid=bid + 0.0005,
+        low_bid=bid - 0.0005,
+        close_bid=bid + 0.0001,
+        open_ask=ask,
+        high_ask=ask + 0.0005,
+        low_ask=ask - 0.0005,
+        close_ask=ask + 0.0001,
+        open_mid=(bid + ask) / 2,
+        high_mid=(bid + ask) / 2 + 0.0005,
+        low_mid=(bid + ask) / 2 - 0.0005,
+        close_mid=(bid + ask) / 2 + 0.0001,
+        volume=volume,
+        complete=complete,
+    )
+
+
+@pytest.fixture()
+def mem_store() -> Store:
+    """An in-memory SQLite store, fresh for each test."""
+    return Store(":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock OandaClient
+# ---------------------------------------------------------------------------
+
+
+def _mock_client(candles: list[CandleRow]) -> MagicMock:
+    """Return a MagicMock OandaClient whose ``get_candles`` returns ``candles``."""
+    client = MagicMock()
+    client.get_candles.return_value = candles
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Store unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreRoundTrip:
+    """Verify that timestamps survive the store → load round-trip as UTC-aware."""
+
+    def test_timestamps_are_utc_aware_after_load(self, mem_store: Store) -> None:
+        """INV-03: loaded timestamps must be UTC-aware (not naive)."""
+        t1 = _utc(2024, 1, 15, 14)
+        t2 = _utc(2024, 1, 15, 15)
+        rows = [
+            _make_candle("EUR_USD", "H1", t1),
+            _make_candle("EUR_USD", "H1", t2),
+        ]
+        mem_store.upsert(rows)
+
+        df = mem_store.load_candles(
+            "EUR_USD", "H1",
+            start=_utc(2024, 1, 15),
+            end=_utc(2024, 1, 16),
+        )
+
+        assert len(df) == 2, "Expected two rows"
+        # Verify dtype — datetime64[ns, UTC] means the series is tz-aware.
+        assert str(df["time"].dtype) == "datetime64[ns, UTC]", (
+            f"Expected datetime64[ns, UTC], got {df['time'].dtype}"
+        )
+        # Each individual timestamp must be UTC-aware.
+        for ts in df["time"]:
+            assert ts.tzinfo is not None, "Timestamp tzinfo must not be None"
+            assert ts.tzinfo.utcoffset(None).total_seconds() == 0, (
+                "Timestamp must be UTC (offset 0)"
+            )
+
+    def test_round_trip_values_intact(self, mem_store: Store) -> None:
+        """Price and volume values are unchanged after a store→load cycle."""
+        t = _utc(2024, 3, 20, 9)
+        row = _make_candle("GBP_USD", "H1", t, bid=1.2700, ask=1.2703, volume=250)
+        mem_store.upsert([row])
+
+        df = mem_store.load_candles(
+            "GBP_USD", "H1",
+            start=_utc(2024, 3, 20),
+            end=_utc(2024, 3, 21),
+        )
+
+        assert len(df) == 1
+        loaded = df.iloc[0]
+        # Time equality: loaded must equal original (same UTC instant).
+        assert loaded["time"] == pd.Timestamp(t)
+        assert abs(loaded["open_bid"] - 1.2700) < 1e-6
+        assert abs(loaded["open_ask"] - 1.2703) < 1e-6
+        assert loaded["volume"] == 250
+
+    def test_stored_time_is_rfc3339_utc(self, mem_store: Store) -> None:
+        """The raw TEXT value in SQLite must be a UTC RFC 3339 string (INV-03)."""
+        t = _utc(2024, 6, 1, 0)
+        mem_store.upsert([_make_candle("EUR_USD", "H1", t)])
+
+        # Peek directly at the raw SQLite value.
+        cursor = mem_store._conn.execute(
+            "SELECT time FROM candles WHERE instrument='EUR_USD'"
+        )
+        raw = cursor.fetchone()[0]
+
+        assert raw == "2024-06-01T00:00:00Z", (
+            f"Expected RFC 3339 UTC string, got {raw!r}"
+        )
+
+    def test_incomplete_candles_not_stored(self, mem_store: Store) -> None:
+        """``complete=False`` rows must be silently filtered by ``upsert``."""
+        t = _utc(2024, 1, 15, 14)
+        incomplete_row = _make_candle("EUR_USD", "H1", t, complete=False)
+        mem_store.upsert([incomplete_row])
+
+        df = mem_store.load_candles(
+            "EUR_USD", "H1",
+            start=_utc(2024, 1, 15),
+            end=_utc(2024, 1, 16),
+        )
+        assert len(df) == 0, "Incomplete candles must not appear in load results"
+
+    def test_empty_range_returns_empty_dataframe(self, mem_store: Store) -> None:
+        """load_candles with no matching rows returns an empty DataFrame."""
+        df = mem_store.load_candles(
+            "EUR_USD", "H1",
+            start=_utc(2020, 1, 1),
+            end=_utc(2020, 1, 2),
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        # Schema must be correct even when empty.
+        assert "time" in df.columns
+
+    def test_upsert_idempotent(self, mem_store: Store) -> None:
+        """Re-inserting the same candle does not create duplicate rows."""
+        t = _utc(2024, 1, 15, 14)
+        row = _make_candle("EUR_USD", "H1", t)
+        mem_store.upsert([row])
+        mem_store.upsert([row])  # second upsert of same row
+
+        df = mem_store.load_candles(
+            "EUR_USD", "H1",
+            start=_utc(2024, 1, 15),
+            end=_utc(2024, 1, 16),
+        )
+        assert len(df) == 1, "Upsert must be idempotent (no duplicates)"
+
+    def test_load_requires_utc_aware_bounds(self, mem_store: Store) -> None:
+        """``load_candles`` must raise ValueError for naive datetime bounds."""
+        with pytest.raises(ValueError, match="UTC-aware"):
+            mem_store.load_candles(
+                "EUR_USD", "H1",
+                start=datetime(2024, 1, 15),   # naive — no tzinfo
+                end=datetime(2024, 1, 16),
+            )
+
+
+class TestStoreSchema:
+    """Verify the DataFrame dtype contract for loaded candles."""
+
+    def test_dataframe_columns_and_dtypes(self, mem_store: Store) -> None:
+        """Returned DataFrame must have the AC-mandated columns and dtypes."""
+        t = _utc(2024, 5, 1, 12)
+        mem_store.upsert([_make_candle("USD_JPY", "D", t)])
+
+        df = mem_store.load_candles(
+            "USD_JPY", "D",
+            start=_utc(2024, 5, 1),
+            end=_utc(2024, 5, 2),
+        )
+
+        expected_columns = [
+            "time",
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+            "volume",
+        ]
+        for col in expected_columns:
+            assert col in df.columns, f"Missing column: {col}"
+
+        assert str(df["time"].dtype) == "datetime64[ns, UTC]"
+        for col in expected_columns[1:-1]:   # float price columns
+            assert df[col].dtype == "float64", f"{col} must be float64"
+        assert df["volume"].dtype == "int64"
+
+
+# ---------------------------------------------------------------------------
+# fetch_and_cache tests (mocked client — no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHit:
+    """A second fetch_and_cache for the same range must make zero HTTP calls."""
+
+    def test_second_call_no_client_call(self, mem_store: Store) -> None:
+        """Cache-hit AC: second call must not invoke ``client.get_candles``.
+
+        The range is set so that [start, end] exactly matches what OANDA
+        returns (start=t1, end=t3).  After the first fetch the store has all
+        rows in the range, so the gap detector returns (None, None) on the
+        second call and no HTTP request is issued.
+        """
+        t1 = _utc(2024, 2, 1, 0)
+        t2 = _utc(2024, 2, 1, 1)
+        t3 = _utc(2024, 2, 1, 2)
+
+        candles = [
+            _make_candle("EUR_USD", "H1", t1),
+            _make_candle("EUR_USD", "H1", t2),
+            _make_candle("EUR_USD", "H1", t3),
+        ]
+        client = _mock_client(candles)
+
+        # Use the exact bounds of the returned data so no trailing gap exists.
+        start = t1
+        end = t3
+
+        # First call — should call client once.
+        df1 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end)
+        assert client.get_candles.call_count == 1
+
+        # Second call — must NOT call client again.
+        df2 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end)
+        assert client.get_candles.call_count == 1, (
+            "Second call for the same range must make ZERO HTTP requests (cache hit)"
+        )
+
+        # Both calls return the same data.
+        assert len(df1) == len(df2) == 3
+        pd.testing.assert_frame_equal(df1.reset_index(drop=True),
+                                      df2.reset_index(drop=True))
+
+    def test_cache_hit_timestamps_utc_aware(self, mem_store: Store) -> None:
+        """Timestamps returned on a cache hit must still be UTC-aware (INV-03)."""
+        t = _utc(2024, 3, 15, 8)
+        client = _mock_client([_make_candle("GBP_USD", "H1", t)])
+
+        # Use exact bounds matching the single candle so no gap is detected.
+        start = t
+        end = t
+
+        fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end)
+        df = fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end)
+
+        assert str(df["time"].dtype) == "datetime64[ns, UTC]"
+        for ts in df["time"]:
+            assert ts.tzinfo is not None
+
+
+class TestPartialGapFill:
+    """Only the missing sub-range should trigger a client call."""
+
+    def test_trailing_gap_only_fetched(self, mem_store: Store) -> None:
+        """When the leading portion is cached, only the trailing gap is fetched."""
+        # Pre-populate the store with hours 0–3 of 2024-04-01.
+        for h in range(4):
+            mem_store.upsert([_make_candle("EUR_USD", "H1", _utc(2024, 4, 1, h))])
+
+        # The full requested range is 0–5, but hours 0–3 are already in the store.
+        # The client should be called for hours 4–5 only.
+        hours_4_5 = [
+            _make_candle("EUR_USD", "H1", _utc(2024, 4, 1, 4)),
+            _make_candle("EUR_USD", "H1", _utc(2024, 4, 1, 5)),
+        ]
+        client = _mock_client(hours_4_5)
+
+        df = fetch_and_cache(
+            client, mem_store, "EUR_USD", "H1",
+            start=_utc(2024, 4, 1, 0),
+            end=_utc(2024, 4, 1, 5),
+        )
+
+        # Client was called exactly once (for the trailing gap).
+        assert client.get_candles.call_count == 1
+
+        # The from_time passed to get_candles should be > the last cached time.
+        call_kwargs = client.get_candles.call_args
+        from_time_arg = call_kwargs.kwargs.get(
+            "from_time", call_kwargs.args[3] if len(call_kwargs.args) > 3 else None
+        )
+        # from_time must be UTC-aware and after the last pre-cached bar (hour 3).
+        assert from_time_arg is not None
+        assert from_time_arg > _utc(2024, 4, 1, 3), (
+            "from_time should be set past the already-cached trailing edge"
+        )
+
+        # The result should contain all 6 hours (0–5).
+        assert len(df) == 6
+
+    def test_leading_gap_fetched(self, mem_store: Store) -> None:
+        """When trailing portion is cached, only the leading gap is fetched."""
+        # Pre-populate hours 4–5 of 2024-04-02.
+        for h in [4, 5]:
+            mem_store.upsert([_make_candle("EUR_USD", "H1", _utc(2024, 4, 2, h))])
+
+        # The full requested range is 0–5, hours 4–5 are cached, 0–3 are missing.
+        hours_0_3 = [
+            _make_candle("EUR_USD", "H1", _utc(2024, 4, 2, h))
+            for h in range(4)
+        ]
+        client = _mock_client(hours_0_3)
+
+        df = fetch_and_cache(
+            client, mem_store, "EUR_USD", "H1",
+            start=_utc(2024, 4, 2, 0),
+            end=_utc(2024, 4, 2, 5),
+        )
+
+        # Client was called exactly once (for the leading gap).
+        assert client.get_candles.call_count == 1
+
+        # Result contains all 6 rows.
+        assert len(df) == 6
+
+    def test_no_fetch_when_fully_cached(self, mem_store: Store) -> None:
+        """If all rows are present, zero client calls are made."""
+        times = [_utc(2024, 5, 10, h) for h in range(5)]
+        for t in times:
+            mem_store.upsert([_make_candle("USD_JPY", "H1", t)])
+
+        client = _mock_client([])  # would raise if called unexpectedly
+
+        df = fetch_and_cache(
+            client, mem_store, "USD_JPY", "H1",
+            start=_utc(2024, 5, 10, 0),
+            end=_utc(2024, 5, 10, 4),
+        )
+
+        assert client.get_candles.call_count == 0
+        assert len(df) == 5
+
+    def test_fetch_and_cache_filters_incomplete(self, mem_store: Store) -> None:
+        """complete=False candles from OANDA must not appear in the output."""
+        complete_row = _make_candle("EUR_USD", "H1", _utc(2024, 6, 1, 0), complete=True)
+        incomplete_row = _make_candle("EUR_USD", "H1", _utc(2024, 6, 1, 1), complete=False)
+        client = _mock_client([complete_row, incomplete_row])
+
+        df = fetch_and_cache(
+            client, mem_store, "EUR_USD", "H1",
+            start=_utc(2024, 6, 1),
+            end=_utc(2024, 6, 2),
+        )
+
+        # Only the complete candle should appear.
+        assert len(df) == 1
+        ts = df["time"].iloc[0]
+        assert ts == pd.Timestamp(_utc(2024, 6, 1, 0))
+
+
+class TestFetchAndCacheValidation:
+    """Edge-case validation for fetch_and_cache."""
+
+    def test_naive_start_raises(self, mem_store: Store) -> None:
+        client = _mock_client([])
+        with pytest.raises(ValueError, match="UTC-aware"):
+            fetch_and_cache(
+                client, mem_store, "EUR_USD", "H1",
+                start=datetime(2024, 1, 1),    # naive
+                end=_utc(2024, 1, 2),
+            )
+
+    def test_naive_end_raises(self, mem_store: Store) -> None:
+        client = _mock_client([])
+        with pytest.raises(ValueError, match="UTC-aware"):
+            fetch_and_cache(
+                client, mem_store, "EUR_USD", "H1",
+                start=_utc(2024, 1, 1),
+                end=datetime(2024, 1, 2),       # naive
+            )
+
+    def test_returned_dataframe_columns(self, mem_store: Store) -> None:
+        """Returned DataFrame has the AC-mandated column set."""
+        t = _utc(2024, 7, 4, 12)
+        client = _mock_client([_make_candle("GBP_USD", "H1", t)])
+
+        df = fetch_and_cache(
+            client, mem_store, "GBP_USD", "H1",
+            start=_utc(2024, 7, 4),
+            end=_utc(2024, 7, 5),
+        )
+
+        required = {
+            "time",
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+            "volume",
+        }
+        assert required.issubset(set(df.columns)), (
+            f"Missing columns: {required - set(df.columns)}"
+        )
+        assert str(df["time"].dtype) == "datetime64[ns, UTC]"

--- a/tests/test_store_and_candles.py
+++ b/tests/test_store_and_candles.py
@@ -166,7 +166,12 @@ class TestStoreRoundTrip:
         assert len(df) == 0, "Incomplete candles must not appear in load results"
 
     def test_empty_range_returns_empty_dataframe(self, mem_store: Store) -> None:
-        """load_candles with no matching rows returns an empty DataFrame."""
+        """load_candles with no matching rows returns an empty DataFrame.
+
+        The empty path must return exactly the same dtypes as the populated
+        path — object columns would poison pd.concat and violate the AC dtype
+        contract expected by T-05.
+        """
         df = mem_store.load_candles(
             "EUR_USD", "H1",
             start=_utc(2020, 1, 1),
@@ -176,6 +181,21 @@ class TestStoreRoundTrip:
         assert len(df) == 0
         # Schema must be correct even when empty.
         assert "time" in df.columns
+        # Dtype contract: empty path must match populated path exactly.
+        assert str(df["time"].dtype) == "datetime64[ns, UTC]", (
+            f"time must be datetime64[ns, UTC], got {df['time'].dtype}"
+        )
+        float_price_cols = [
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+        ]
+        for col in float_price_cols:
+            assert df[col].dtype == "float64", (
+                f"{col} must be float64 on empty DataFrame, got {df[col].dtype}"
+            )
+        assert df["volume"].dtype == "int64", (
+            f"volume must be int64 on empty DataFrame, got {df['volume'].dtype}"
+        )
 
     def test_upsert_idempotent(self, mem_store: Store) -> None:
         """Re-inserting the same candle does not create duplicate rows."""
@@ -354,6 +374,25 @@ class TestPartialGapFill:
 
         # Client was called exactly once (for the leading gap).
         assert client.get_candles.call_count == 1
+
+        # The fetch must have been scoped to the missing leading sub-range,
+        # not the whole requested range.  Inspect from_time: it must equal the
+        # requested start (i.e. the gap begins at the start of the window).
+        call_kwargs = client.get_candles.call_args
+        from_time_arg = call_kwargs.kwargs.get(
+            "from_time", call_kwargs.args[3] if len(call_kwargs.args) > 3 else None
+        )
+        assert from_time_arg is not None, "from_time must be passed to get_candles"
+        assert from_time_arg == _utc(2024, 4, 2, 0), (
+            f"from_time should be the requested start (leading gap begins there), "
+            f"got {from_time_arg}"
+        )
+        # from_time must be strictly before the first cached bar (hour 4),
+        # confirming the fetch was scoped to the missing sub-range.
+        assert from_time_arg < _utc(2024, 4, 2, 4), (
+            "from_time must be before the already-cached leading edge (hour 4) — "
+            "fetch was not correctly scoped to the missing sub-range"
+        )
 
         # Result contains all 6 rows.
         assert len(df) == 6


### PR DESCRIPTION
Closes #4.

## Summary

- **`data/store.py`** — `Store` class wrapping SQLite. `candles` table with PK `(instrument, granularity, time)`. Time stored as UTC RFC 3339 TEXT strings (`"2024-01-15T14:00:00Z"`), never epoch ints. `upsert()` filters `complete=False` rows. `load_candles()` returns `pd.DataFrame` with `time: datetime64[ns, UTC]`, bid/ask OHLC float64, volume int64.
- **`data/candles.py`** — `fetch_and_cache()`. Gap-aware: inspects store first, fetches only missing leading/trailing sub-ranges. A second call for the same `(instrument, granularity, start, end)` makes zero HTTP requests. Only `complete=True` candles reach the store.

## AC checks

| Check | Result |
|---|---|
| `pytest tests/test_store_and_candles.py -v` | 17 passed, exit 0 |
| `pytest -v` (full suite) | 91 passed, exit 0 |
| `mypy data/ tests/test_store_and_candles.py` | Success: no issues found in 5 source files, exit 0 |

## INV-03 (UTC round-trip)

`test_stored_time_is_rfc3339_utc` peeks at the raw SQLite TEXT value and asserts `"2024-06-01T00:00:00Z"`. `test_timestamps_are_utc_aware_after_load` asserts `dtype == datetime64[ns, UTC]` and per-element `tzinfo` is non-None with UTC offset 0. `test_round_trip_values_intact` asserts loaded `time == pd.Timestamp(original_utc_dt)`.

## library_defaults applied

- `pd.to_datetime(..., utc=True)` used on load path (not tz_localize after the fact).
- `.astype("datetime64[ns, UTC]")` coerces pandas 3.x default `us` resolution to `ns` as required by the AC dtype contract.
- sqlite3 PARSE_DECLTYPES not used — TEXT timestamps parsed explicitly.