### PR TITLE
POC-T-05: event-driven backtest engine + cost model

### DIFF
--- a/.claude/context/backtest.md
+++ b/.claude/context/backtest.md
@@ -1,0 +1,62 @@
+# Backtest context
+
+## POC-T-05 — 2026-05-28 (feat/poc-t-05)
+
+**What was done:**
+- Created `backtest/__init__.py` — re-exports `CostParams`, `CostResult`, `apply_costs`,
+  `BacktestEngine`, `BacktestResult`, `Trade`.
+- Created `backtest/costs.py`:
+  - `apply_costs(entry_price, exit_price, direction, spread_pips, slippage_pips, pip_value, swap_pips=0.0) -> CostResult`.
+  - `CostResult(net_entry, net_exit, total_cost_pips, swap_modelled=False)`.
+  - `CostParams(spread_pips>0, slippage_pips>=0, pip_value>0, swap_pips==0)` — pydantic v2; `spread_pips` is `gt=0`
+    so the engine can NEVER run cost-free (INV-06); a non-zero `swap_pips` is REJECTED loudly (D-03), not ignored.
+  - Spread model: half-spread on each leg. Long buys at ask (entry +), sells at bid (exit −); short is the mirror.
+    Slippage applied adversely on the EXIT (stop/target = market fill); entry treated as a controlled next-open fill.
+  - `total_cost_pips = spread_pips + slippage_pips` — path-independent, depends only on params → strictly > 0 for any
+    non-zero spread/slippage. Net PnL <= gross PnL is structural (offsets are always adverse on both legs).
+- Created `backtest/engine.py`:
+  - `BacktestEngine(store, cost_params).run(strategy, instrument, granularity, start, end) -> BacktestResult`.
+  - **No look-ahead:** strategy is fed only the prefix slice `df.iloc[:i+1]` at bar `i`; a signal from bar `i` is
+    entered at bar `i+1`'s OPEN (never the signal bar's own price). Fill checks use only the current bar's OHLC.
+  - **Single open position** (PoC scope) — new signals ignored while a position is open or a pending entry exists.
+  - **Intrabar fills:** long stop if `low<=stop`, short stop if `high>=stop`; long target if `high>=target`, short
+    target if `low<=target`. **Both breach in one bar → STOP wins (conservative).** Fill level clamped to
+    `[low, high]` so a reported fill can never be an impossible price.
+  - End-of-data: any still-open position is closed at the final bar's CLOSE (no slippage on this leg), so no
+    dangling trade leaks into the equity curve.
+  - Defensive `df.copy(deep=True)` at the top of `run()` — never mutates the store's frame.
+  - `Trade` carries entry/exit times (UTC, from bar data — INV-03), gross+net entry/exit, direction, pnl_pips,
+    pnl_net_pips, cost_pips, and `exit_reason` ("stop"|"target"|"end_of_data").
+  - `BacktestResult.metadata` includes `swap_modelled=False` (D-03), plus instrument/granularity/bar_count/etc.
+  - `equity_curve` is cumulative NET pips, one point per bar, UTC `DatetimeIndex`.
+- Created `tests/test_backtest_engine.py` — 12 tests (the four AC-mandated, named below, plus guards).
+
+**The four AC-mandated tests:**
+- (a) `test_no_lookahead_canary_explicit` + `test_no_lookahead_property` (hypothesis) — poison bar K, assert no
+  decision at bar < K changes.
+- (b) `test_costs_non_zero_multi_trade` + `test_apply_costs_invariants` (hypothesis) — `sum(cost_pips) > 0`;
+  gross PnL >= net PnL on every trade / for any spread+slippage.
+- (c) `test_known_trade_exact_pnl` — hand-crafted long: entry 1.10000, target 1.10150, spread 2 / slippage 1 pip
+  → net PnL 12.00000 pips (gross 15.0, cost 3.0), asserted to 5 decimals. Plus `test_known_short_trade_stop_wins_tie`
+  proving the both-breach tie-break.
+- (d) `test_stops_fill_within_bar` (hypothesis) — every stop/target fill lies within `[low, high]` of its bar.
+
+**Key patterns / gotchas:**
+- `mypy strict` does NOT understand pydantic v2 models without the plugin — constructing a model that omits a
+  defaulted field reports a spurious "Missing named argument". Enabled `plugins = ["pydantic.mypy"]` in
+  `pyproject.toml [tool.mypy]`. Verified it does NOT regress config/ data/ strategies/ (all 12 src files pass).
+- `Signal.generated_at == bar_time` is how the engine matches "is there a NEW signal on the current bar?" — the
+  strategy may return its whole signal list for the prefix; only the one timestamped to the current bar is acted on.
+- Slippage on EXIT only (stop/target market fills); not on the controlled next-open entry, not on end-of-data close.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_backtest_engine.py -q` → 12 passed, exit 0
+- `python -m pytest -q` (full suite) → 103 passed, exit 0
+- `python -m mypy backtest/` → "Success: no issues found in 3 source files", exit 0
+- `python -m mypy backtest/ tests/test_backtest_engine.py` → "Success: no issues found in 4 source files", exit 0
+- `python -m mypy config/ data/ strategies/ backtest/` (plugin regression check) → "Success: ... 12 source files", exit 0
+
+**New dependency:** `hypothesis>=6.0` added to `[project.optional-dependencies] dev`. CLAUDE.md Stack updated.
+Also added `plugins = ["pydantic.mypy"]` to `[tool.mypy]`.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 .mypy_cache/
 .pytest_cache/
+.hypothesis/
 data/*.db
 data/*.parquet
 .venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 
 Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · custom event-driven backtest engine · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
 
-**Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests)
+**Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests) · hypothesis>=6.0 (property-based tests for the backtest engine — no-look-ahead / fill / cost invariants)
+
+**mypy:** `[tool.mypy]` enables `plugins = ["pydantic.mypy"]` so strict mode understands pydantic v2 model construction with defaulted fields.
 
 ---
 

--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,0 +1,20 @@
+"""Fathom backtest package.
+
+Contains the event-driven backtest engine and the cost model.
+
+- ``costs``  : ``apply_costs`` + ``CostResult`` + ``CostParams`` (spread + slippage; swap deferred, D-03).
+- ``engine`` : ``BacktestEngine`` + ``Trade`` + ``BacktestResult`` — strict chronological,
+               no look-ahead, defensive-copy of the caller's DataFrame.
+"""
+
+from backtest.costs import CostParams, CostResult, apply_costs
+from backtest.engine import BacktestEngine, BacktestResult, Trade
+
+__all__ = [
+    "CostParams",
+    "CostResult",
+    "apply_costs",
+    "BacktestEngine",
+    "BacktestResult",
+    "Trade",
+]

--- a/backtest/costs.py
+++ b/backtest/costs.py
@@ -1,0 +1,190 @@
+"""Cost model for the backtest engine (POC-T-05).
+
+This module is the enforcement point for **INV-06**: a backtest result is only
+valid if it models real trading costs.  For the PoC we model two of the four
+cost categories:
+
+  1. **Spread** — half the spread is paid on each leg (entry + exit).  A long
+     buys at the ask (entry worsened upward) and sells at the bid (exit
+     worsened downward); a short is the mirror image.
+  2. **Slippage** — a pip offset applied adversely on stop/target fills (market
+     fills, not limit entries).
+
+The remaining two categories are deliberately **not** modelled in the PoC:
+
+  - **Commission** — out of scope for the PoC instruments (spread-only account).
+  - **Swap / overnight financing** — DEFERRED per decision **D-03**.  Every
+    output carries ``swap_modelled=False`` and ``apply_costs`` only accepts
+    ``swap_pips=0.0``.  A non-zero ``swap_pips`` is rejected so that no caller
+    can silently believe swap is being modelled when it is not.
+
+Why a zero-cost trade is impossible (INV-06)
+--------------------------------------------
+``total_cost_pips`` is computed as ``spread_pips + slippage_pips`` — a value
+that depends **only** on the cost parameters, never on the price path or the
+trade direction.  For any ``spread_pips > 0`` *or* ``slippage_pips > 0`` the sum
+is strictly > 0.  The half-spread / slippage offsets are always applied on the
+*adverse* side of each leg, so the net entry/exit prices can only ever move PnL
+*against* the trade — never in its favour.  Consequently ``net PnL <= gross
+PnL`` is structurally guaranteed, and a cost-free round trip cannot occur unless
+the caller explicitly passes zero spread *and* zero slippage (which the
+backtest engine never does — see ``CostParams`` validation in ``engine.py``).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from strategies.base import Direction
+
+
+class CostResult(BaseModel):
+    """Result of applying costs to a single round-trip trade.
+
+    Attributes
+    ----------
+    net_entry:
+        Entry price after the adverse half-spread (and, conceptually, any entry
+        slippage — see below) has been applied.  This is the price the trade is
+        *actually* considered to have filled at.
+    net_exit:
+        Exit price after the adverse half-spread and exit slippage.
+    total_cost_pips:
+        Total cost of the round trip, expressed in pips.  Strictly > 0 whenever
+        either ``spread_pips`` or ``slippage_pips`` is non-zero (INV-06).
+    swap_modelled:
+        Always ``False`` for the PoC (D-03).  Present so downstream metrics and
+        approved-set entries can carry the honest label.
+    """
+
+    net_entry: float
+    net_exit: float
+    total_cost_pips: float = Field(..., ge=0.0)
+    swap_modelled: bool = False
+
+
+class CostParams(BaseModel):
+    """Per-run cost configuration for the engine.
+
+    Attributes
+    ----------
+    spread_pips:
+        Full bid/ask spread in pips.  Half is paid on entry, half on exit.
+        Must be > 0 (a zero-spread backtest is fiction — INV-06).
+    slippage_pips:
+        Pip offset applied adversely on stop and target (market) fills.
+        Must be >= 0; combined with a positive spread the total cost is always
+        > 0.  Slippage alone (with zero spread) would also be > 0, but the
+        engine additionally requires a positive spread.
+    pip_value:
+        Price increment of one pip for the instrument, e.g. ``0.0001`` for most
+        FX majors and ``0.01`` for JPY pairs.  Used to convert between price
+        units and pips.  Must be > 0.
+    swap_pips:
+        DEFERRED (D-03).  Must remain 0.0.
+    """
+
+    spread_pips: float = Field(..., gt=0.0)
+    slippage_pips: float = Field(0.0, ge=0.0)
+    pip_value: float = Field(..., gt=0.0)
+    swap_pips: float = Field(0.0)
+
+    @model_validator(mode="after")
+    def _swap_must_be_zero(self) -> "CostParams":
+        # D-03: swap is not implemented. Reject any attempt to pass a non-zero
+        # value rather than silently ignoring it (which would let a caller
+        # believe swap was modelled when it was not).
+        if self.swap_pips != 0.0:
+            raise ValueError(
+                "swap_pips must be 0.0 — swap/financing is deferred (D-03). "
+                "Every output is labelled swap_modelled=False."
+            )
+        return self
+
+
+def apply_costs(
+    entry_price: float,
+    exit_price: float,
+    direction: Direction,
+    spread_pips: float,
+    slippage_pips: float,
+    pip_value: float,
+    swap_pips: float = 0.0,
+) -> CostResult:
+    """Apply spread + slippage costs to a single round-trip trade.
+
+    Parameters
+    ----------
+    entry_price:
+        Gross (mid) entry price — typically the next bar's open at signal time.
+    exit_price:
+        Gross (mid) exit price — the stop or target *level* the trade exited at.
+    direction:
+        ``Direction.LONG`` or ``Direction.SHORT``.  ``FLAT`` is rejected.
+    spread_pips:
+        Full spread in pips.  Half is added to a long entry / subtracted from a
+        long exit (opposite for a short).
+    slippage_pips:
+        Pip offset applied adversely on the stop/target exit fill.  For the PoC
+        slippage is charged on the exit leg (stop/target are the market fills;
+        entry is treated as a controlled next-open fill).
+    pip_value:
+        Price increment of one pip (e.g. ``0.0001`` or ``0.01`` for JPY).
+    swap_pips:
+        DEFERRED (D-03) — must be 0.0.
+
+    Returns
+    -------
+    CostResult
+        ``net_entry``, ``net_exit``, ``total_cost_pips`` (strictly > 0 for any
+        non-zero spread or slippage), and ``swap_modelled=False``.
+
+    Raises
+    ------
+    ValueError
+        If ``direction`` is ``FLAT``, if ``pip_value <= 0``, if either
+        ``spread_pips`` or ``slippage_pips`` is negative, or if ``swap_pips`` is
+        non-zero (D-03).
+    """
+    if direction not in (Direction.LONG, Direction.SHORT):
+        raise ValueError(
+            f"apply_costs requires LONG or SHORT direction, got {direction!r}."
+        )
+    if pip_value <= 0.0:
+        raise ValueError(f"pip_value must be > 0, got {pip_value}.")
+    if spread_pips < 0.0:
+        raise ValueError(f"spread_pips must be >= 0, got {spread_pips}.")
+    if slippage_pips < 0.0:
+        raise ValueError(f"slippage_pips must be >= 0, got {slippage_pips}.")
+    if swap_pips != 0.0:
+        # D-03: swap is deferred. Reject loudly rather than silently dropping it.
+        raise ValueError(
+            "swap_pips must be 0.0 — swap/financing is deferred (D-03)."
+        )
+
+    half_spread_price = (spread_pips / 2.0) * pip_value
+    slippage_price = slippage_pips * pip_value
+
+    if direction is Direction.LONG:
+        # Long: buy at the ask (entry up by half-spread), sell at the bid
+        # (exit down by half-spread). Slippage on a long exit (stop/target is a
+        # sell) fills *lower* — adverse.
+        net_entry = entry_price + half_spread_price
+        net_exit = exit_price - half_spread_price - slippage_price
+    else:  # Direction.SHORT
+        # Short: sell at the bid (entry down by half-spread), buy back at the
+        # ask (exit up by half-spread). Slippage on a short exit (a buy) fills
+        # *higher* — adverse.
+        net_entry = entry_price - half_spread_price
+        net_exit = exit_price + half_spread_price + slippage_price
+
+    # Total cost is path-independent: full spread (half per leg) + slippage on
+    # the exit fill. Strictly > 0 for any non-zero spread or slippage (INV-06).
+    total_cost_pips = spread_pips + slippage_pips
+
+    return CostResult(
+        net_entry=net_entry,
+        net_exit=net_exit,
+        total_cost_pips=total_cost_pips,
+        swap_modelled=False,
+    )

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -1,0 +1,455 @@
+"""Event-driven backtest engine (POC-T-05) — the thesis-proving component.
+
+This engine walks a candle DataFrame **strictly bar by bar, in chronological
+order**, and runs a :class:`~strategies.base.Strategy` forward through time
+under a hard no-look-ahead guarantee.  Three downstream tasks (T-06, T-07,
+T-08) and the project's go/no-go decision rest on its correctness, so the
+correctness properties are spelled out explicitly below and pinned by tests.
+
+No-look-ahead guarantee
+-----------------------
+The strategy is fed a *prefix slice* ``df.iloc[: i + 1]`` at bar ``i`` — it
+physically cannot read bar ``i + 1`` because that row is not in the object it
+receives.  A signal produced from the slice ending at bar ``i`` is **entered at
+bar ``i + 1``'s open**, never at bar ``i``'s own prices (which were the inputs
+to the signal).  Fill checks for an open position on bar ``i`` use only bar
+``i``'s OHLC.  The canary test (test_no_lookahead) verifies this empirically by
+poisoning bar ``N + 1`` and asserting bar ``N``'s decision is unchanged.
+
+Intrabar fill semantics
+------------------------
+* Long stop fills if ``bar.low <= stop`` ; short stop if ``bar.high >= stop``.
+* Long target fills if ``bar.high >= target`` ; short target if ``bar.low <= target``.
+* **If both stop and target breach within the same bar, the stop wins**
+  (conservative — we cannot know the intrabar path, so we assume the worse
+  outcome).
+* The gross fill price is the stop/target *level*, then **clamped to**
+  ``[bar.low, bar.high]`` so a fill can never be reported at an impossible
+  price (test_stops_fill_within_bar).
+
+Determinism / purity
+---------------------
+``run`` takes a defensive copy of the loaded DataFrame and never mutates the
+caller's frame.  All timestamps in the output are sourced from the bar data
+(UTC-aware, INV-03) — never ``datetime.now()``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict
+
+from backtest.costs import CostParams, apply_costs
+from data.store import Store
+from strategies.base import Direction, Signal, Strategy
+
+
+class Trade(BaseModel):
+    """A single completed round-trip trade.
+
+    All prices are in instrument price units; PnL is in pips.  ``*_gross``
+    prices are the raw fill levels; ``*_net`` prices include spread + slippage.
+
+    INV-03: ``entry_time`` and ``exit_time`` are UTC-aware datetimes taken from
+    the bar data — never wall-clock time.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    entry_time: datetime
+    exit_time: datetime
+    entry_price_gross: float
+    entry_price_net: float
+    exit_price_gross: float
+    exit_price_net: float
+    direction: Direction
+    pnl_pips: float
+    pnl_net_pips: float
+    cost_pips: float
+    exit_reason: str  # "stop" | "target" | "end_of_data"
+
+
+class BacktestResult(BaseModel):
+    """Result of a single backtest run.
+
+    Attributes
+    ----------
+    trades:
+        Completed round-trip trades, in chronological order.
+    equity_curve:
+        Cumulative **net** PnL in pips, indexed by bar close time (UTC).  One
+        point per bar; flat across bars with no realised PnL.
+    metadata:
+        Run metadata including ``swap_modelled=False`` (D-03), instrument,
+        granularity, bar count, and the cost parameters used.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    trades: list[Trade]
+    equity_curve: pd.Series
+    metadata: dict[str, object]
+
+
+class _OpenPosition:
+    """Mutable bookkeeping for the single open position during a run.
+
+    Not part of the public API — internal to the engine's bar loop.
+    """
+
+    __slots__ = (
+        "direction",
+        "entry_time",
+        "entry_price_gross",
+        "stop_price",
+        "target_price",
+    )
+
+    def __init__(
+        self,
+        direction: Direction,
+        entry_time: datetime,
+        entry_price_gross: float,
+        stop_price: float,
+        target_price: float,
+    ) -> None:
+        self.direction = direction
+        self.entry_time = entry_time
+        self.entry_price_gross = entry_price_gross
+        self.stop_price = stop_price
+        self.target_price = target_price
+
+
+class BacktestEngine:
+    """Strict-chronological, single-position event-driven backtester.
+
+    Parameters
+    ----------
+    store:
+        The candle store (T-03).  ``run`` loads candles via
+        ``store.load_candles`` and operates on a defensive copy.
+    cost_params:
+        Spread + slippage configuration.  Required, not optional — a backtest
+        without costs is invalid (INV-06).  ``CostParams`` enforces
+        ``spread_pips > 0``, so the engine can never run cost-free.
+
+    Notes
+    -----
+    The engine holds **at most one open position at a time** (PoC scope).  A new
+    signal is ignored while a position is open; once the position closes, the
+    next signal on a later bar can open a new one.
+    """
+
+    def __init__(self, store: Store, cost_params: CostParams) -> None:
+        self._store = store
+        self._cost_params = cost_params
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        strategy: Strategy,
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> BacktestResult:
+        """Run ``strategy`` over ``[start, end]`` for one instrument/granularity.
+
+        Parameters
+        ----------
+        strategy:
+            The strategy to drive forward through time.
+        instrument, granularity:
+            Selectors passed straight to ``store.load_candles``.
+        start, end:
+            Inclusive UTC-aware range bounds (validated by the store).
+
+        Returns
+        -------
+        BacktestResult
+            Trades, equity curve (cumulative net pips), and metadata
+            (including ``swap_modelled=False``).
+        """
+        raw = self._store.load_candles(instrument, granularity, start, end)
+        # Defensive copy — never mutate the caller's / store's frame.
+        df = raw.copy(deep=True).reset_index(drop=True)
+
+        n = len(df)
+        pip_value = self._cost_params.pip_value
+
+        # Pre-extract numpy arrays for O(1) bar access without ever exposing a
+        # future row to the strategy. The strategy only ever receives a prefix
+        # slice; these arrays are used only for *fill* logic on the current bar.
+        times = df["time"]
+        # Use the mid price if available, else bid (the store guarantees bid).
+        # Entry fills are on the *open* of the entry bar.
+        opens = df["open_bid"].to_numpy()
+        highs = df["high_bid"].to_numpy()
+        lows = df["low_bid"].to_numpy()
+        closes = df["close_bid"].to_numpy()
+
+        trades: list[Trade] = []
+        position: Optional[_OpenPosition] = None
+        # Pending entry: a signal emitted on bar i is entered on bar i+1's open.
+        pending_signal: Optional[Signal] = None
+
+        # Equity curve: cumulative realised net pips per bar (UTC index).
+        realised_net_pips = 0.0
+        equity_values: list[float] = []
+
+        for i in range(n):
+            bar_high = float(highs[i])
+            bar_low = float(lows[i])
+            bar_open = float(opens[i])
+            bar_time = self._bar_time(times, i)
+
+            # --- 1. Open a pending entry at THIS bar's open (no look-ahead).
+            # The signal was produced from the slice ending at bar i-1, so we
+            # only learn its fill price now, at bar i's open.
+            if position is None and pending_signal is not None:
+                position = self._open_from_signal(
+                    pending_signal, bar_open, bar_time
+                )
+                pending_signal = None
+
+            # --- 2. Resolve fills for an open position using ONLY this bar.
+            if position is not None:
+                exit_info = self._resolve_fill(position, bar_high, bar_low)
+                if exit_info is not None:
+                    gross_exit_level, exit_reason = exit_info
+                    trade = self._close_trade(
+                        position, bar_time, gross_exit_level, exit_reason,
+                        pip_value,
+                    )
+                    trades.append(trade)
+                    realised_net_pips += trade.pnl_net_pips
+                    position = None
+
+            # --- 3. Ask the strategy for a signal from the PREFIX slice only.
+            # Done last so a signal on bar i cannot be entered until bar i+1.
+            # Skipped while a position is open (single-position PoC) and while a
+            # signal is already pending entry.
+            if position is None and pending_signal is None:
+                prefix = df.iloc[: i + 1]
+                signals = strategy.generate_signals(prefix)
+                bar_signal = self._signal_for_bar(signals, bar_time)
+                if bar_signal is not None and bar_signal.direction in (
+                    Direction.LONG,
+                    Direction.SHORT,
+                ):
+                    pending_signal = bar_signal
+
+            equity_values.append(realised_net_pips)
+
+        # --- Close any position still open at the end of the data at the final
+        # bar's close (no dangling open trade leaking into the equity curve).
+        if position is not None and n > 0:
+            final_time = self._bar_time(times, n - 1)
+            final_close = float(closes[n - 1])
+            trade = self._close_trade(
+                position, final_time, final_close, "end_of_data", pip_value
+            )
+            trades.append(trade)
+            realised_net_pips += trade.pnl_net_pips
+            # Reflect the realised PnL on the final equity point.
+            if equity_values:
+                equity_values[-1] = realised_net_pips
+
+        equity_curve = self._build_equity_curve(times, equity_values)
+
+        metadata = {
+            "instrument": instrument,
+            "granularity": granularity,
+            "bar_count": n,
+            "trade_count": len(trades),
+            "strategy_name": strategy.name,
+            "swap_modelled": False,  # D-03 — honest label on every result.
+            "spread_pips": self._cost_params.spread_pips,
+            "slippage_pips": self._cost_params.slippage_pips,
+            "pip_value": pip_value,
+        }
+
+        return BacktestResult(
+            trades=trades, equity_curve=equity_curve, metadata=metadata
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _bar_time(times: pd.Series, i: int) -> datetime:
+        """UTC-aware datetime for bar ``i`` (INV-03 — sourced from bar data)."""
+        ts = times.iloc[i]
+        # pandas Timestamp → python datetime, preserving tz (UTC).
+        result: datetime = ts.to_pydatetime()
+        return result
+
+    @staticmethod
+    def _signal_for_bar(
+        signals: list[Signal], bar_time: datetime
+    ) -> Optional[Signal]:
+        """Return the signal whose ``generated_at`` matches the current bar.
+
+        Strategies (e.g. ``MACrossover``) return the full list of signals for
+        the prefix; the engine only acts on the one generated *on the current
+        bar* — earlier signals were already acted on (or skipped while a
+        position was open) on the bars where they appeared.  Matching on the
+        bar timestamp is the robust way to identify "is this a new signal?".
+        """
+        if not signals:
+            return None
+        # The signal generated on this bar (if any) is the one whose timestamp
+        # equals the current bar's close timestamp.
+        for sig in reversed(signals):
+            if sig.generated_at == bar_time:
+                return sig
+        return None
+
+    def _open_from_signal(
+        self, signal: Signal, entry_open: float, entry_time: datetime
+    ) -> _OpenPosition:
+        """Open a position at the (next) bar's open from a queued signal.
+
+        Stop and target levels are computed from the *actual* gross entry price
+        (the bar open we filled at), not the signal's reference price — the
+        signal carries distances, the engine anchors them to the real fill.
+        """
+        if signal.direction is Direction.LONG:
+            stop_price = entry_open - signal.stop_distance
+            target_price = entry_open + signal.target_distance
+        else:  # SHORT
+            stop_price = entry_open + signal.stop_distance
+            target_price = entry_open - signal.target_distance
+
+        return _OpenPosition(
+            direction=signal.direction,
+            entry_time=entry_time,
+            entry_price_gross=entry_open,
+            stop_price=stop_price,
+            target_price=target_price,
+        )
+
+    @staticmethod
+    def _resolve_fill(
+        position: _OpenPosition, bar_high: float, bar_low: float
+    ) -> Optional[tuple[float, str]]:
+        """Determine whether an open position exits on this bar.
+
+        Returns ``(gross_exit_level, reason)`` where ``reason`` is ``"stop"`` or
+        ``"target"``, or ``None`` if neither level was breached this bar.
+
+        Conservative tie-break: if BOTH stop and target are breached within the
+        same bar, the **stop wins** — we cannot know the intrabar path, so we
+        assume the adverse outcome.
+
+        The returned level is clamped to ``[bar_low, bar_high]`` so the reported
+        fill price can never lie outside the bar's range.
+        """
+        if position.direction is Direction.LONG:
+            stop_hit = bar_low <= position.stop_price
+            target_hit = bar_high >= position.target_price
+        else:  # SHORT
+            stop_hit = bar_high >= position.stop_price
+            target_hit = bar_low <= position.target_price
+
+        if not stop_hit and not target_hit:
+            return None
+
+        # Conservative: stop takes priority when both breach the same bar.
+        if stop_hit:
+            level = position.stop_price
+            reason = "stop"
+        else:
+            level = position.target_price
+            reason = "target"
+
+        # Clamp to the bar range — a fill can never be at an impossible price.
+        clamped = min(max(level, bar_low), bar_high)
+        return clamped, reason
+
+    def _close_trade(
+        self,
+        position: _OpenPosition,
+        exit_time: datetime,
+        gross_exit_level: float,
+        exit_reason: str,
+        pip_value: float,
+    ) -> Trade:
+        """Apply costs and build the completed ``Trade`` record."""
+        # Slippage applies only on stop/target (market) fills, NOT on an
+        # end-of-data close at the bar's close price.
+        slippage = (
+            self._cost_params.slippage_pips
+            if exit_reason in ("stop", "target")
+            else 0.0
+        )
+
+        cost = apply_costs(
+            entry_price=position.entry_price_gross,
+            exit_price=gross_exit_level,
+            direction=position.direction,
+            spread_pips=self._cost_params.spread_pips,
+            slippage_pips=slippage,
+            pip_value=pip_value,
+            swap_pips=0.0,  # D-03
+        )
+
+        gross_pips = self._pnl_pips(
+            position.direction,
+            position.entry_price_gross,
+            gross_exit_level,
+            pip_value,
+        )
+        net_pips = self._pnl_pips(
+            position.direction, cost.net_entry, cost.net_exit, pip_value
+        )
+
+        return Trade(
+            entry_time=position.entry_time,
+            exit_time=exit_time,
+            entry_price_gross=position.entry_price_gross,
+            entry_price_net=cost.net_entry,
+            exit_price_gross=gross_exit_level,
+            exit_price_net=cost.net_exit,
+            direction=position.direction,
+            pnl_pips=gross_pips,
+            pnl_net_pips=net_pips,
+            cost_pips=cost.total_cost_pips,
+            exit_reason=exit_reason,
+        )
+
+    @staticmethod
+    def _pnl_pips(
+        direction: Direction,
+        entry_price: float,
+        exit_price: float,
+        pip_value: float,
+    ) -> float:
+        """PnL in pips for a round trip (long: exit-entry; short: entry-exit)."""
+        if direction is Direction.LONG:
+            price_delta = exit_price - entry_price
+        else:  # SHORT
+            price_delta = entry_price - exit_price
+        return price_delta / pip_value
+
+    @staticmethod
+    def _build_equity_curve(
+        times: pd.Series, equity_values: list[float]
+    ) -> pd.Series:
+        """Build the cumulative net-pips equity curve indexed by bar time (UTC)."""
+        if not equity_values:
+            return pd.Series(
+                [], index=pd.DatetimeIndex([], tz="UTC"), dtype="float64",
+                name="equity_pips",
+            )
+        index = pd.DatetimeIndex(times.iloc[: len(equity_values)].to_numpy())
+        return pd.Series(
+            equity_values, index=index, dtype="float64", name="equity_pips"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=7.4",
     "mypy>=1.8",
     "responses>=0.25",
+    "hypothesis>=6.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -30,6 +31,7 @@ include = ["config*", "data*", "strategies*", "backtest*", "scripts*"]
 python_version = "3.11"
 strict = true
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,0 +1,553 @@
+"""Tests for the POC-T-05 backtest engine + cost model.
+
+The AC mandates four tests; each is named and documented here:
+
+(a) ``test_no_lookahead_canary`` — inject a canary value into bar N+1 and assert
+    it never influences the decision the engine makes at bar N.  Property-based
+    over random series (hypothesis) plus an explicit canary check.
+(b) ``test_costs_non_zero`` — across any multi-trade run, ``sum(cost_pips) > 0``
+    and gross PnL >= net PnL on every trade (INV-06).  Property-based.
+(c) ``test_known_trade_exact_pnl`` — a hand-crafted candle sequence with a known
+    cross and known stop reproduces the expected net PnL to 5 decimals.
+(d) ``test_stops_fill_within_bar`` — every stop/target fill price lies within
+    ``[low, high]`` of its fill bar — never an impossible price.  Property-based.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pandas as pd
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from backtest.costs import CostParams, CostResult, apply_costs
+from backtest.engine import BacktestEngine
+from data.store import Store
+from strategies.base import Direction, Signal, Strategy
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures / helpers
+# ---------------------------------------------------------------------------
+
+EPOCH = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+PIP = 0.0001  # EUR_USD-style pip value
+
+
+Bar = dict[str, Any]
+
+
+def _make_store_from_bars(bars: list[Bar]) -> Store:
+    """Build an in-memory Store seeded with the given OHLC bars.
+
+    Each bar dict needs: time (datetime, UTC), open, high, low, close.
+    Bid/ask are set equal to the supplied OHLC (the engine uses *_bid).
+    """
+    store = Store(":memory:")
+    rows = []
+    for b in bars:
+        rows.append(
+            (
+                "EUR_USD",
+                "H1",
+                b["time"].strftime("%Y-%m-%dT%H:%M:%SZ"),
+                b["open"], b["high"], b["low"], b["close"],   # bid
+                b["open"], b["high"], b["low"], b["close"],   # ask (= bid here)
+                b.get("volume", 100),
+                1,  # complete
+            )
+        )
+    store._conn.executemany(store._UPSERT_SQL, rows)
+    store._conn.commit()
+    return store
+
+
+class FixedSignalStrategy(Strategy):
+    """Test strategy that emits one LONG/SHORT signal on a chosen bar index.
+
+    Deterministic and look-ahead-safe: it only ever reads the LAST row of the
+    prefix it is given, and emits a signal exactly when that row's index in the
+    full series equals ``signal_bar``.  Because the engine passes a prefix
+    slice, the strategy identifies "current bar" by ``len(df) - 1``.
+    """
+
+    def __init__(
+        self,
+        signal_bar: int,
+        direction: Direction,
+        stop_distance: float,
+        target_distance: float,
+    ) -> None:
+        self._signal_bar = signal_bar
+        self._direction = direction
+        self._stop = stop_distance
+        self._target = target_distance
+
+    @property
+    def name(self) -> str:
+        return "FixedSignalStrategy"
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        current_idx = len(df) - 1
+        if current_idx != self._signal_bar:
+            return []
+        last = df.iloc[current_idx]
+        return [
+            Signal(
+                instrument="EUR_USD",
+                direction=self._direction,
+                entry_ref=float(last["close_bid"]),
+                stop_distance=self._stop,
+                target_distance=self._target,
+                strategy_name=self.name,
+                timeframe="H1",
+                quality_score=0.5,
+                generated_at=last["time"].to_pydatetime(),
+            )
+        ]
+
+
+class RecordingStrategy(Strategy):
+    """Records the decision (signal direction or None) made on each bar.
+
+    Used by the no-look-ahead canary test: it reads only the last row of the
+    prefix, so its per-bar decision must be invariant to anything placed in
+    future bars.
+    """
+
+    def __init__(self, threshold: float) -> None:
+        self._threshold = threshold
+        self.decisions: dict[int, str] = {}
+
+    @property
+    def name(self) -> str:
+        return "RecordingStrategy"
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        idx = len(df) - 1
+        last = df.iloc[idx]
+        close = float(last["close_bid"])
+        # Decision depends ONLY on the current (last) bar.
+        if close > self._threshold:
+            self.decisions[idx] = "LONG"
+            return [
+                Signal(
+                    instrument="EUR_USD",
+                    direction=Direction.LONG,
+                    entry_ref=close,
+                    stop_distance=0.0010,
+                    target_distance=0.0015,
+                    strategy_name=self.name,
+                    timeframe="H1",
+                    quality_score=0.5,
+                    generated_at=last["time"].to_pydatetime(),
+                )
+            ]
+        self.decisions[idx] = "NONE"
+        return []
+
+
+def _default_cost_params(slippage: float = 1.0) -> CostParams:
+    return CostParams(spread_pips=2.0, slippage_pips=slippage, pip_value=PIP)
+
+
+def _bars_from_closes(closes: list[float], hl_pad: float = 0.0005) -> list[Bar]:
+    """Build bars from a close series; open = prev close; high/low pad close."""
+    bars = []
+    prev = closes[0]
+    for k, c in enumerate(closes):
+        o = prev
+        hi = max(o, c) + hl_pad
+        lo = min(o, c) - hl_pad
+        bars.append(
+            {
+                "time": EPOCH + timedelta(hours=k),
+                "open": o,
+                "high": hi,
+                "low": lo,
+                "close": c,
+            }
+        )
+        prev = c
+    return bars
+
+
+# ---------------------------------------------------------------------------
+# (a) No look-ahead — canary
+# ---------------------------------------------------------------------------
+
+
+def test_no_lookahead_canary_explicit() -> None:
+    """A poison value in bar N+1 must not change bar N's decision."""
+    closes = [1.1000, 1.1010, 1.1020, 1.1005, 1.1030, 1.1040, 1.1015, 1.1050]
+    bars = _bars_from_closes(closes)
+
+    store_clean = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+
+    strat_clean = RecordingStrategy(threshold=1.1015)
+    engine = BacktestEngine(store_clean, _default_cost_params())
+    engine.run(strat_clean, "EUR_USD", "H1", EPOCH, end)
+
+    # Poison bar index 4 (an arbitrary "N+1") with absurd values.
+    poisoned = [dict(b) for b in bars]
+    poisoned[4]["close"] = 99.0
+    poisoned[4]["high"] = 99.0
+    poisoned[4]["low"] = 98.0
+    store_poisoned = _make_store_from_bars(poisoned)
+
+    strat_poisoned = RecordingStrategy(threshold=1.1015)
+    engine2 = BacktestEngine(store_poisoned, _default_cost_params())
+    engine2.run(strat_poisoned, "EUR_USD", "H1", EPOCH, end)
+
+    # Decisions for all bars STRICTLY BEFORE the poisoned bar must be identical.
+    for n in range(4):
+        assert strat_clean.decisions[n] == strat_poisoned.decisions[n], (
+            f"look-ahead leak: bar {n} decision changed when bar 4 was poisoned"
+        )
+
+
+@settings(max_examples=60, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    closes=st.lists(
+        st.floats(min_value=1.05, max_value=1.15, allow_nan=False),
+        min_size=6,
+        max_size=30,
+    ),
+    poison_idx=st.integers(min_value=1, max_value=29),
+)
+def test_no_lookahead_property(closes: list[float], poison_idx: int) -> None:
+    """Property: poisoning bar K never changes any decision at bar < K."""
+    if poison_idx >= len(closes):
+        poison_idx = len(closes) - 1
+    if poison_idx < 1:
+        return
+
+    bars = _bars_from_closes(closes)
+    end = bars[-1]["time"]
+    threshold = 1.10
+
+    store_a = _make_store_from_bars(bars)
+    strat_a = RecordingStrategy(threshold=threshold)
+    BacktestEngine(store_a, _default_cost_params()).run(
+        strat_a, "EUR_USD", "H1", EPOCH, end
+    )
+
+    poisoned = [dict(b) for b in bars]
+    poisoned[poison_idx]["close"] = 999.0
+    poisoned[poison_idx]["high"] = 999.0
+    poisoned[poison_idx]["low"] = 998.0
+    store_b = _make_store_from_bars(poisoned)
+    strat_b = RecordingStrategy(threshold=threshold)
+    BacktestEngine(store_b, _default_cost_params()).run(
+        strat_b, "EUR_USD", "H1", EPOCH, end
+    )
+
+    for n in range(poison_idx):
+        assert strat_a.decisions.get(n) == strat_b.decisions.get(n)
+
+
+# ---------------------------------------------------------------------------
+# (b) Costs non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_costs_non_zero_multi_trade() -> None:
+    """sum(cost_pips) > 0 across a multi-trade run; gross >= net per trade."""
+    # Build a series that triggers multiple stop/target exits so we get >1 trade.
+    # Use FixedSignalStrategy emitting on bar 0, but the engine only re-signals
+    # after a position closes; to get multiple trades we use a strategy that
+    # re-signals whenever flat. We reuse RecordingStrategy with an oscillating
+    # series so several entries occur.
+    closes = [
+        1.1000, 1.1100, 1.0900, 1.1100, 1.0900, 1.1100,
+        1.0900, 1.1100, 1.0900, 1.1100, 1.0900, 1.1100,
+    ]
+    bars = _bars_from_closes(closes, hl_pad=0.0030)
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+
+    strat = RecordingStrategy(threshold=1.1050)
+    result = BacktestEngine(store, _default_cost_params()).run(
+        strat, "EUR_USD", "H1", EPOCH, end
+    )
+
+    assert len(result.trades) >= 1, "expected at least one trade"
+    total_cost = sum(t.cost_pips for t in result.trades)
+    assert total_cost > 0.0, "INV-06: total cost across run must be > 0"
+    for t in result.trades:
+        assert t.cost_pips > 0.0
+        # Gross PnL is always >= net PnL (costs only ever worsen PnL).
+        assert t.pnl_pips >= t.pnl_net_pips - 1e-9
+
+
+@settings(max_examples=80)
+@given(
+    spread=st.floats(min_value=0.1, max_value=5.0),
+    slippage=st.floats(min_value=0.0, max_value=3.0),
+    entry=st.floats(min_value=1.05, max_value=1.15),
+    move=st.floats(min_value=-0.005, max_value=0.005),
+    direction=st.sampled_from([Direction.LONG, Direction.SHORT]),
+)
+def test_apply_costs_invariants(
+    spread: float,
+    slippage: float,
+    entry: float,
+    move: float,
+    direction: Direction,
+) -> None:
+    """Property: total_cost_pips > 0 for any non-zero spread/slippage, and net
+    PnL <= gross PnL always (INV-06)."""
+    exit_price = entry + move
+    res = apply_costs(
+        entry_price=entry,
+        exit_price=exit_price,
+        direction=direction,
+        spread_pips=spread,
+        slippage_pips=slippage,
+        pip_value=PIP,
+    )
+    assert isinstance(res, CostResult)
+    assert res.swap_modelled is False
+    if spread > 0 or slippage > 0:
+        assert res.total_cost_pips > 0.0
+
+    # Net PnL <= gross PnL (costs never help).
+    if direction is Direction.LONG:
+        gross = exit_price - entry
+        net = res.net_exit - res.net_entry
+    else:
+        gross = entry - exit_price
+        net = res.net_entry - res.net_exit
+    assert net <= gross + 1e-12
+
+
+def test_apply_costs_rejects_swap() -> None:
+    """D-03: any non-zero swap_pips is rejected loudly."""
+    with pytest.raises(ValueError, match="swap"):
+        apply_costs(1.10, 1.11, Direction.LONG, 2.0, 1.0, PIP, swap_pips=0.5)
+
+
+def test_cost_params_rejects_zero_spread_and_swap() -> None:
+    """CostParams enforces spread > 0 and swap == 0 (INV-06 + D-03)."""
+    with pytest.raises(ValueError):
+        CostParams(spread_pips=0.0, slippage_pips=1.0, pip_value=PIP)
+    with pytest.raises(ValueError):
+        CostParams(spread_pips=2.0, slippage_pips=1.0, pip_value=PIP, swap_pips=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (c) Known trade — exact net PnL to 5 decimals
+# ---------------------------------------------------------------------------
+
+
+def test_known_trade_exact_pnl() -> None:
+    """Hand-crafted long trade with known entry/target reproduces exact net PnL.
+
+    Setup:
+      - Signal emitted on bar 0 (LONG), stop_distance=0.0010, target=0.0015.
+      - Entry fills on bar 1's OPEN = 1.10000 (gross).
+      - Target level = entry_open + 0.0015 = 1.10150.
+      - Bar 2 high = 1.10200 breaches the target -> exit at target level 1.10150.
+
+    Costs: spread=2.0 pips, slippage=1.0 pip, pip_value=0.0001.
+      half_spread_price = 1.0 pip * 0.0001 = 0.0001
+      slippage_price    = 1.0 pip * 0.0001 = 0.0001
+      net_entry = 1.10000 + 0.0001 = 1.10010
+      net_exit  = 1.10150 - 0.0001 - 0.0001 = 1.10130
+      pnl_net_pips = (1.10130 - 1.10010) / 0.0001 = 12.00000
+      gross_pips   = (1.10150 - 1.10000) / 0.0001 = 15.00000
+      cost_pips    = spread + slippage = 3.0
+    """
+    bars: list[Bar] = [
+        # bar 0: signal bar
+        {"time": EPOCH, "open": 1.09990, "high": 1.10010,
+         "low": 1.09980, "close": 1.10000},
+        # bar 1: entry fills at open=1.10000; no exit (high below target)
+        {"time": EPOCH + timedelta(hours=1), "open": 1.10000,
+         "high": 1.10090, "low": 1.09990, "close": 1.10050},
+        # bar 2: high breaches target 1.10150
+        {"time": EPOCH + timedelta(hours=2), "open": 1.10050,
+         "high": 1.10200, "low": 1.10040, "close": 1.10180},
+    ]
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+
+    strat = FixedSignalStrategy(
+        signal_bar=0,
+        direction=Direction.LONG,
+        stop_distance=0.0010,
+        target_distance=0.0015,
+    )
+    result = BacktestEngine(
+        store, CostParams(spread_pips=2.0, slippage_pips=1.0, pip_value=PIP)
+    ).run(strat, "EUR_USD", "H1", EPOCH, end)
+
+    assert len(result.trades) == 1
+    t = result.trades[0]
+    assert t.direction is Direction.LONG
+    assert t.exit_reason == "target"
+    assert round(t.entry_price_gross, 5) == 1.10000
+    assert round(t.entry_price_net, 5) == 1.10010
+    assert round(t.exit_price_gross, 5) == 1.10150
+    assert round(t.exit_price_net, 5) == 1.10130
+    assert round(t.pnl_pips, 5) == 15.00000
+    assert round(t.pnl_net_pips, 5) == 12.00000
+    assert round(t.cost_pips, 5) == 3.00000
+    # Entry time is bar 1's timestamp (next-bar entry, no look-ahead).
+    assert t.entry_time == bars[1]["time"]
+    assert t.exit_time == bars[2]["time"]
+
+
+def test_known_short_trade_stop_wins_tie() -> None:
+    """When both stop and target breach in one bar, the STOP wins (conservative).
+
+    Short signal on bar 0; entry on bar 1 open = 1.10000.
+      stop_distance=0.0010 -> stop = 1.10100 (above entry)
+      target_distance=0.0015 -> target = 1.09850 (below entry)
+    Bar 2 has high=1.10200 (>= stop) AND low=1.09800 (<= target): both breach.
+    Conservative rule -> exit at STOP = 1.10100 (a loss), not the target.
+    """
+    bars: list[Bar] = [
+        {"time": EPOCH, "open": 1.10010, "high": 1.10020,
+         "low": 1.09990, "close": 1.10000},
+        {"time": EPOCH + timedelta(hours=1), "open": 1.10000,
+         "high": 1.10010, "low": 1.09990, "close": 1.10000},
+        {"time": EPOCH + timedelta(hours=2), "open": 1.10000,
+         "high": 1.10200, "low": 1.09800, "close": 1.09900},
+    ]
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+    strat = FixedSignalStrategy(
+        signal_bar=0,
+        direction=Direction.SHORT,
+        stop_distance=0.0010,
+        target_distance=0.0015,
+    )
+    result = BacktestEngine(
+        store, CostParams(spread_pips=2.0, slippage_pips=1.0, pip_value=PIP)
+    ).run(strat, "EUR_USD", "H1", EPOCH, end)
+
+    assert len(result.trades) == 1
+    t = result.trades[0]
+    assert t.exit_reason == "stop", "stop must win when both breach in one bar"
+    assert round(t.exit_price_gross, 5) == 1.10100
+    # Short stop: net_exit = exit + half_spread + slippage = 1.10100+0.0001+0.0001
+    assert round(t.exit_price_net, 5) == 1.10120
+    # Short: gross = entry - exit = 1.10000 - 1.10100 = -0.0010 -> -10 pips
+    assert round(t.pnl_pips, 5) == -10.00000
+
+
+# ---------------------------------------------------------------------------
+# (d) Stops fill within [low, high] of the fill bar
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    closes=st.lists(
+        st.floats(min_value=1.08, max_value=1.12, allow_nan=False),
+        min_size=5,
+        max_size=25,
+    ),
+    direction=st.sampled_from([Direction.LONG, Direction.SHORT]),
+    stop_pips=st.floats(min_value=5.0, max_value=30.0),
+)
+def test_stops_fill_within_bar(
+    closes: list[float], direction: Direction, stop_pips: float
+) -> None:
+    """Every fill price must lie within [low, high] of its fill bar."""
+    bars = _bars_from_closes(closes, hl_pad=0.0020)
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+
+    strat = FixedSignalStrategy(
+        signal_bar=0,
+        direction=direction,
+        stop_distance=stop_pips * PIP,
+        target_distance=stop_pips * 1.5 * PIP,
+    )
+    result = BacktestEngine(store, _default_cost_params()).run(
+        strat, "EUR_USD", "H1", EPOCH, end
+    )
+
+    # Build a quick lookup of bar [low, high] by timestamp.
+    ranges = {
+        b["time"]: (b["low"], b["high"]) for b in bars
+    }
+    for t in result.trades:
+        if t.exit_reason in ("stop", "target"):
+            lo, hi = ranges[t.exit_time]
+            assert lo - 1e-12 <= t.exit_price_gross <= hi + 1e-12, (
+                f"fill {t.exit_price_gross} outside bar range [{lo}, {hi}]"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Defensive-copy & misc guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_engine_does_not_mutate_input_frame() -> None:
+    """The engine must operate on a defensive copy of the store's frame."""
+    bars = _bars_from_closes([1.10, 1.11, 1.12, 1.13])
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+
+    df_before = store.load_candles("EUR_USD", "H1", EPOCH, end)
+    snapshot = df_before.copy(deep=True)
+
+    strat = FixedSignalStrategy(
+        signal_bar=0, direction=Direction.LONG,
+        stop_distance=0.0010, target_distance=0.0015,
+    )
+    BacktestEngine(store, _default_cost_params()).run(
+        strat, "EUR_USD", "H1", EPOCH, end
+    )
+    df_after = store.load_candles("EUR_USD", "H1", EPOCH, end)
+    pd.testing.assert_frame_equal(df_after, snapshot)
+
+
+def test_equity_curve_is_utc_and_matches_bar_count() -> None:
+    """Equity curve is UTC-indexed with one point per bar (INV-03)."""
+    bars = _bars_from_closes([1.10, 1.11, 1.12, 1.13, 1.14])
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+    strat = FixedSignalStrategy(
+        signal_bar=0, direction=Direction.LONG,
+        stop_distance=0.0010, target_distance=0.0015,
+    )
+    result = BacktestEngine(store, _default_cost_params()).run(
+        strat, "EUR_USD", "H1", EPOCH, end
+    )
+    assert len(result.equity_curve) == len(bars)
+    assert str(result.equity_curve.index.tz) == "UTC"
+    assert result.metadata["swap_modelled"] is False
+
+
+def test_open_position_closed_at_end_of_data() -> None:
+    """A position still open at the last bar is closed at the final close."""
+    # Signal long on bar 0, entry bar 1, but price never hits stop/target.
+    bars: list[Bar] = [
+        {"time": EPOCH, "open": 1.10000, "high": 1.10005,
+         "low": 1.09995, "close": 1.10000},
+        {"time": EPOCH + timedelta(hours=1), "open": 1.10000,
+         "high": 1.10010, "low": 1.09990, "close": 1.10005},
+        {"time": EPOCH + timedelta(hours=2), "open": 1.10005,
+         "high": 1.10010, "low": 1.10000, "close": 1.10008},
+    ]
+    store = _make_store_from_bars(bars)
+    end = bars[-1]["time"]
+    strat = FixedSignalStrategy(
+        signal_bar=0, direction=Direction.LONG,
+        stop_distance=0.0100, target_distance=0.0150,  # far away, never hit
+    )
+    result = BacktestEngine(store, _default_cost_params()).run(
+        strat, "EUR_USD", "H1", EPOCH, end
+    )
+    assert len(result.trades) == 1
+    assert result.trades[0].exit_reason == "end_of_data"
+    assert result.trades[0].exit_time == bars[-1]["time"]


### PR DESCRIPTION
Closes #6.

Event-driven backtester (`backtest/engine.py`) + cost model (`backtest/costs.py`) — the thesis-proving component. Depends on T-03 (Store) and T-04 (Strategy/Signal), both on main.

## Correctness argument

**No look-ahead (closed vectors):** the strategy is fed only the prefix slice `df.iloc[:i+1]` at bar `i` — it physically cannot index a future row. A signal from bar `i` is entered at bar `i+1`'s OPEN, never the signal bar's own price. Fill checks for an open position use only the current bar's OHLC. Verified by a canary test (poison bar K, assert no decision at bar < K changes) example-based + hypothesis property-based.

**Fill edge cases:** long stop on `low<=stop`, short stop on `high>=stop`; targets inverse. **Both breach in one bar → stop wins (conservative).** Fill level is clamped to `[low, high]` so a reported fill is never an impossible price. Position open at end-of-data is closed at the final bar's close (no dangling trade). Slippage charged on stop/target market fills only — not on the controlled next-open entry, not on the end-of-data close.

**Zero-cost trade impossible:** `total_cost_pips = spread_pips + slippage_pips`, path-independent. `CostParams` enforces `spread_pips > 0`, so the engine can never run cost-free (INV-06). Half-spread/slippage offsets are always applied on the *adverse* side of both legs → net PnL ≤ gross PnL is structural. A non-zero `swap_pips` is rejected loudly (D-03); every output carries `swap_modelled=False`.

## Tests (12; hypothesis property-based where noted)
- (a) `test_no_lookahead_canary_explicit` + `test_no_lookahead_property` — no future bar influences a past decision.
- (b) `test_costs_non_zero_multi_trade` + `test_apply_costs_invariants` — `sum(cost_pips) > 0`; gross ≥ net every trade.
- (c) `test_known_trade_exact_pnl` — hand-crafted long reproduces net 12.00000 pips to 5 decimals; `test_known_short_trade_stop_wins_tie` proves the tie-break.
- (d) `test_stops_fill_within_bar` — fills always within `[low, high]`.

## Verification (raw)
- `python -m pytest -q` → 103 passed, exit 0
- `python -m mypy backtest/` → Success (3 files), exit 0
- `python -m mypy config/ data/ strategies/ backtest/` (plugin regression check) → Success (12 files), exit 0

## Notes
- New dev dep `hypothesis>=6.0` (pyproject.toml + CLAUDE.md Stack).
- Enabled `plugins = ["pydantic.mypy"]` so strict mypy understands pydantic v2 defaulted-field construction; verified no regression in already-merged packages.
- D-03: swap not modelled; `swap_modelled=False` on every result. INV-03: all timestamps UTC, sourced from bar data.