### PR TITLE
docs: Phase 1 spec layer + cross-spec audit

### DIFF
--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -1,0 +1,49 @@
+# Fathom — Code Map
+
+Area boundaries and safe-parallel rules for orchestrated dispatch. The orchestrator (`runbook-orchestration-kickoff`) uses this to assign one worktree per area and avoid merge collisions. **Rule of thumb: never two parallel workers in the same file.**
+
+Single Python repo (not a monorepo) — "areas" are package directories.
+
+## Areas
+
+| Area | Directory / files | Owns | Status |
+|---|---|---|---|
+| `config` | `config/settings.py` | pydantic config, demo/live switch | shipped (PoC) |
+| `data` | `data/oanda_client.py`, `data/candles.py`, `data/store.py`, `data/stream.py`, `data/calendar.py` | OANDA access, candle fetch/cache, storage, live stream, calendar | partial (PoC: client+candles+store) |
+| `strategies` | `strategies/base.py`, `strategies/_indicators.py`, `strategies/trend.py`, `strategies/mean_reversion.py`, `strategies/momentum.py`, `strategies/breakout.py` | strategy interface + shared indicators (`atr()`) + implementations | partial (PoC: base + trend/MACrossover) |
+| `backtest` | `backtest/engine.py`, `backtest/costs.py`, `backtest/walkforward.py`, `backtest/metrics.py` | event-driven engine, cost model, walk-forward, metrics | shipped (PoC); `costs.py` extended in Phase 1 |
+| `cli` | `cli.py` | `fathom backtest` (Phase 1), `scan\|watchlist\|chart` (Phase 2) | new in Phase 1 |
+| `scripts` | `scripts/poc_run.py` | one-off runners | shipped (PoC) |
+| `tests` | `tests/`, `tests/integration/` | test suites (per-area files) | shipped (PoC) |
+| _future_ | `signals/`, `risk/`, `execution/`, `monitoring/`, `hermes_integration/`, `panel/` | Phase 2+ | not started |
+
+## Shared / coordinator-owned files
+
+Edits to these go through the **coordinator branch** or are **serialized** — never two parallel feature workers. (In the PoC, two parallel workers both edited `pyproject.toml`; git auto-merged identical changes by luck. Don't rely on luck.)
+
+- `pyproject.toml` — any new dependency
+- `CLAUDE.md` — stack/commands/doc-map
+- `.gitignore`
+- `docs/invariants.md`
+- `docs/features/INDEX.md`
+- `docs/code-map.md` (this file)
+
+**Dispatch rule:** a worker that needs a new dependency declares it; the coordinator applies the `pyproject.toml` + `CLAUDE.md` edits on the coordinator branch (or serializes them), and feature workers rebase onto it.
+
+## Safe-parallel rules
+
+- **Different area / different file → parallel OK.** e.g. `momentum.py` and `breakout.py` workers run concurrently.
+- **Same file → NEVER parallel.** Serialize, or merge into one task.
+- **Shared file (above) → coordinator branch only.**
+
+## Phase 1 dispatch implications (pre-resolved collisions)
+
+| Collision | Files | Resolution |
+|---|---|---|
+| `bollinger-zscore-reversion` + `rsi-reversion` | both write `strategies/mean_reversion.py` | **serialize** (one task after the other) or merge into one `mean-reversion-strategies` task |
+| `data-layer-expansion` internals | `oanda_client.py` + `candles.py` + `store.py` | **one task** (single owner of the data-layer change set) — do not split across parallel workers |
+| every strategy worker + the runner | all add deps to `pyproject.toml` | dep edits via **coordinator branch** |
+| `donchian-breakout` | extends `strategies/trend.py` (alongside existing `MACrossover`) | single worker; no parallel edit of `trend.py` |
+| shared ATR helper | all 5 strategy specs import `strategies/_indicators.py::atr()` (INV-11) | `_indicators.py` is a **shared prerequisite** — it must be created (extract the existing `trend.py` ATR, `ewm(com=period-1, adjust=False)`) before the strategy tasks can import it. Sequence it first (a small dedicated task, or fold into the donchian/trend task and have the others depend on it). |
+
+**Safe-parallel set for Phase 1 (after `data-layer-expansion` AND `_indicators.py` land):** `{donchian (trend.py)}`, `{bollinger→rsi (mean_reversion.py, serialized)}`, `{roc (momentum.py)}`, `{breakout (breakout.py)}`, `{live-streaming (stream.py)}`, `{economic-calendar (calendar.py)}` can all run concurrently — distinct files, all importing the shared `_indicators.atr()`. `swap-cost-model (costs.py)` is independent of the strategies. The runner (`cli.py`) is the join point and runs last.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -1,29 +1,62 @@
 # Fathom — Feature Index
 
-One line per feature area. Expand each into its own file under `docs/features/` as it is designed or built.
+One row per feature. Scannable in a single read — the cross-feature-consistency anchor. Phases follow the carved scheme: **PoC** (shipped) → **Phase 1** (research engine) → **Phase 2** (watchlist→Discord) → later. Spec files live beside this one under `docs/features/`.
 
-| Feature Area | Summary | Phase | Status |
+## PoC — shipped
+
+| Feature | Summary | Spec file | Status |
 |---|---|---|---|
-| `data-layer` | OANDA REST + HTTP streaming client, candle cache, live price stream, economic calendar/news pull, Parquet + SQLite storage | 1 | Not started |
-| `instrument-metadata` | Pip location, min trade size, margin rate, trading hours, typical spread — fetched once, refreshed periodically | 1 | Not started |
-| `strategy-interface` | Common `Strategy` base class and `Signal` model that all strategies implement | 2 | Not started |
-| `trend-strategies` | MA crossover and Donchian channel breakout strategies | 2 | Not started |
-| `mean-reversion-strategies` | Bollinger band / z-score reversion and RSI extremes strategies | 2 | Not started |
-| `momentum-strategies` | Rate-of-change / breakout-of-range with volatility confirmation | 2 | Not started |
-| `breakout-strategies` | Session and range breakout strategies (intraday, session opens) | 2 | Not started |
-| `backtest-engine` | Event-driven backtester with bar-by-bar simulation, intrabar stop/target fills, no look-ahead | 2 | Not started |
-| `backtest-costs` | Spread, slippage, commission, overnight swap modelling — required for any valid backtest | 2 | Not started |
-| `walk-forward-validation` | Rolling train/test window, approved-set table output with per-(strategy, pair, timeframe) metrics | 2 | Not started |
-| `signal-ranker` | Score, filter (spread, liquidity, news), de-duplicate, conflict policy, portfolio correlation limits | 3 | Not started |
-| `cli-commands` | `fathom scan \| watchlist \| backtest \| chart` — Hermes calls these as tools | 3 | Not started |
-| `chart-generation` | Candle chart with signal markers, proposed entry/stop/target overlays, exported for Discord | 3 | Not started |
-| `hermes-job-definitions` | Plain-English Hermes cron job definitions: daily swing run + intraday run | 3 | Not started |
-| `news-risk-assessment` | Claude prompt + pydantic response model for per-pair event-risk scoring (high/medium/low) | 3 | Not started |
-| `watchlist-narration` | Claude-written one-line rationale per watchlist candidate | 3 | Not started |
-| `pretrade-check` | Deterministic pre-trade Claude sanity check via `anthropic` SDK; veto path | 3 | Not started |
-| `position-sizing` | Risk-based lot size from stop distance + 0.25% equity cap | 4 | Not started |
-| `risk-limits` | Exposure limits, correlation caps, daily loss kill switch | 4 | Not started |
-| `execution-engine` | OANDA v20 order placement, bracket stops/targets, idempotency, retries, partial fill capture | 4 | Not started |
-| `reconciliation` | Broker-vs-database state reconciliation on startup and periodically | 4 | Not started |
-| `deviation-monitor` | Always-on service: adverse path, slippage, volatility spikes, feed health; auto-flatten policy | 4 | Not started |
-| `admin-panel` | Streamlit + TradingView Lightweight Charts: charts, equity curve, live blotter, watchlist, deviation log | 5 | Not started |
+| config/settings | pydantic config, demo/live switch | _(built from taskgraph; no spec file)_ | shipped |
+| oanda-client | OANDA v20 REST, candle endpoint, pagination, typed errors | _(taskgraph)_ | shipped |
+| candle-store | SQLite candle cache, gap-aware fetch, UTC round-trip | _(taskgraph)_ | shipped |
+| strategy-interface | `Strategy` ABC + `Signal` model + `Direction` | _(taskgraph)_ | shipped |
+| ma-crossover | MA crossover trend strategy | _(taskgraph)_ | shipped |
+| backtest-engine | event-driven, intrabar fills, no look-ahead | _(taskgraph)_ | shipped |
+| backtest-costs | spread + slippage (swap deferred D-03) | _(taskgraph)_ | shipped |
+| walk-forward | rolling train/test, per-window approved-set gate | _(taskgraph)_ | shipped |
+| poc-runner | end-to-end PoC runner | _(taskgraph)_ | shipped |
+
+## Phase 1 — research engine (specs ready; cross-spec audit passed 2026-05-29)
+
+**Epic 1A (research engine → approved-set):**
+
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| data-layer-expansion | full pair universe + instrument metadata + Parquet archive | [data-layer-expansion.md](data-layer-expansion.md) | ready |
+| swap-cost-model | overnight financing + commission; INV-06 fully satisfied | [swap-cost-model.md](swap-cost-model.md) | ready |
+| donchian-breakout | Donchian channel breakout (trend family) | [donchian-breakout.md](donchian-breakout.md) | ready |
+| bollinger-zscore-reversion | Bollinger / z-score mean reversion | [bollinger-zscore-reversion.md](bollinger-zscore-reversion.md) | ready |
+| rsi-reversion | RSI extremes mean reversion (shares mean_reversion.py) | [rsi-reversion.md](rsi-reversion.md) | ready |
+| roc-momentum | rate-of-change momentum + volatility confirmation | [roc-momentum.md](roc-momentum.md) | ready |
+| session-range-breakout | session / rolling-range breakout (UTC sessions) | [session-range-breakout.md](session-range-breakout.md) | ready |
+| full-universe-backtest-runner | `fathom backtest` CLI, scaled walk-forward, persisted approved-set | [full-universe-backtest-runner.md](full-universe-backtest-runner.md) | ready |
+
+**Epic 1B (live-data groundwork — off the critical path to the approved-set):**
+
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| live-streaming | OANDA pricing stream, reconnect/backoff/gap | [live-streaming.md](live-streaming.md) | ready |
+| economic-calendar | calendar/news pull, currency+impact tags | [economic-calendar.md](economic-calendar.md) | draft — blocked on provider choice |
+
+## Phase 2 — watchlist → Discord (not yet specced)
+
+| Feature | Summary | Status |
+|---|---|---|
+| signal-ranker | score, filter (spread/liquidity/news), dedupe, conflict policy, portfolio correlation | planned |
+| cli-commands | `fathom scan \| watchlist \| chart` (Hermes tools) | planned |
+| chart-generation | candle chart + signal/entry/stop/target overlays for Discord | planned |
+| hermes-job-definitions | plain-English Hermes cron jobs (daily + intraday) | planned |
+| news-risk-assessment | Claude structured event-risk scoring (INV-02) | planned |
+| watchlist-narration | Claude one-line rationale per candidate | planned |
+
+## Later — execution, monitoring, panel (Phase 3+)
+
+| Feature | Summary | Status |
+|---|---|---|
+| pretrade-check | deterministic pre-trade Claude sanity check (INV-02) | planned |
+| position-sizing | lot size from stop distance + 0.25% cap (INV-05) | planned |
+| risk-limits | exposure, correlation caps, daily kill switch | planned |
+| execution-engine | OANDA orders, brackets (INV-04), idempotency, retries | planned |
+| reconciliation | broker-vs-DB state reconciliation | planned |
+| deviation-monitor | always-on adverse-path/slippage/feed-health alerts | planned |
+| admin-panel | Streamlit + Lightweight Charts dashboard | planned |

--- a/docs/features/bollinger-zscore-reversion.md
+++ b/docs/features/bollinger-zscore-reversion.md
@@ -1,0 +1,52 @@
+# Feature: bollinger-zscore-reversion
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a Bollinger-band / z-score mean-reversion strategy. When price stretches a configurable number of standard deviations from its moving average (a high absolute z-score), it signals a reversion *against* the stretch — SHORT when over-extended above, LONG when over-extended below. New file `strategies/mean_reversion.py`. **Shares that file with [[rsi-reversion]]** — per [[code-map]] these two must be serialized or merged, never built by parallel workers.
+
+## User-facing behaviour
+
+Backend strategy. `BollingerReversion(Strategy)`, parameterised by `period: int` (MA + std window) and `num_std: float` (band width / z-score threshold). `generate_signals(df)`: SHORT when close's z-score ≥ `+num_std` (upper band breach), LONG when ≤ `−num_std` (lower band breach), at most one per bar.
+
+## Acceptance criteria
+
+- [ ] LONG when close z-score relative to the rolling `period`-bar mean/std is ≤ `−num_std`; SHORT when ≥ `+num_std`.
+- [ ] No signal while price is within the bands.
+- [ ] `stop_distance` = ATR(14) via the shared `strategies/_indicators.py::atr()` (> 0); `target_distance` = `stop_distance × rr_ratio` (default 1.5). Per **INV-11** this convention is fixed — no band-midline target.
+- [ ] `quality_score` ∈ [0, 1] from the magnitude of the z-score beyond the threshold.
+- [ ] At most one signal per bar; `generated_at` = bar close (UTC-aware, INV-03).
+- [ ] Rolling std uses sample std (ddof=1) consistently; EMAs/MAs documented (SMA vs EMA chosen explicitly).
+- [ ] Tested at `(period, num_std)` ∈ {(20, 2.0), (20, 2.5)}.
+
+## Non-goals
+
+- No trend filter to suppress reversion in strong trends (a known weakness — left to the ranker/portfolio layer in Phase 2, or a future enhancement).
+- No band-midline trailing exit (engine applies fixed stop/target).
+
+## Touches
+
+- [INV-03] — `generated_at` UTC-aware. [INV-10] — signals gated by approved-set.
+- [INV-11] — ATR(14) stop + `stop × rr_ratio` target via the shared indicator helper (fixed; no midline target).
+
+## Depends on
+
+- `strategies/base.py` — exists on `main`.
+- `strategies/_indicators.py::atr()` — the single shared ATR helper (per INV-11 / AMBIGUOUS-02).
+- File-shares `strategies/mean_reversion.py` with [[rsi-reversion]] (serialize per code-map).
+
+## Approach
+
+New `mean_reversion.py`. Compute rolling mean + sample std over `period`; z = (close − mean) / std. Emit SHORT/LONG on threshold breach with the shared `_indicators.atr()` stop (INV-11) and a fixed `stop × rr_ratio` target.
+
+## Open questions
+
+- SMA or EMA for the band centre? (Lean: SMA — classic Bollinger.)
+
+## Out of scope
+
+- The RSI reversion strategy ([[rsi-reversion]]) — separate spec, same file.

--- a/docs/features/data-layer-expansion.md
+++ b/docs/features/data-layer-expansion.md
@@ -1,0 +1,67 @@
+# Feature: data-layer-expansion
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Broaden the PoC data layer from 3 hardcoded pairs to the full OANDA FX universe, add the instrument-metadata fetch that downstream cost modelling and sizing depend on, and split storage into a Parquet candle archive (research scans) plus SQLite operational state. This is the foundation the swap-cost model and the full-universe backtest runner build on; it is one cohesive change set owned by a single worker (it touches `oanda_client.py`, `candles.py`, and `store.py` together — see [[code-map]]).
+
+## User-facing behaviour
+
+Backend module surface (no human UI). Consumed programmatically:
+
+- `OandaClient.list_instruments() -> list[InstrumentMeta]` — fetches the tradeable FX universe for the configured account via `GET /v3/accounts/{accountID}/instruments`.
+- `InstrumentMeta` (new pydantic model): `name` (e.g. `EUR_USD`), `pip_location` (int exponent, e.g. −4), `min_trade_size`, `margin_rate`, `display_precision`, and the financing fields (`long_rate`, `short_rate`, `financing_days_of_week`) used by [[swap-cost-model]]. **This model owns the canonical financing field names** (`long_rate`/`short_rate`); swap-cost-model maps them into `CostParams.swap_long_rate`/`swap_short_rate` at the engine boundary (audit AMBIGUOUS-01).
+- `fetch_and_cache(...)` unchanged in signature; gains a Parquet write path so large multi-pair scans don't thrash SQLite.
+- `Store` gains: `write_parquet(instrument, granularity, df)` / `load_parquet(...)` for the candle archive (partitioned by instrument + date); existing SQLite `candles` table is retained for operational/cache state and gap detection.
+
+## Acceptance criteria
+
+- [ ] `list_instruments()` returns every tradeable FX instrument for the demo account, each as a validated `InstrumentMeta`; metadata cached to SQLite and refreshable.
+- [ ] `pip_location` is correctly derived per instrument (JPY pairs −2, most majors −4) and exposed so callers never hardcode pip value.
+- [ ] Candle archive writes to Parquet partitioned by `instrument` and `date`; a round-trip (`write_parquet` → `load_parquet`) preserves `datetime64[ns, UTC]` timestamps and float64/int64 dtypes — identical contract to `Store.load_candles` (INV-03).
+- [ ] SQLite remains the source of truth for gap detection (`get_cached_times`) and operational state; Parquet is the bulk archive.
+- [ ] A multi-pair fetch over the full universe is gap-aware (no re-fetch of cached ranges) and does not exceed OANDA rate limits (sequential or throttled).
+- [ ] No OANDA token appears in any log line (INV-08).
+
+## Component design
+
+New model `InstrumentMeta` in `data/oanda_client.py` (alongside `CandleRow`). `OandaClient` gains `list_instruments()` using `oandapyV20.endpoints.accounts.AccountInstruments`. `Store` gains Parquet methods using `pyarrow`; archive path layout `archive/{instrument}/{YYYY-MM-DD}.parquet`. The existing `candles` SQLite table and `load_candles`/`get_cached_times`/`upsert` are unchanged in contract — Parquet is additive. `fetch_and_cache` writes through to both SQLite (gap state) and Parquet (archive) but its return contract (the `pd.DataFrame` shape) is unchanged.
+
+**Wire-format note:** OANDA returns `pipLocation` as an integer exponent and financing rates as decimal strings; coerce at the client boundary (`InstrumentMeta` validators) — never leak raw strings downstream.
+
+## Non-goals
+
+- No live streaming (that is [[live-streaming]]).
+- No change to the `CandleRow` schema or the `load_candles` DataFrame contract.
+- No PostgreSQL/TimescaleDB migration (deferred; SQLite + Parquet is sufficient for Phase 1).
+
+## Touches
+
+- [INV-03] — all archived/loaded timestamps UTC RFC 3339 / `datetime64[ns, UTC]`.
+- [INV-08] — token never logged; metadata fetch uses the same `SecretStr` path.
+- [INV-09] — instrument list is account-scoped via `settings.env`; no demo/live branch in logic.
+
+## Depends on
+
+- PoC data layer (`oanda_client.py`, `candles.py`, `store.py`) — exists on `main`.
+
+External:
+- `oandapyV20` (`AccountInstruments` endpoint), `pyarrow` (Parquet) — `pyarrow` is a new dependency.
+
+## Approach
+
+Extend, don't rewrite. `list_instruments()` is a thin new endpoint wrapper mirroring the existing `get_candles` pagination/error pattern (`OandaAPIError` on 4xx/5xx). Parquet methods sit beside the SQLite ones in `Store`; the dual-write keeps gap detection cheap (SQLite) while making full-universe scans fast (columnar Parquet). Metadata is cached so the universe list and pip locations aren't re-fetched every run.
+
+## Open questions
+
+- Parquet partition granularity — by date (daily files) vs by month? Daily is simpler for gap reasoning; month reduces file count for D-granularity. (Lean: by date for H1/H4, by month for D — decide in Plan.)
+- Full universe is ~68–70 FX pairs; confirm the demo account's tradeable set and whether any are illiquid enough to exclude up front (vs letting the ranker deprioritise later — Phase 2 concern, so include all here).
+
+## Out of scope
+
+- The backtest runner's parallelism (that's [[full-universe-backtest-runner]]).
+- Swap-rate *application* (this spec only *fetches* the financing metadata; [[swap-cost-model]] applies it).

--- a/docs/features/donchian-breakout.md
+++ b/docs/features/donchian-breakout.md
@@ -1,0 +1,52 @@
+# Feature: donchian-breakout
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a Donchian channel breakout strategy to the trend family. A long signal fires when price breaks above the highest high of the last N bars; a short when it breaks below the lowest low. It implements the existing `Strategy` interface and produces standard `Signal` objects, so the engine, walk-forward, and approved-set consume it with zero special-casing. Lives in `strategies/trend.py` alongside the shipped `MACrossover`.
+
+## User-facing behaviour
+
+Backend strategy. `DonchianBreakout(Strategy)`, parameterised by `channel_period: int` (lookback for the high/low channel). `generate_signals(df)` returns `Signal` objects: LONG on a close above the prior `channel_period`-bar high, SHORT on a close below the prior `channel_period`-bar low, at most one per bar.
+
+## Acceptance criteria
+
+- [ ] LONG signal when the bar's close breaks above the rolling max of the prior `channel_period` highs (excluding the current bar — no look-ahead within the indicator).
+- [ ] SHORT signal on the mirror condition against the rolling min of lows.
+- [ ] No signal while price stays inside the channel.
+- [ ] `stop_distance` = ATR(14) at the signal bar (> 0); `target_distance` = `stop_distance × rr_ratio` (default 1.5) — same convention as `MACrossover`.
+- [ ] `quality_score` ∈ [0, 1] derived from breakout strength (e.g. normalised distance beyond the channel edge).
+- [ ] At most one signal per bar; `generated_at` = the bar's close timestamp (UTC-aware, INV-03), never `datetime.now()`.
+- [ ] Tested at `channel_period` ∈ {20, 55} (classic Donchian/turtle values).
+
+## Non-goals
+
+- No position management or exits beyond the stop/target the engine applies.
+- No volatility filter (that's the momentum strategy's confirmation step).
+
+## Touches
+
+- [INV-03] — `Signal.generated_at` UTC-aware from the bar close.
+- [INV-10] — produces signals only; live use is gated by the approved-set.
+- [INV-11] — ATR(14) stop + `stop × rr_ratio` target via the shared indicator helper.
+
+## Depends on
+
+- `strategies/base.py` (`Strategy`, `Signal`, `Direction`) — exists on `main`. Anchors to the same contract `MACrossover` uses.
+- `strategies/_indicators.py::atr()` — the single shared ATR helper (per INV-11). Part of this work is extracting the existing `trend.py` ATR (`ewm(com=period-1, adjust=False)`) into `_indicators.py` so all strategies share one implementation.
+
+## Approach
+
+Mirror `MACrossover`'s shape in `trend.py`: compute the rolling channel with pandas (`.rolling(channel_period).max()/.min()`, shifted by 1 bar to exclude the current bar), detect the breakout crossing, emit one `Signal` per breakout bar with the shared `_indicators.atr()` stop.
+
+## Open questions
+
+- Use close-based breakout (close beyond channel) or intrabar high/low breakout? Close-based is less whippy and avoids intrabar look-ahead ambiguity. (Lean: close-based.)
+
+## Out of scope
+
+- Any change to `MACrossover` or the `Strategy` interface.

--- a/docs/features/economic-calendar.md
+++ b/docs/features/economic-calendar.md
@@ -1,0 +1,56 @@
+# Feature: economic-calendar
+
+**Status.** draft
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a scheduled pull of the upcoming economic calendar (rate decisions, CPI, NFP, etc.) and per-currency headline feed (`data/calendar.py`). Each event is tagged with currency, UTC time, and expected impact (high/medium/low). This is the raw material Claude's news/event-risk assessment reasons over in Phase 2 — it does **not** feed the Phase 1 approved-set. Independent branch; candidate for epic **1B** if Phase 1 is split.
+
+## User-facing behaviour
+
+Backend module. `EconomicCalendar(...)` exposing `upcoming_events(currencies, window) -> list[CalendarEvent]` and a refresh method. `CalendarEvent` (pydantic): `currency`, `event_name`, `time` (UTC-aware, INV-03), `impact` (enum high/medium/low), optional `actual`/`forecast`/`previous`. Stored in SQLite operational state for later consumption.
+
+## Acceptance criteria
+
+- [ ] Pulls upcoming economic events for the relevant FX currencies and stores them with UTC timestamps (INV-03).
+- [ ] Each event carries a normalised `impact` level (high/medium/low) via a documented mapping from the source.
+- [ ] Events are tagged with their currency (USD, EUR, GBP, JPY, …) so a per-pair query can union both legs' currencies.
+- [ ] A refresh is idempotent (re-pulling the same window updates, doesn't duplicate).
+- [ ] The source/provider is pluggable behind the `EconomicCalendar` interface (so a provider swap doesn't ripple).
+- [ ] No secrets/keys for the calendar provider are committed (INV-08); any API key lives in `.env`.
+
+## Non-goals
+
+- No LLM reasoning over the calendar (that is Phase 2's news-risk assessment — this feature only supplies the data).
+- No down-ranking/veto logic (Phase 2 ranker).
+- No real-time news streaming — a scheduled pull is sufficient.
+
+## Touches
+
+- [INV-03] — event times UTC RFC 3339. [INV-08] — any provider API key in `.env` only.
+- [INV-09] — provider config is read via the same env-scoped `Settings` path; no demo/live branch in logic.
+- [INV-02] — *not* this feature, but noted: when Phase 2 feeds these events to Claude, that output must be structured JSON with safe defaults. This feature just provides clean, typed input.
+
+## Depends on
+
+- `config/settings.py` (for any provider key), `data/store.py` (operational persistence) — exist on `main`.
+
+External:
+- An economic-calendar/news data source (provider TBD — see Open questions). Could be a free calendar API or a scraped feed.
+
+## Approach
+
+Define `CalendarEvent` + an `EconomicCalendar` interface with a concrete provider implementation behind it. Pull on a schedule (invoked by the Phase 2 Hermes job later; for Phase 1 a manual/CLI refresh suffices), normalise impact + currency, store to SQLite. Keep the provider behind the interface so the (uncertain) data source can change without touching consumers.
+
+## Open questions
+
+- **Provider choice** — this is the main unknown. Options: a free economic-calendar API (rate-limited), a paid feed, or scraping (fragile). OANDA's v20 API does *not* provide an economic calendar (it has a separate, deprecated labs calendar endpoint). Decide the provider before drafting the Plan; it determines auth, rate limits, and the impact-level mapping. **Blocking for this spec's implementation, not for the rest of Phase 1.**
+- Headline/news feed: bundle with the calendar provider, or separate source? (Lean: calendar first; headlines are a softer Phase 2 input.)
+
+## Out of scope
+
+- Live streaming ([[live-streaming]]).
+- Phase 2 news-risk scoring and watchlist veto.

--- a/docs/features/full-universe-backtest-runner.md
+++ b/docs/features/full-universe-backtest-runner.md
@@ -1,0 +1,77 @@
+# Feature: full-universe-backtest-runner
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The Phase 1 integration capstone: a `fathom backtest` CLI command (`cli.py`) that runs walk-forward validation across **every** (strategy, pair, timeframe) combination in the full universe and writes the resulting approved-set table to the database. This is where all the Phase 1 pieces join — the expanded data layer, the swap-aware cost model, and all five new strategies plus the existing MA crossover. Its output (the approved-set) is the gate Phase 2's ranker consumes (INV-10). It also designs in the two lessons the PoC surfaced: **daily-timeframe starvation** and the **per-window approval gate**.
+
+## User-facing behaviour
+
+CLI command:
+
+```
+fathom backtest [--instruments ALL|EUR_USD,...] [--timeframes H1,H4,D]
+                [--strategies all|macrossover,donchian,...]
+                [--workers N] [--db-path PATH]
+```
+
+Runs every requested combination through `WalkForwardValidator`, prints a summary of approved entries (strategy, pair, timeframe, mean OOS Sharpe, total OOS trades, `swap_modelled`), and **persists the approved-set table to the database** so Phase 2 can read it. Empty approved-set is a valid, exit-0 result (carried from the PoC).
+
+## Acceptance criteria
+
+- [ ] `fathom backtest` discovers the full FX universe via `list_instruments()` (or an explicit `--instruments`) and runs all (strategy, pair, timeframe) combos.
+- [ ] Walk-forward uses the swap-aware cost model ([[swap-cost-model]]) — every result is INV-06-valid (`swap_modelled=True` where financing applies).
+- [ ] **Approved-set table is persisted to the DB** (new table), not just printed — Phase 2's ranker reads it (INV-10). Schema mirrors the shipped `ApprovedSetEntry`: `strategy_name`, `instrument`, **`granularity`** (the shipped field name — not "timeframe"), `oos_sharpe_mean`, `oos_trade_count_total`, `swap_modelled`, plus a DB-table-only `run_timestamp` (UTC RFC 3339). `ApprovedSetEntry` itself is unchanged — `run_timestamp` is added at the persistence layer only (audit DRIFT-03).
+- [ ] **Per-timeframe window sizing** so the daily timeframe is not structurally starved (the PoC's daily combos got 0–2 trades on 3-month windows). Longer test windows for D (and H4); documented per-timeframe `train_months`/`test_months`.
+- [ ] **Approval gate** stays strict per-window (Sharpe>0 AND ≥5 trades every OOS window — carried from the PoC ruling) unless the per-timeframe sizing makes a different gate appropriate; the chosen gate is documented and applied uniformly.
+- [ ] Multi-process execution (`--workers N`) so ~1,700 combos complete in reasonable wall-clock; results are deterministic regardless of worker count.
+- [ ] All run timestamps UTC RFC 3339 (INV-03); no credentials logged (INV-08).
+- [ ] Empty approved-set exits 0 with a clear message (PoC behaviour preserved).
+
+## Component design
+
+New `cli.py` with a `backtest` subcommand (argparse or click — see Open questions). It composes existing pieces: `list_instruments()` → for each (strategy, pair, timeframe), construct `BacktestEngine(store, CostParams(...with swap...))` + the strategy, run `WalkForwardValidator.run(...)`, collect `ApprovedSetEntry` objects. A new `approved_set` SQLite table persists them. Multi-process via `concurrent.futures.ProcessPoolExecutor` over the combo list (each combo is independent → embarrassingly parallel); the engine already takes a defensive DataFrame copy, so workers don't share mutable state. Per-timeframe window config is a small table/dict consulted per run.
+
+**Write concurrency (INV-12, resolving audit AMBIGUOUS-03):** worker processes return `ApprovedSetEntry` objects to the parent; **all** `approved_set` inserts happen in the parent process, after every future is collected, in a single `BEGIN…COMMIT` transaction. No worker writes to the DB directly — this is a committed design point, not an open question.
+
+**Persistence contract:** the `approved_set` table is the INV-10 gate. Phase 2's ranker loads it at startup and refuses to operate if empty. Schema (mirroring `ApprovedSetEntry` + a DB-only `run_timestamp`) and the "empty = no signals, not all signals" semantics are owned here.
+
+## Non-goals
+
+- No vectorised pre-screen backtester (D-P1-1: skip — one engine, done right).
+- No signal ranking / portfolio logic (Phase 2).
+- No live trading (INV-07).
+
+## Touches
+
+- [INV-06] — all results swap-aware (depends on [[swap-cost-model]]).
+- [INV-10] — owns the approved-set table that gates Phase 2 signals.
+- [INV-11] — consumes strategy Signals whose ATR/RR stops make OOS Sharpe comparable across strategies.
+- [INV-12] — single-writer, parent-serialized approved-set writes.
+- [INV-03] — UTC timestamps. [INV-08] — no logged secrets. [INV-09] — account-scoped via `settings.env`.
+
+## Depends on
+
+- [[data-layer-expansion]] — universe discovery + metadata (pip values, financing rates).
+- [[swap-cost-model]] — INV-06-valid costs.
+- [[donchian-breakout]], [[bollinger-zscore-reversion]], [[rsi-reversion]], [[roc-momentum]], [[session-range-breakout]] — the strategies it validates (plus the existing `MACrossover`).
+- PoC `backtest/walkforward.py`, `engine.py`, `metrics.py` — exist on `main`.
+
+## Approach
+
+A thin orchestration layer over already-tested components — most of the risk is in the *composition* (correct per-timeframe windows, deterministic parallelism, the persisted gate schema), not new algorithmic code. Build the combo list, fan out over a process pool, collect `ApprovedSetEntry` results, write the `approved_set` table. This is the join point of the Phase 1 DAG and should be the **last** spec drafted and the last task dispatched.
+
+## Open questions
+
+- **D-P1-2 / D-P1-3 (window sizing + gate):** what `train_months`/`test_months` per timeframe, given daily starvation? Candidates: H1 = 12/3 (PoC); H4 = 18/6; D = 24/6 or longer. And does the strict per-window gate survive for D, or do low-frequency timeframes get a per-timeframe trade floor? **Needs a ruling in Plan** — this directly determines what gets approved.
+- **D-P1-5 (scale):** ~70 pairs × 6 strategies × 3 timeframes ≈ 1,260–1,700 combos. Confirm `ProcessPoolExecutor` worker count. (Write serialization is settled — parent-only writes per INV-12; see Component design.)
+- CLI framework: argparse (stdlib, no new dep) vs click (nicer UX). (Lean: argparse — the PoC runner already uses it; no new dependency.)
+
+## Out of scope
+
+- The `scan|watchlist|chart` CLI subcommands (Phase 2).
+- Re-architecting the engine for speed beyond process-level parallelism.

--- a/docs/features/live-streaming.md
+++ b/docs/features/live-streaming.md
@@ -1,0 +1,88 @@
+# Feature: live-streaming
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a long-lived OANDA v20 pricing stream (`data/stream.py`): a persistent HTTP streaming connection that emits live price ticks plus heartbeats, with automatic reconnection (exponential backoff), heartbeat-timeout detection, and gap detection on reconnect. OANDA's v20 stream is **not** a WebSocket — it is a chunked HTTP response from `GET /v3/accounts/{accountID}/pricing/stream`, capped at ~4 prices/sec/instrument.
+
+**Scope note:** this feature does **not** feed the Phase 1 approved-set (which is historical-candle-driven). It is groundwork for Phase 2's live signal evaluation and the deviation monitor. It is an independent branch — a candidate for epic **1B** if Phase 1 is split (see [[../phases/phase-1]]).
+
+## User-facing behaviour
+
+Backend module. `PriceStream(settings, instruments)` exposing an iterator/callback of typed `PriceTick` objects (`instrument`, `time` UTC-aware, `bid`, `ask`, `status`). Heartbeats are consumed internally (connection-liveness), not surfaced as ticks. On disconnect it reconnects automatically; the consumer sees a continuous tick stream with a `gap_detected` flag when a reconnect skipped data.
+
+## Acceptance criteria
+
+- [ ] Establishes a persistent HTTP stream to the **practice** endpoint (per `settings.env`, INV-09) and yields `PriceTick` objects with UTC-aware timestamps (INV-03).
+- [ ] Heartbeat messages are recognised and reset a liveness timer; absence of heartbeat beyond a timeout triggers reconnect.
+- [ ] Reconnect uses exponential backoff with a cap (e.g. 1s → 2s → … → 30s) and jitter; reconnect attempts are logged (no token in logs — INV-08).
+- [ ] On reconnect, a `gap_detected` signal is raised so downstream consumers know data may have been missed.
+- [ ] The stream can be cleanly shut down (no orphaned connection / thread).
+- [ ] Connection failures raise typed errors, not raw library exceptions, consistent with `OandaAPIError`.
+
+## Sequence diagram
+
+> Included: 3 actors (consumer, stream client, OANDA) + asynchronous coordination (heartbeat timeout, reconnect with backoff) — meets the threshold.
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant S as PriceStream
+    participant O as OANDA pricing/stream
+
+    C->>S: start(instruments)
+    S->>O: GET /pricing/stream (chunked HTTP)
+    loop while connected
+        O-->>S: PRICE tick
+        S-->>C: PriceTick (UTC-aware)
+        O-->>S: HEARTBEAT
+        S->>S: reset liveness timer
+    end
+    Note over S,O: connection drops OR heartbeat timeout
+    S->>S: backoff (exp + jitter, capped)
+    S->>O: reconnect GET /pricing/stream
+    S-->>C: gap_detected = true
+```
+
+### Failure modes considered
+
+- OANDA drops the connection silently → heartbeat-timeout timer fires → reconnect.
+- Reconnect storms → exponential backoff + cap prevents hammering the API.
+- Reconnect skipped ticks → `gap_detected` flag so consumers (Phase 2 monitor) can react, not silently trust continuity.
+- Clean shutdown mid-stream → no orphaned thread/socket.
+
+## Non-goals
+
+- No persistence of ticks to a long-term tick archive (Phase 2+ concern; may write recent ticks to operational state only).
+- No signal evaluation off the stream (Phase 2).
+- No order placement — streaming is read-only price data (INV-01 boundary unaffected).
+
+## Touches
+
+- [INV-03] — tick timestamps UTC-aware. [INV-08] — token never logged. [INV-09] — endpoint from `settings.env`.
+
+## Depends on
+
+- `data/oanda_client.py` / `config/settings.py` — exist on `main` (reuses auth + env selection).
+- Light dependency on `data/store.py` if recent ticks are persisted to operational state.
+
+External:
+- `oandapyV20` pricing-stream endpoint (`oandapyV20.endpoints.pricing.PricingStream`).
+
+## Approach
+
+Wrap `oandapyV20`'s `PricingStream` (a generator over the chunked HTTP body). Run it on a background thread or async task; classify each message as PRICE or HEARTBEAT; maintain a liveness timer; on drop/timeout, reconnect with capped exponential backoff + jitter and raise `gap_detected`. Reuse the env/auth path from `OandaClient` so demo/live selection stays single-source (INV-09).
+
+## Open questions
+
+- Threading vs asyncio for the stream loop? (Lean: a background thread with a thread-safe queue — simplest to integrate with the otherwise-synchronous codebase.)
+- Do we persist recent ticks now, or defer all persistence to Phase 2? (Lean: defer; expose the live iterator only.)
+
+## Out of scope
+
+- Economic calendar ([[economic-calendar]]).
+- Anything that consumes the stream for signals/monitoring (Phase 2).

--- a/docs/features/roc-momentum.md
+++ b/docs/features/roc-momentum.md
@@ -1,0 +1,52 @@
+# Feature: roc-momentum
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a rate-of-change (ROC) momentum strategy with a volatility-confirmation filter: go with the move when momentum is strong *and* volatility confirms a real expansion (not noise). LONG on strong positive ROC, SHORT on strong negative ROC, suppressed when volatility is too low to trust the move. New file `strategies/momentum.py`.
+
+## User-facing behaviour
+
+Backend strategy. `ROCMomentum(Strategy)`, parameterised by `roc_period: int`, `roc_threshold: float` (momentum trigger), and `atr_filter_period: int` (volatility confirmation window). `generate_signals(df)`: LONG when ROC ≥ `+roc_threshold` and volatility confirms; SHORT when ROC ≤ `−roc_threshold` and volatility confirms; at most one per bar.
+
+## Acceptance criteria
+
+- [ ] ROC = percentage change of close over `roc_period` bars; LONG/SHORT when it crosses ±`roc_threshold`.
+- [ ] **Volatility confirmation:** signal suppressed unless current ATR exceeds its own recent average (range expansion) — the "with volatility confirmation" requirement from the product spec. Documented threshold.
+- [ ] No signal when momentum is below threshold OR volatility does not confirm.
+- [ ] `stop_distance` = ATR(14) at the signal bar (> 0); `target_distance` = `stop_distance × rr_ratio` (default 1.5).
+- [ ] `quality_score` ∈ [0, 1] from ROC magnitude beyond threshold (optionally scaled by the volatility-confirmation margin).
+- [ ] At most one signal per bar; `generated_at` = bar close (UTC-aware, INV-03).
+- [ ] Tested at `(roc_period, roc_threshold)` ∈ {(10, 0.5%), (20, 1.0%)} with the volatility filter on and off (to prove the filter changes behaviour).
+
+## Non-goals
+
+- No multi-timeframe confirmation.
+- No breakout-of-range logic (that's [[session-range-breakout]] — kept distinct despite the product doc grouping them, because the surfaces differ).
+
+## Touches
+
+- [INV-03] — `generated_at` UTC-aware. [INV-10] — gated by approved-set.
+- [INV-11] — ATR(14) stop + `stop × rr_ratio` target via the shared indicator helper.
+
+## Depends on
+
+- `strategies/base.py` — exists on `main`.
+- `strategies/_indicators.py::atr()` — the single shared ATR helper (per INV-11); also used for the volatility-confirmation gate.
+
+## Approach
+
+New `momentum.py`. ROC via `close.pct_change(roc_period)`. Volatility confirmation compares current ATR (from the shared `_indicators.atr()`) to its rolling mean (range-expansion gate). Emit signal only when both momentum and volatility conditions hold; stop from the same shared ATR.
+
+## Open questions
+
+- Volatility-confirmation definition: ATR > rolling-mean-ATR (range expansion) vs ATR percentile vs Bollinger bandwidth. (Lean: ATR > k × rolling-mean-ATR, k≈1.0, tunable.)
+- ROC threshold units — percent vs pips. (Lean: percent, instrument-agnostic.)
+
+## Out of scope
+
+- Session/range breakout ([[session-range-breakout]]).

--- a/docs/features/rsi-reversion.md
+++ b/docs/features/rsi-reversion.md
@@ -1,0 +1,52 @@
+# Feature: rsi-reversion
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add an RSI-extremes mean-reversion strategy: LONG when RSI falls below an oversold threshold, SHORT when it rises above overbought. Shares `strategies/mean_reversion.py` with [[bollinger-zscore-reversion]]. **Per [[code-map]], these two specs target the same file and must be serialized (or merged into one `mean-reversion-strategies` task) — never parallel workers.**
+
+## User-facing behaviour
+
+Backend strategy. `RSIReversion(Strategy)`, parameterised by `period: int` (RSI lookback, default 14), `oversold: float` (default 30), `overbought: float` (default 70). `generate_signals(df)`: LONG when RSI crosses up out of oversold, SHORT when it crosses down out of overbought, at most one per bar.
+
+## Acceptance criteria
+
+- [ ] RSI computed with Wilder's smoothing (the standard) over `period` bars — documented explicitly (matches the ATR Wilder convention already used in the trend module).
+- [ ] LONG on RSI crossing back above `oversold` (exiting the oversold zone); SHORT on crossing back below `overbought`. (Cross-out, not mere level — avoids a continuous signal while pinned in the zone.)
+- [ ] No signal while RSI is mid-range.
+- [ ] `stop_distance` = ATR(14) at the signal bar (> 0); `target_distance` = `stop_distance × rr_ratio` (default 1.5).
+- [ ] `quality_score` ∈ [0, 1] from how deep into the extreme RSI reached before reverting.
+- [ ] At most one signal per bar; `generated_at` = bar close (UTC-aware, INV-03).
+- [ ] Tested at `(period, oversold, overbought)` ∈ {(14, 30, 70), (14, 20, 80)}.
+
+## Non-goals
+
+- No divergence detection (price/RSI divergence is a richer signal, deferred).
+- No trend filter (see [[bollinger-zscore-reversion]] non-goals).
+
+## Touches
+
+- [INV-03] — `generated_at` UTC-aware. [INV-10] — gated by approved-set.
+- [INV-11] — ATR(14) stop + `stop × rr_ratio` target via the shared indicator helper.
+
+## Depends on
+
+- `strategies/base.py` — exists on `main`.
+- `strategies/_indicators.py::atr()` — the single shared ATR helper (per INV-11).
+- Shares `strategies/mean_reversion.py` with [[bollinger-zscore-reversion]].
+
+## Approach
+
+Add `RSIReversion` to `mean_reversion.py`. RSI via Wilder's smoothing (`ewm(com=period-1, adjust=False)` on gains/losses — the same formulation the shared ATR uses). Signal on the cross-out of the extreme zone; stop from the shared `_indicators.atr()`. Because it co-lives with the Bollinger strategy, the worker building this either follows the Bollinger task (serialized) or both ship in one mean-reversion task.
+
+## Open questions
+
+- Cross-out vs level-based trigger — cross-out chosen to avoid repeated signals while pinned. Confirm in Plan.
+
+## Out of scope
+
+- The Bollinger strategy itself ([[bollinger-zscore-reversion]]) — separate spec, same file.

--- a/docs/features/session-range-breakout.md
+++ b/docs/features/session-range-breakout.md
@@ -1,0 +1,53 @@
+# Feature: session-range-breakout
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add a session/range breakout strategy: define a reference range (e.g. the Asian session range, or the prior N-bar range) and signal a breakout when price closes beyond it during the active session. Useful intraday around session opens. New file `strategies/breakout.py`. Session boundaries are defined in UTC (INV-03).
+
+## User-facing behaviour
+
+Backend strategy. `SessionRangeBreakout(Strategy)`, parameterised by the reference-range definition (`range_start_utc`, `range_end_utc` for a session window, or `range_lookback` bars) and an optional `buffer_pips` to filter marginal breaks. `generate_signals(df)`: LONG when a bar closes above the reference-range high (+ buffer), SHORT when it closes below the range low (− buffer), at most one per bar.
+
+## Acceptance criteria
+
+- [ ] Reference range computed correctly — either a fixed UTC session window per day or a rolling `range_lookback`-bar high/low.
+- [ ] LONG when close breaks above range high + `buffer_pips`; SHORT below range low − `buffer_pips`.
+- [ ] Session windows are defined and compared in **UTC** (INV-03) — no local-time assumptions; FX session boundaries (Sydney/Tokyo/London/NY) stated as UTC offsets and documented.
+- [ ] At most one breakout signal per session/day per direction (no repeated firing once the range is broken).
+- [ ] `stop_distance` = ATR(14) via the shared `strategies/_indicators.py::atr()` (> 0); `target_distance` = `stop_distance × rr_ratio` (default 1.5). Per **INV-11** the stop is ATR-derived (a range-width stop is a future-enhancement note, not this spec).
+- [ ] `quality_score` ∈ [0, 1] from break distance beyond the range edge.
+- [ ] `generated_at` = bar close (UTC-aware, INV-03).
+- [ ] Tested on H1 with a defined session window and on a rolling-range variant.
+
+## Non-goals
+
+- No false-breakout fade logic.
+- No daily-bias filter.
+
+## Touches
+
+- [INV-03] — session boundaries and `generated_at` strictly UTC. This is the strategy where UTC discipline matters most (sessions are time-of-day defined).
+- [INV-10] — gated by approved-set.
+- [INV-11] — ATR(14) stop + `stop × rr_ratio` target via the shared indicator helper.
+
+## Depends on
+
+- `strategies/base.py` — exists on `main`.
+
+## Approach
+
+New `breakout.py`. For the session variant: group bars by UTC date, compute the reference-window high/low, then detect the first close beyond it during the active window; reset per day. For the rolling variant: `rolling(range_lookback).max()/.min()` shifted by 1 bar. The "once per session per direction" rule needs explicit state across bars within a day — implement as a per-day latch, not a naive per-bar check.
+
+## Open questions
+
+- Which reference range is primary for Phase 1 — fixed Asian-session window (classic, but needs the session times pinned in UTC) or rolling N-bar range (simpler, timeframe-agnostic)? (Lean: rolling N-bar range for Phase 1 simplicity; add the session-window variant if it earns its place.)
+- Session times: confirm the UTC offsets to use given DST shifts (London/NY observe DST; Tokyo does not). (Lean: if doing the session variant, use fixed UTC windows and note the DST caveat in results.)
+
+## Out of scope
+
+- ROC momentum ([[roc-momentum]]) — distinct strategy despite the product doc grouping breakout under momentum.

--- a/docs/features/swap-cost-model.md
+++ b/docs/features/swap-cost-model.md
@@ -1,0 +1,74 @@
+# Feature: swap-cost-model
+
+**Status.** ready
+**Phase.** Phase 1
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Add overnight swap/financing (and commission, if the account charges it) to the backtest cost model, satisfying INV-06 in full. The PoC deferred swap (D-03): `CostParams`/`apply_costs` rejected any non-zero `swap_pips` and every output carried `swap_modelled=False`. Phase 1 lifts that deferral — multi-day positions (especially on H4/D timeframes) accrue real financing cost, and a backtest that ignores it overstates swing-strategy returns. Financing rates come from the instrument metadata fetched by [[data-layer-expansion]].
+
+## User-facing behaviour
+
+Backend module surface. Consumed by the engine:
+
+- `CostParams` gains `swap_long_rate` / `swap_short_rate` (per-instrument daily financing, mapped from `InstrumentMeta.long_rate`/`short_rate`) and a `commission_pips` field (default 0.0 for spread-only accounts). The legacy `swap_pips` field and both `swap_pips != 0.0 → ValueError` guard sites are **removed**; `swap_modelled` becomes `True` when financing is applied.
+- `apply_costs(...)` takes `holding_days: int` (financing days, computed by the engine) so it can charge `swap = rate × days` on the appropriate side. The swap charge is direction-aware: long uses `swap_long_rate`, short uses `swap_short_rate`.
+- `CostResult.swap_modelled` is now `True` for any run that passes financing data; `metrics.py` / `walkforward.py` / the approved-set propagate the honest label unchanged.
+
+## Acceptance criteria
+
+- [ ] `apply_costs` charges financing = `daily_rate × holding_days` on the correct side (long vs short), in addition to spread + slippage; `total_cost_pips` includes it.
+- [ ] A position closed same-bar (0 holding days) accrues **zero** swap — swap applies only to overnight holds.
+- [ ] `swap_modelled` is `True` whenever financing data is supplied and `False` only when explicitly run without it; the label propagates to `Metrics`, `ApprovedSetEntry`.
+- [ ] INV-06 still holds: `total_cost_pips > 0` for any non-zero spread/slippage; gross PnL ≥ net PnL on every trade (financing can only worsen or, for a positive-carry side, slightly improve net — the engine must handle positive carry without ever producing a cost-free *spread* path).
+- [ ] Commission (if configured > 0) is charged per round trip.
+- [ ] A regression test confirms the PoC's spread+slippage numbers are unchanged when `swap=0, commission=0` (backward compatibility).
+- [ ] The `swap_pips`-must-be-zero guard (D-03) is removed and its tests updated, not deleted silently.
+
+## Component design
+
+Extend `backtest/costs.py`. Precise, committed changes (resolving audit DRIFT-02):
+
+- **`CostParams`:** **remove** the `swap_pips` field entirely; **remove** the `_swap_must_be_zero` validator. **Add** `swap_long_rate: float`, `swap_short_rate: float` (daily financing in pips, populated from `InstrumentMeta` — see field mapping below), and `commission_pips: float = 0.0`.
+- **`apply_costs`:** final committed signature —
+  `apply_costs(entry_price, exit_price, direction, spread_pips, slippage_pips, pip_value, swap_long_rate, swap_short_rate, holding_days: int, commission_pips=0.0) -> CostResult`.
+  The legacy `swap_pips=0.0` parameter is **removed**, and the inline guard at `costs.py:159` (`if swap_pips != 0.0: raise`) is **removed** along with the pydantic validator — both D-03 guard sites go, not just one.
+- **`holding_days`** is computed by the engine (`backtest/engine.py`) per trade from the entry/exit bar UTC dates and passed in. Financing charged = `rate × holding_days` on the direction's side (long → `swap_long_rate`, short → `swap_short_rate`).
+- `CostResult.swap_modelled = True` whenever financing is applied.
+
+**Field-name mapping (resolving audit AMBIGUOUS-01):** [[data-layer-expansion]] owns the authoritative names on `InstrumentMeta`: `long_rate`, `short_rate`. This spec maps them at the engine boundary: `CostParams.swap_long_rate = InstrumentMeta.long_rate`, `CostParams.swap_short_rate = InstrumentMeta.short_rate`. The rename happens once, in the engine's `CostParams` construction — documented here so there is no ambiguity about which side owns the name.
+
+Carry sign: positive-carry trades reduce net cost; the cost-floor invariant is on *spread+slippage*, which remains strictly positive, so INV-06 is not weakened by positive carry.
+
+## Non-goals
+
+- No intraday financing (financing is a daily overnight event).
+- No modelling of broker-specific swap-free (Islamic) accounts.
+- No change to spread/slippage logic (that stays exactly as shipped in the PoC).
+
+## Touches
+
+- [INV-06] — this feature is what makes INV-06 *fully* satisfied (all four cost categories: spread ✓, slippage ✓, commission, swap).
+- [INV-03] — holding-days derived from UTC bar timestamps.
+
+## Depends on
+
+- [[data-layer-expansion]] — supplies per-instrument financing rates (`swap_long_rate`, `swap_short_rate`) and `financing_days_of_week` via `InstrumentMeta`.
+- PoC `backtest/costs.py` + `backtest/engine.py` — exist on `main`.
+
+## Approach
+
+Surgical extension of the existing, well-tested cost model. The PoC's structural guarantee (costs applied adversely on both legs, path-independent spread+slippage floor) is preserved; swap is an additive per-day charge keyed off holding duration and the per-instrument rate. Reverse the D-03 deferral cleanly: remove the guard, flip `swap_modelled` to reflect reality, keep the spread+slippage maths byte-identical.
+
+## Open questions
+
+- **Weekend triple-swap:** most brokers charge 3× financing on Wednesday (Wed→Thu rollover covers the weekend). Model it, or use a flat per-calendar-day rate for Phase 1? (Lean: flat per-overnight for Phase 1; note the simplification in results.)
+- **Holding-days source:** derive from bar count × timeframe, or from calendar days between entry/exit UTC dates? Calendar days is more accurate for D; bar-count is simpler for H1. (Lean: calendar days between entry and exit dates.)
+- Does the OANDA demo account charge commission? If spread-only, `commission_pips` defaults to 0 and that path is exercised only by tests.
+
+## Out of scope
+
+- Re-running the PoC's MA-crossover approved-set with swap (that's the runner's job, [[full-universe-backtest-runner]]).
+- Position sizing / risk (Phase 3).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -102,3 +102,23 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 **Reason:** Running unvalidated strategies on even a demo account produces noise, dilutes the signal quality of approved entries, and builds false confidence.
 
 **Enforcement:** `signals/ranker.py` loads the approved-set table at startup and filters all candidates against it. An empty approved set means no signals (not all signals).
+
+---
+
+## INV-11 · Every Strategy Signal Carries an ATR(14)-Derived Stop and an RR-Multiple Target
+
+**Rule:** Every `Signal` a strategy produces must set `stop_distance` to the 14-bar ATR at the signal bar (Wilder's smoothing — `ewm(com=period-1, adjust=False)`, the shipped `trend.py` formula, exposed once via `strategies/_indicators.py::atr()`), and `target_distance` to `stop_distance × rr_ratio` where `rr_ratio` is a documented fixed parameter (default 1.5). Both must be strictly positive (already enforced by the `Signal` validators). Alternative derivations (range-width stop, band-midline target, etc.) must be proposed as an amendment to this invariant — never implemented unilaterally in one strategy.
+
+**Reason:** Comparable stop distances are the prerequisite for comparable Sharpe ratios and position sizing across strategies. The Phase 2 ranker and the Phase 3 sizing layer treat all strategies symmetrically; a strategy with a structurally different stop/target derivation carries different effective leverage and cannot be ranked or sized against the others fairly. INV-04 requires brackets to exist; INV-11 fixes how they are sized so the approved-set is apples-to-apples.
+
+**Enforcement:** `Signal` validators enforce positivity. All strategies import the single `strategies/_indicators.py::atr()` — no per-file ATR copies. Code review enforces the RR-multiple target. A shared test fixture verifies each shipped `Strategy.generate_signals` produces ATR-consistent stops.
+
+---
+
+## INV-12 · Approved-Set Table Writes Are Single-Writer, Parent-Serialized
+
+**Rule:** The `approved_set` table must be written by exactly one process/thread at a time. In the multi-process backtest runner, worker processes return `ApprovedSetEntry` objects to the parent; the parent performs all inserts in a single transaction. No worker writes directly to the approved-set table.
+
+**Reason:** SQLite without explicit WAL + retry is not safe for concurrent writers. A partially-failed concurrent write produces an incomplete approved-set that INV-10 cannot distinguish from a legitimately small one — silently undermining the gate (some combinations approved but missing, while the runner exits 0).
+
+**Enforcement:** `fathom backtest` collects all `ProcessPoolExecutor` futures into a list before any DB write, then writes the full batch in one `BEGIN…COMMIT`. Reviewed at the runner task.

--- a/docs/phases/phase-1-spec-audit-2026-05-29.md
+++ b/docs/phases/phase-1-spec-audit-2026-05-29.md
@@ -1,0 +1,36 @@
+# Fathom Phase 1 — Cross-Spec Audit (2026-05-29)
+
+Run per `runbook-cross-spec-audit` by a fresh, independent auditor (read-only, no specs edited during audit). Fixes applied by the lead afterward — each finding annotated with its resolution.
+
+## Scope
+
+10 Phase 1 specs: data-layer-expansion, swap-cost-model, donchian-breakout, bollinger-zscore-reversion, rsi-reversion, roc-momentum, session-range-breakout, live-streaming, economic-calendar, full-universe-backtest-runner. Cross-checked against `invariants.md`, `code-map.md`, `INDEX.md`, `phase-1.md`, and shipped PoC contracts (`base.py`, `costs.py`, `walkforward.py`, `store.py`, `oanda_client.py`).
+
+## Summary
+
+14 shared concepts audited · 7 consistent · 4 drift · 3 ambiguous · 2 invariant-promotion candidates. 3 blocking, 4 non-blocking.
+
+## Findings & resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| DRIFT-01 | blocking | Bollinger spec left an unresolved midline-vs-fixed-RR target fork in its AC; RSI did not — inconsistent target semantics in the same file | **Fixed** — promoted **INV-11** (ATR stop + fixed RR target for all strategies); bollinger AC now states `stop × rr_ratio` unconditionally |
+| DRIFT-02 | blocking | swap-cost-model's `apply_costs` signature change underspecified: fate of `swap_pips` field, exact new signature, both guard-removal sites | **Fixed** — swap-cost spec now commits: remove `swap_pips` field + both guards (pydantic validator + inline check at `costs.py:159`), add `swap_long_rate`/`swap_short_rate` + `holding_days: int` |
+| DRIFT-03 | non-blocking | runner's persisted schema used `timeframe` vs shipped `ApprovedSetEntry.granularity`; `run_timestamp` field fate unclear | **Fixed** — runner spec uses `granularity`; `run_timestamp` is DB-table-only, `ApprovedSetEntry` unchanged |
+| DRIFT-04 | non-blocking | session-range-breakout left a stop fork (ATR vs range-width) in its AC | **Fixed** — stop committed to ATR(14) via INV-11; range-width demoted to a future-enhancement note |
+| AMBIGUOUS-01 | blocking | `InstrumentMeta` financing fields (`long_rate`/`short_rate`) vs `CostParams` (`swap_long_rate`/`swap_short_rate`) — no canonical naming authority | **Fixed** — data-layer-expansion owns `long_rate`/`short_rate` on `InstrumentMeta`; swap-cost-model maps them into `CostParams.swap_long_rate`/`swap_short_rate` (mapping documented) |
+| AMBIGUOUS-02 | non-blocking | ATR formula stated fully only in rsi spec; others say "Wilder/consistent" — duplication + drift hazard | **Fixed** — mandated shared `strategies/_indicators.py::atr()` (`ewm(com=period-1, adjust=False)`, the shipped `trend.py` formula); all strategy specs reference it |
+| AMBIGUOUS-03 | non-blocking | runner's SQLite write concurrency left as an open question | **Fixed** — promoted **INV-12** (single-writer, parent-serialized); runner Component design commits to parent-collects-then-writes in one transaction |
+
+## Invariant-promotion candidates (both promoted)
+
+- **INV-11** — every strategy Signal carries an ATR(14)-derived positive stop and an RR-multiple target. Closes DRIFT-01/-04 structurally.
+- **INV-12** — approved-set table writes are single-writer, parent-serialized. Closes AMBIGUOUS-03 structurally.
+
+## Other notes fixed
+
+- `phase-1.md` "Done When" said "all four baseline strategies" then enumerated six — corrected to the full baseline set.
+- economic-calendar `Touches` missing INV-09 (env-scoped provider config) — added.
+- DAG confirmed acyclic; code-map collision table (bollinger+rsi on `mean_reversion.py`; donchian on `trend.py`) consistent with specs; INDEX matches files. The shared `_indicators.py` is added to code-map's `strategies` area.
+
+*Audit verdict after fixes: spec corpus coherent; ready for taskgraph generation.*

--- a/docs/phases/phase-1.md
+++ b/docs/phases/phase-1.md
@@ -17,7 +17,7 @@ At the end of Phase 1, the system knows which strategies have demonstrated edge,
 
 ## Done When
 
-- [ ] All four baseline strategies implemented: MA crossover, Donchian breakout, Bollinger/z-score mean-reversion, RSI mean-reversion, ROC momentum, session breakout
+- [ ] The full baseline strategy set implemented (six strategies across four families): MA crossover + Donchian breakout (trend), Bollinger/z-score + RSI (mean-reversion), ROC momentum, session/range breakout
 - [ ] Live HTTP streaming connection to OANDA (`data/stream.py`) running with reconnect + backoff + gap detection
 - [ ] Economic calendar and news headline pull (`data/calendar.py`) with currency tagging and impact level
 - [ ] Parquet storage for candle archive; SQLite for operational state


### PR DESCRIPTION
Layer-4 spec layer for Phase 1, planning only — no code.

**Adds:** 10 feature specs under docs/features/, docs/code-map.md, cross-spec audit report (docs/phases/phase-1-spec-audit-2026-05-29.md).
**Promotes:** INV-11 (every Signal carries an ATR(14) stop + RR-multiple target via shared strategies/_indicators.py) and INV-12 (approved-set writes single-writer/parent-serialized) — both from audit findings.
**Audit:** fresh-session cross-spec audit found 3 blocking + 4 non-blocking; all resolved (target-convention fork, apply_costs signature, InstrumentMeta field mapping, approved-set schema/granularity, ATR duplication, SQLite write concurrency).

Epic 1A (8 specs) is ready for taskgraph generation. Epic 1B: live-streaming ready, economic-calendar parked on provider choice. No code in this PR.