### PR TITLE
P1A-T-02: shared _indicators.atr()

### DIFF
--- a/.claude/context/strategies.md
+++ b/.claude/context/strategies.md
@@ -45,3 +45,42 @@
 **No new runtime dependencies added** (uses `pandas` and stdlib only, both already in pyproject.toml).
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+## P1A-T-02 — 2026-05-29 (feat/p1a-t-02)
+
+**What was done:**
+- Created `strategies/_indicators.py`:
+  - `atr(df: pd.DataFrame, period: int = 14) -> pd.Series` — shared ATR helper (INV-11).
+  - Formula extracted verbatim from PoC `MACrossover._compute_atr`: Wilder's smoothing
+    `ewm(com=period-1, adjust=False)` on True Range computed from bid OHLC columns
+    (`high_bid`, `low_bid`, `close_bid`).
+  - Row 0 TR = `high_bid[0] - low_bid[0]` (no prev_close available); ewm initialises
+    from that value — result[0] is NOT NaN (matches the PoC private method exactly).
+- Refactored `strategies/trend.py` / `MACrossover`:
+  - Removed `_compute_atr` static method.
+  - Added `from strategies._indicators import atr as _atr`.
+  - Call site in `generate_signals` changed to `_atr(df, self._atr_period)`.
+  - No behavioural change — all 46 existing MACrossover tests pass unchanged.
+- Created `tests/test_indicators.py` — 11 tests covering:
+  - `TestAtrReproducesReference` (5 tests): exact float reproduction against the PoC
+    `_compute_atr` reference via `pd.testing.assert_series_equal` — default period 14,
+    period 7, period 20, asymmetric H/L spreads, spot-check on a small known series.
+  - `TestAtrContract` (6 tests): series length == df length; row 0 == `high-low`; all
+    non-NaN values > 0; default period is 14; no mutation of input df; minimal 2-row df.
+
+**Key patterns / gotchas:**
+- The shared `atr()` helper must be imported as `from strategies._indicators import atr`
+  in every downstream strategy (T-04 through T-07).
+- `pd.concat([...]).max(axis=1)` with NaN inputs: `pandas.max(axis=1)` skips NaN by
+  default (`skipna=True`), so TR[0] = `high[0] - low[0]` (not NaN) even though
+  `prev_close[0]` is NaN. This is the expected behaviour — matches PoC exactly.
+- No new runtime dependencies (pandas only, already in pyproject.toml).
+
+**AC verification results:**
+- `pytest tests/test_indicators.py tests/test_strategies.py -v` → **57 passed**, exit 0
+- `pytest -v` (full suite) → **156 passed**, exit 0
+- `mypy strategies/` → **"Success: no issues found in 4 source files"**, exit 0
+
+**pyproject.toml:** untouched (no new dep required).
+**CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/strategies/_indicators.py
+++ b/strategies/_indicators.py
@@ -1,0 +1,64 @@
+"""Shared technical indicators for Fathom strategies.
+
+All strategies must import from this module (INV-11) — never define their own
+copies of these computations.
+
+library_defaults:
+  pandas.ewm(com=..., adjust=False) — Wilder's recursive smoothing.
+  adjust=False is required to match charting-tool implementations.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compute Average True Range using Wilder's smoothing.
+
+    True Range = max(
+        high_bid - low_bid,
+        |high_bid - prev_close_bid|,
+        |low_bid  - prev_close_bid|,
+    )
+
+    ATR is the EWM of True Range with ``com = period - 1`` and
+    ``adjust=False`` (alpha = 1/period — Wilder's definition).
+
+    Parameters
+    ----------
+    df:
+        Candle DataFrame with columns ``high_bid``, ``low_bid``,
+        ``close_bid``.  Must contain at least one row.
+    period:
+        Look-back for the EWM average.  Default 14 (standard Wilder ATR).
+
+    Returns
+    -------
+    pd.Series
+        ATR values aligned to ``df.index``.  Row 0 is initialised from
+        ``high_bid[0] - low_bid[0]`` (no prev_close available); subsequent
+        values are produced by the EWM.
+
+    Notes
+    -----
+    Formula is extracted verbatim from the PoC ``MACrossover._compute_atr``
+    (``trend.py``).  No behaviour change — the two implementations produce
+    identical floating-point results.
+    """
+    high = df["high_bid"].astype(float)
+    low = df["low_bid"].astype(float)
+    close = df["close_bid"].astype(float)
+
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    # Wilder's ATR: ewm with com = period - 1 (alpha = 1/period), adjust=False
+    return tr.ewm(com=period - 1, adjust=False).mean()

--- a/strategies/trend.py
+++ b/strategies/trend.py
@@ -13,6 +13,8 @@ library_defaults (from poc-taskgraph.md):
 
 INV-03: Signal.generated_at is set to the bar's close timestamp (UTC-aware),
         never datetime.now().
+INV-11: ATR is computed via the shared strategies._indicators.atr() helper —
+        no per-file ATR copy.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
+from strategies._indicators import atr as _atr
 from strategies.base import Direction, Signal, Strategy
 
 
@@ -116,8 +119,8 @@ class MACrossover(Strategy):
         fast_ema: pd.Series[float] = close.ewm(span=self._fast_period, adjust=False).mean()
         slow_ema: pd.Series[float] = close.ewm(span=self._slow_period, adjust=False).mean()
 
-        # ATR(14) — standard True Range average.
-        atr = self._compute_atr(df, self._atr_period)
+        # ATR(14) — standard True Range average (shared helper, INV-11).
+        atr = _atr(df, self._atr_period)
 
         signals: list[Signal] = []
 
@@ -182,34 +185,3 @@ class MACrossover(Strategy):
 
         return signals
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _compute_atr(df: pd.DataFrame, period: int) -> pd.Series[float]:
-        """Compute Average True Range using Wilder's smoothing (ewm, adjust=False).
-
-        True Range = max(
-            high - low,
-            |high - prev_close|,
-            |low  - prev_close|
-        )
-        """
-        high = df["high_bid"].astype(float)
-        low = df["low_bid"].astype(float)
-        close = df["close_bid"].astype(float)
-
-        prev_close = close.shift(1)
-        tr = pd.concat(
-            [
-                high - low,
-                (high - prev_close).abs(),
-                (low - prev_close).abs(),
-            ],
-            axis=1,
-        ).max(axis=1)
-
-        # Wilder's ATR: ewm with com = period - 1 (equiv. alpha = 1/period), adjust=False
-        atr: pd.Series[float] = tr.ewm(com=period - 1, adjust=False).mean()
-        return atr

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,176 @@
+"""Tests for strategies/_indicators.py.
+
+AC (P1A-T-02):
+- atr() reproduces the shipped MACrossover._compute_atr values exactly
+  (same ewm(com=period-1, adjust=False) formula).
+- Existing MACrossover tests are unaffected (covered in test_strategies.py).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+from strategies._indicators import atr
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candles(
+    closes: list[float],
+    *,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+) -> pd.DataFrame:
+    """Build a minimal synthetic OHLC DataFrame — same factory as test_strategies."""
+    n = len(closes)
+    if highs is None:
+        highs = [c * 1.001 for c in closes]
+    if lows is None:
+        lows = [c * 0.999 for c in closes]
+    start = _utc(2024, 1, 1)
+    times = [start + timedelta(hours=i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime(times, utc=True),
+            "open_bid": closes,
+            "high_bid": highs,
+            "low_bid": lows,
+            "close_bid": closes,
+            "volume": [100] * n,
+        }
+    )
+
+
+def _reference_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """Verbatim copy of the PoC MACrossover._compute_atr — used as the reference."""
+    high = df["high_bid"].astype(float)
+    low = df["low_bid"].astype(float)
+    close = df["close_bid"].astype(float)
+
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    return tr.ewm(com=period - 1, adjust=False).mean()
+
+
+# ---------------------------------------------------------------------------
+# Exact reproduction tests (primary AC)
+# ---------------------------------------------------------------------------
+
+class TestAtrReproducesReference:
+    """atr() must produce floating-point-identical values to the PoC _compute_atr."""
+
+    def test_default_period_14_exact_match(self) -> None:
+        """Default period=14: shared helper == PoC private method on 100 bars."""
+        closes = [1.2000 + i * 0.0003 for i in range(100)]
+        df = _make_candles(closes)
+        result = atr(df)
+        reference = _reference_atr(df, 14)
+        pd.testing.assert_series_equal(result, reference, check_names=False)
+
+    def test_period_7_exact_match(self) -> None:
+        """Non-default period: ensure ewm com parameter is passed correctly."""
+        closes = [1.0 + i * 0.0005 for i in range(80)]
+        df = _make_candles(closes)
+        result = atr(df, period=7)
+        reference = _reference_atr(df, 7)
+        pd.testing.assert_series_equal(result, reference, check_names=False)
+
+    def test_period_20_exact_match(self) -> None:
+        closes = [1.5000 - i * 0.0002 for i in range(150)]
+        df = _make_candles(closes)
+        result = atr(df, period=20)
+        reference = _reference_atr(df, 20)
+        pd.testing.assert_series_equal(result, reference, check_names=False)
+
+    def test_varying_high_low_exact_match(self) -> None:
+        """Asymmetric high/low spreads — True Range uses |high - prev_close| path."""
+        n = 60
+        closes = [1.1000 + i * 0.0010 for i in range(n)]
+        highs = [c + 0.0025 for c in closes]
+        lows = [c - 0.0015 for c in closes]
+        df = _make_candles(closes, highs=highs, lows=lows)
+        result = atr(df)
+        reference = _reference_atr(df, 14)
+        pd.testing.assert_series_equal(result, reference, check_names=False)
+
+    def test_exact_numeric_values_spot_check(self) -> None:
+        """Spot-check a small series against hand-verified reference values."""
+        # 5 bars with known H/L/C so TR is deterministic
+        highs = [1.0050, 1.0060, 1.0070, 1.0065, 1.0080]
+        lows  = [1.0010, 1.0015, 1.0020, 1.0025, 1.0030]
+        closes = [1.0040, 1.0050, 1.0060, 1.0055, 1.0070]
+        df = _make_candles(closes, highs=highs, lows=lows)
+        result = atr(df, period=3)
+        reference = _reference_atr(df, 3)
+        pd.testing.assert_series_equal(result, reference, check_names=False)
+
+
+# ---------------------------------------------------------------------------
+# Contract / boundary tests
+# ---------------------------------------------------------------------------
+
+class TestAtrContract:
+    def test_returns_series_same_length_as_df(self) -> None:
+        df = _make_candles([1.0] * 30)
+        result = atr(df)
+        assert len(result) == len(df)
+
+    def test_first_value_uses_high_minus_low(self) -> None:
+        """Row 0 has no prev_close, so the True Range components that need it are NaN.
+        However, pd.concat(...).max(axis=1) treats NaN as missing, so TR[0] = high[0] - low[0]
+        (the one non-NaN component).  ewm(adjust=False) then initialises from that value,
+        meaning result[0] == high[0] - low[0] and is NOT NaN.
+        This is the correct and expected behaviour — matches the PoC _compute_atr exactly.
+        """
+        df = _make_candles([1.1000 + i * 0.0001 for i in range(20)])
+        result = atr(df)
+        expected_first = df["high_bid"].iloc[0] - df["low_bid"].iloc[0]
+        assert not pd.isna(result.iloc[0]), "First ATR value should not be NaN"
+        assert abs(result.iloc[0] - expected_first) < 1e-12
+
+    def test_values_positive_after_warmup(self) -> None:
+        """All non-NaN ATR values must be > 0 when high != low."""
+        closes = [1.0 + i * 0.0005 for i in range(50)]
+        df = _make_candles(closes)  # highs = close*1.001, lows = close*0.999
+        result = atr(df)
+        non_nan = result.dropna()
+        assert (non_nan > 0).all(), "Non-NaN ATR values must be strictly positive"
+
+    def test_default_period_is_14(self) -> None:
+        """Calling atr(df) with no period arg == atr(df, 14)."""
+        df = _make_candles([1.0 + i * 0.0003 for i in range(50)])
+        assert atr(df).equals(atr(df, 14))
+
+    def test_does_not_mutate_input_df(self) -> None:
+        df = _make_candles([1.2000] * 40)
+        original_columns = set(df.columns)
+        original_shape = df.shape
+        _ = atr(df)
+        assert set(df.columns) == original_columns
+        assert df.shape == original_shape
+
+    def test_works_on_minimal_two_row_df(self) -> None:
+        """atr() must not raise on a 2-row DataFrame (both TR values are valid)."""
+        df = _make_candles([1.2000, 1.2010])
+        result = atr(df)
+        assert len(result) == 2
+        # Row 0 TR = high[0] - low[0] (non-NaN); row 1 TR uses prev_close
+        assert not pd.isna(result.iloc[0])
+        assert result.iloc[1] > 0


### PR DESCRIPTION
Closes #22.

## Summary

- Creates `strategies/_indicators.py` with `atr(df, period=14) -> pd.Series` extracted verbatim from `MACrossover._compute_atr` in `trend.py` (Wilder's smoothing: `ewm(com=period-1, adjust=False)` on bid OHLC). This is the single ATR implementation mandated by INV-11 for all five Phase 1A strategies.
- Refactors `strategies/trend.py` / `MACrossover` to import `_atr` from `_indicators` and removes the private `_compute_atr` static method. No behavioural change to `MACrossover`.
- Adds `tests/test_indicators.py` (11 tests): exact floating-point reproduction against the PoC reference via `pd.testing.assert_series_equal` across four data shapes and period variants; contract tests for length, positivity, non-mutation, and edge cases.

## AC verification

```
pytest tests/test_indicators.py tests/test_strategies.py -v  → 57 passed, exit 0
pytest -v (full suite)                                        → 156 passed, exit 0
mypy strategies/                                              → Success: no issues found in 4 source files, exit 0
```

`pyproject.toml` is untouched (no new dependency). T-04 through T-07 can now import `from strategies._indicators import atr`.