### PR TITLE
P1A-T-01: data-layer-expansion

### DIFF
--- a/.claude/context/data.md
+++ b/.claude/context/data.md
@@ -81,3 +81,65 @@
 **CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P1A-T-01 — 2026-05-29 (feat/p1a-t-01)
+
+**What was done:**
+- Added `InstrumentMeta` pydantic v2 model to `data/oanda_client.py`:
+  - Fields: `name`, `pip_location (int)`, `min_trade_size`, `margin_rate`,
+    `display_precision`, `long_rate`, `short_rate`, `financing_days_of_week`.
+  - Canonical financing field names (`long_rate`/`short_rate`; swap-cost model
+    maps these to `CostParams.swap_long_rate/swap_short_rate` at engine boundary).
+  - `field_validator` coerces OANDA string rates to float at the boundary.
+  - `_instrument_from_raw()` helper maps OANDA camelCase wire format; parses
+    `financingDaysOfWeek` dicts to int weekday numbers (0=Mon, 6=Sun); ignores
+    unknown day strings silently.
+- Added `OandaClient.list_instruments() -> list[InstrumentMeta]`:
+  - Uses `oandapyV20.endpoints.accounts.AccountInstruments`.
+  - Mirrors existing `get_candles` error pattern: `V20Error` → `OandaAPIError`.
+  - Filters to `type == "CURRENCY"` only (INV-09: account-scoped).
+- Extended `data/store.py` with:
+  - `instruments` SQLite table (PK: `name`); created in `_create_tables`.
+  - `upsert_instruments(instruments, fetched_at=None)` — idempotent; stores
+    `financing_days_of_week` as JSON string; timestamps UTC RFC 3339 (INV-03).
+  - `load_instruments() -> list[InstrumentMeta]` — reconstructs from SQLite.
+  - `write_parquet(instrument, granularity, df)` — pyarrow; archive layout
+    `{archive_dir}/{instrument}/{granularity}/{YYYY-MM-DD}.parquet`. Granularity
+    encoded in path (not in file) to prevent collisions between H1/H4 on same date.
+  - `load_parquet(instrument, granularity, start, end)` — enumerates daily files
+    in date range, reads and concatenates, filters to [start, end], coerces dtypes.
+  - Backward-compat alias `_UPSERT_SQL = _UPSERT_CANDLE_SQL` for existing test helpers.
+  - `_archive_dir: Path | None` type annotation to satisfy mypy strict mode.
+- Updated `data/candles.py` `fetch_and_cache`:
+  - Added `write_parquet: bool = True` parameter.
+  - When `True` and new rows fetched: calls `store.write_parquet()` after SQLite upsert.
+  - When `False`: Parquet write skipped (for in-memory-store tests without archive_dir).
+  - Return contract (DataFrame shape) unchanged.
+- Added `pyarrow>=14` to `pyproject.toml` dependencies.
+- Updated `CLAUDE.md` Stack line to include `pyarrow>=14`.
+
+**Key patterns and gotchas (pyarrow/INV-03):**
+- pyarrow Parquet round-trip DOES preserve UTC timezone: stores tz in column
+  metadata; reads back as `datetime64[us, UTC]` which is coerced to
+  `datetime64[ns, UTC]` via `.astype()` in `load_parquet`. Confirmed by test.
+- Granularity encoded in file path, not as a column in the Parquet file.
+  H1 and H4 for same instrument+date → separate subdirectories, no collision.
+- `pq.write_table` and `pq.read_table` are untyped in pyarrow stubs; suppressed
+  with `# type: ignore[no-untyped-call]`.
+- `Store(":memory:")` with no `archive_dir` sets `_archive_dir = None`; any
+  `write_parquet`/`load_parquet` call raises `RuntimeError` immediately.
+  Tests that don't need Parquet pass `write_parquet=False` to `fetch_and_cache`.
+- `financing_days_of_week` stored as JSON string in SQLite; reconstructed via
+  `json.loads` on load. `daysCharged` multiplier not stored (cost model handles it).
+
+**AC verification results:**
+- `pytest tests/test_data_layer_expansion.py -v` → 26 passed, exit 0
+- `pytest -v` (full suite) → 171 passed, exit 0
+- `mypy data/` → "Success: no issues found in 4 source files", exit 0
+
+**New dependency:** `pyarrow>=14` added to `pyproject.toml`.
+**CLAUDE.md trigger-table:** pyproject.toml dep added → CLAUDE.md Stack updated (YES).
+
+**Merge plan:** `gh pr merge 31 --squash --delete-branch` (lead action after reviewer pass)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 
 ## Stack at a Glance
 
-Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
+Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · pyarrow>=14 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
 
 **Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests) · hypothesis>=6.0 (property-based tests for the backtest engine — no-look-ahead / fill / cost invariants)
 

--- a/data/candles.py
+++ b/data/candles.py
@@ -1,11 +1,15 @@
 """Candle fetch-and-cache logic.
 
-Scope: PoC (POC-T-03).
+Scope: Phase 1 (P1A-T-01 data-layer-expansion; extends PoC POC-T-03).
 
 This module is the single entry point for obtaining candle data.  It is
 gap-aware: it inspects the SQLite store first and only calls OANDA for
 rows that are not already cached.  A second call for the same range makes
 ZERO HTTP requests (cache-hit path).
+
+Dual-write: ``fetch_and_cache`` now writes through to both the SQLite
+operational store (for gap detection) and the Parquet archive (for bulk
+research scans).  The return contract — a ``pd.DataFrame`` — is unchanged.
 
 D-02: data is returned as ``pd.DataFrame`` with ``time`` dtype
     ``datetime64[ns, UTC]``.
@@ -111,6 +115,7 @@ def fetch_and_cache(
     granularity: str,
     start: datetime,
     end: datetime,
+    write_parquet: bool = True,
 ) -> pd.DataFrame:
     """Fetch candles for [start, end], cache them, and return as DataFrame.
 
@@ -120,6 +125,10 @@ def fetch_and_cache(
 
     Only ``complete=True`` candles are stored and returned.
 
+    Dual-write: fetched rows are written to both the SQLite operational
+    store (source of truth for gap detection) and the Parquet archive
+    (columnar bulk store for research scans), unless ``write_parquet=False``.
+
     Args:
         client: Initialised ``OandaClient``.
         store: Initialised ``Store`` instance.
@@ -127,6 +136,9 @@ def fetch_and_cache(
         granularity: OANDA granularity string, e.g. ``"H1"`` or ``"D"``.
         start: Inclusive range start, UTC-aware.
         end: Inclusive range end, UTC-aware.
+        write_parquet: If ``True`` (default) also write newly-fetched rows
+            to the Parquet archive.  Set to ``False`` to skip (e.g. for
+            tests that do not configure an archive directory).
 
     Returns:
         ``pd.DataFrame`` with columns::
@@ -179,6 +191,11 @@ def fetch_and_cache(
         ]
 
         store.upsert(rows_in_range)
+
+        # Dual-write: also persist to Parquet archive for research scans.
+        if write_parquet and rows_in_range:
+            df_new = store.load_candles(instrument, granularity, start, end)
+            store.write_parquet(instrument, granularity, df_new)
 
     # Return the full requested range from the store (single source of truth).
     return store.load_candles(instrument, granularity, start, end)

--- a/data/oanda_client.py
+++ b/data/oanda_client.py
@@ -1,6 +1,6 @@
-"""OANDA v20 REST client — candle endpoint only.
+"""OANDA v20 REST client — candle and instrument-metadata endpoints.
 
-Scope: PoC (POC-T-02). No streaming, no order methods.
+Scope: Phase 1 (P1A-T-01 data-layer-expansion). No streaming, no order methods.
 
 INV-03 compliance: all timestamps are UTC-aware datetime from first touch.
 INV-08 compliance: token is read via SecretStr.get_secret_value(); never logged.
@@ -13,12 +13,13 @@ D-01: uses oandapyV20 as the HTTP transport.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, List
 
 import oandapyV20
+import oandapyV20.endpoints.accounts as oanda_accounts
 import oandapyV20.endpoints.instruments as oanda_instruments
 from oandapyV20.exceptions import V20Error
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, field_validator
 
 from config.settings import Settings
 
@@ -48,6 +49,63 @@ class OandaAPIError(Exception):
         self.status_code = status_code
         self.message = message
         super().__init__(f"OANDA API error {status_code}: {message}")
+
+
+class InstrumentMeta(BaseModel):
+    """Instrument metadata from the OANDA accounts/instruments endpoint.
+
+    Canonical financing field names are ``long_rate`` / ``short_rate``
+    (the swap-cost model maps these to ``CostParams.swap_long_rate`` /
+    ``swap_short_rate`` at the engine boundary — see AMBIGUOUS-01 audit).
+
+    Wire-format coercion happens here at the boundary:
+    - ``pipLocation`` (int from OANDA) → ``pip_location``.
+    - Financing rates arrive as decimal strings (e.g. ``"-0.0002"``);
+      they are coerced to ``float`` by the field validators below.
+    - ``financing_days_of_week`` is a list of weekday-number ints (0=Mon).
+
+    INV-09: the instrument list is account-scoped (fetched via the account
+    endpoint, not the public instruments list).
+    """
+
+    name: str
+    """OANDA instrument identifier, e.g. ``"EUR_USD"``."""
+
+    pip_location: int
+    """Pip exponent.  −4 for most majors; −2 for JPY pairs."""
+
+    min_trade_size: float
+    """Minimum trade size in units (coerced from OANDA string)."""
+
+    margin_rate: float
+    """Required margin rate (coerced from OANDA decimal string)."""
+
+    display_precision: int
+    """Number of decimal places for display."""
+
+    long_rate: float
+    """Daily financing rate for long positions (canonical name; coerced from
+    OANDA's ``longRate`` decimal string)."""
+
+    short_rate: float
+    """Daily financing rate for short positions (canonical name; coerced from
+    OANDA's ``shortRate`` decimal string)."""
+
+    financing_days_of_week: List[int]
+    """Weekday numbers (0=Mon … 6=Sun) on which financing is charged.
+    Most FX instruments charge 3× on Wednesday."""
+
+    @field_validator("min_trade_size", "margin_rate", mode="before")
+    @classmethod
+    def _coerce_float_str(cls, v: object) -> float:
+        """Coerce OANDA string fields to float at the boundary."""
+        return float(v)  # type: ignore[arg-type]
+
+    @field_validator("long_rate", "short_rate", mode="before")
+    @classmethod
+    def _coerce_rate_str(cls, v: object) -> float:
+        """Coerce OANDA financing rate strings to float."""
+        return float(v)  # type: ignore[arg-type]
 
 
 class CandleRow(BaseModel):
@@ -176,8 +234,59 @@ def _request_page(
         raise OandaAPIError(exc.code, exc.msg) from exc
 
 
+def _instrument_from_raw(raw: dict[str, Any]) -> InstrumentMeta:
+    """Convert a single raw OANDA instrument dict to an ``InstrumentMeta``.
+
+    Handles the OANDA wire-format field names (camelCase) and coerces
+    string rates to float at the boundary.
+
+    Args:
+        raw: A single instrument dict from ``AccountInstruments`` response.
+
+    Returns:
+        A validated ``InstrumentMeta`` instance.
+    """
+    financing = raw.get("financing", {})
+    # financing_days_of_week is a list of dicts: [{"dayOfWeek": "MONDAY", ...}]
+    # or a list of ints in some API versions. We normalise to int (0=Mon…6=Sun).
+    days_raw = financing.get("financingDaysOfWeek", [])
+    _DAY_MAP: dict[str, int] = {
+        "MONDAY": 0,
+        "TUESDAY": 1,
+        "WEDNESDAY": 2,
+        "THURSDAY": 3,
+        "FRIDAY": 4,
+        "SATURDAY": 5,
+        "SUNDAY": 6,
+    }
+    days: list[int] = []
+    for entry in days_raw:
+        if isinstance(entry, dict):
+            day_str = entry.get("dayOfWeek", "")
+            days_count = int(entry.get("daysCharged", 1))
+            if day_str in _DAY_MAP:
+                # Repeat the day for each daysCharged value (usually 1 or 3).
+                # We record the unique weekday number; daysCharged=3 means
+                # 3 days of financing are charged on that single day.
+                # We store the weekday once and let the cost model handle multiplier.
+                days.append(_DAY_MAP[day_str])
+        elif isinstance(entry, int):
+            days.append(entry)
+
+    return InstrumentMeta(
+        name=raw["name"],
+        pip_location=int(raw["pipLocation"]),
+        min_trade_size=raw["minimumTradeSize"],
+        margin_rate=raw["marginRate"],
+        display_precision=int(raw["displayPrecision"]),
+        long_rate=financing.get("longRate", "0"),
+        short_rate=financing.get("shortRate", "0"),
+        financing_days_of_week=days,
+    )
+
+
 class OandaClient:
-    """OANDA v20 REST client — candle data only.
+    """OANDA v20 REST client — candle data and instrument metadata.
 
     Wraps ``oandapyV20`` to provide a typed, paginated interface.
     Authentication and environment selection are taken exclusively from
@@ -194,6 +303,39 @@ class OandaClient:
             access_token=settings.oanda_api_token.get_secret_value(),
             environment=oanda_env,
         )
+
+    def list_instruments(self) -> list[InstrumentMeta]:
+        """Fetch the full tradeable FX instrument list for this account.
+
+        Calls ``GET /v3/accounts/{accountID}/instruments`` via
+        ``oandapyV20.endpoints.accounts.AccountInstruments``.  Only FX
+        instruments (``type == "CURRENCY"``) are returned; other asset
+        classes (CFDs, metals, crypto) are filtered out.
+
+        Results should be cached by the caller (e.g. via
+        ``Store.upsert_instruments`` / ``Store.load_instruments``) to
+        avoid re-fetching on every run.
+
+        Returns:
+            A list of ``InstrumentMeta`` instances, one per tradeable FX
+            instrument.  Order is unspecified (matches OANDA response order).
+
+        Raises:
+            OandaAPIError: If OANDA returns HTTP 4xx or 5xx.
+        """
+        account_id = self._settings.oanda_account_id
+        try:
+            req = oanda_accounts.AccountInstruments(accountID=account_id)
+            response = self._api.request(req)
+        except V20Error as exc:
+            raise OandaAPIError(exc.code, exc.msg) from exc
+
+        raw_instruments: list[dict[str, Any]] = response.get("instruments", [])
+        return [
+            _instrument_from_raw(r)
+            for r in raw_instruments
+            if r.get("type") == "CURRENCY"
+        ]
 
     def get_candles(
         self,

--- a/data/oanda_client.py
+++ b/data/oanda_client.py
@@ -263,12 +263,10 @@ def _instrument_from_raw(raw: dict[str, Any]) -> InstrumentMeta:
     for entry in days_raw:
         if isinstance(entry, dict):
             day_str = entry.get("dayOfWeek", "")
-            days_count = int(entry.get("daysCharged", 1))
             if day_str in _DAY_MAP:
-                # Repeat the day for each daysCharged value (usually 1 or 3).
-                # We record the unique weekday number; daysCharged=3 means
-                # 3 days of financing are charged on that single day.
-                # We store the weekday once and let the cost model handle multiplier.
+                # We store the unique weekday number once; daysCharged=3 means
+                # 3 days of financing are charged on that single day — the cost
+                # model handles the multiplier, so we do not capture it here.
                 days.append(_DAY_MAP[day_str])
         elif isinstance(entry, int):
             days.append(entry)

--- a/data/store.py
+++ b/data/store.py
@@ -9,7 +9,7 @@ Storage design:
   - SQLite ``instruments`` table: metadata cache for ``InstrumentMeta``.
     Refreshable (upsert on re-fetch).
   - Parquet archive: bulk columnar store for full-universe research scans.
-    Partitioned as ``{archive_dir}/{instrument}/{YYYY-MM-DD}.parquet``.
+    Partitioned as ``{archive_dir}/{instrument}/{granularity}/{YYYY-MM-DD}.parquet``.
     Written via ``pyarrow``; read back as ``pd.DataFrame`` with the same
     dtype contract as ``load_candles``.
 
@@ -76,7 +76,8 @@ class Store:
     Creates and manages a ``candles`` table (gap detection / operational state)
     and an ``instruments`` table (metadata cache) in SQLite.
 
-    Parquet files are written to ``{archive_dir}/{instrument}/{YYYY-MM-DD}.parquet``
+    Parquet files are written to
+    ``{archive_dir}/{instrument}/{granularity}/{YYYY-MM-DD}.parquet``
     when ``write_parquet`` is called.  The archive directory is created on first
     write if it does not exist.
 

--- a/data/store.py
+++ b/data/store.py
@@ -1,10 +1,22 @@
-"""SQLite persistence layer for candle data.
+"""SQLite persistence layer for candle data and instrument metadata,
+plus Parquet candle archive.
 
-Scope: PoC (POC-T-03). Single table: ``candles``.
+Scope: Phase 1 (P1A-T-01 data-layer-expansion).
+
+Storage design:
+  - SQLite ``candles`` table: source of truth for gap detection and
+    operational/cache state.  Unchanged contract from PoC.
+  - SQLite ``instruments`` table: metadata cache for ``InstrumentMeta``.
+    Refreshable (upsert on re-fetch).
+  - Parquet archive: bulk columnar store for full-universe research scans.
+    Partitioned as ``{archive_dir}/{instrument}/{YYYY-MM-DD}.parquet``.
+    Written via ``pyarrow``; read back as ``pd.DataFrame`` with the same
+    dtype contract as ``load_candles``.
 
 INV-03 compliance: ``time`` values are stored as UTC RFC 3339 TEXT strings
-    (e.g. ``"2024-01-15T14:00:00Z"``).  They are never stored as Unix epoch
-    integers or local-time strings.  On load, they are parsed explicitly with
+    in SQLite and as ``datetime64[ns, UTC]`` in Parquet (pyarrow stores the
+    timezone in column metadata; the round-trip is verified in tests).  On
+    SQLite load, timestamps are parsed explicitly with
     ``pd.to_datetime(..., utc=True)`` — we do NOT rely on sqlite3 PARSE_DECLTYPES.
 
 D-02: all data is returned as ``pd.DataFrame`` with ``time`` dtype
@@ -13,14 +25,17 @@ D-02: all data is returned as ``pd.DataFrame`` with ``time`` dtype
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
-from data.oanda_client import CandleRow
+from data.oanda_client import CandleRow, InstrumentMeta
 
 
 # ---------------------------------------------------------------------------
@@ -56,18 +71,26 @@ def _to_rfc3339(dt: datetime) -> str:
 
 
 class Store:
-    """SQLite-backed candle store.
+    """SQLite-backed candle store + Parquet candle archive.
 
-    Creates and manages a ``candles`` table with a composite primary key
-    ``(instrument, granularity, time)``.
+    Creates and manages a ``candles`` table (gap detection / operational state)
+    and an ``instruments`` table (metadata cache) in SQLite.
+
+    Parquet files are written to ``{archive_dir}/{instrument}/{YYYY-MM-DD}.parquet``
+    when ``write_parquet`` is called.  The archive directory is created on first
+    write if it does not exist.
 
     Args:
         db_path: File path for the SQLite database.  Pass ``":memory:"`` for
             an in-memory database (useful in tests).
+        archive_dir: Directory root for the Parquet archive.  Defaults to a
+            sibling ``archive/`` directory next to ``db_path``.  For in-memory
+            databases a temporary directory must be supplied explicitly if
+            Parquet methods are used.
     """
 
     #: SQL to create the candles table if it does not already exist.
-    _CREATE_TABLE_SQL: str = """
+    _CREATE_CANDLES_SQL: str = """
         CREATE TABLE IF NOT EXISTS candles (
             instrument   TEXT    NOT NULL,
             granularity  TEXT    NOT NULL,
@@ -86,8 +109,23 @@ class Store:
         )
     """
 
+    #: SQL to create the instruments metadata table if it does not exist.
+    _CREATE_INSTRUMENTS_SQL: str = """
+        CREATE TABLE IF NOT EXISTS instruments (
+            name                     TEXT    NOT NULL PRIMARY KEY,
+            pip_location             INTEGER NOT NULL,
+            min_trade_size           REAL    NOT NULL,
+            margin_rate              REAL    NOT NULL,
+            display_precision        INTEGER NOT NULL,
+            long_rate                REAL    NOT NULL,
+            short_rate               REAL    NOT NULL,
+            financing_days_of_week   TEXT    NOT NULL,
+            fetched_at               TEXT    NOT NULL
+        )
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
-    _UPSERT_SQL: str = """
+    _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
             (instrument, granularity, time,
              open_bid,  high_bid,  low_bid,  close_bid,
@@ -97,22 +135,50 @@ class Store:
             (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
-    def __init__(self, db_path: str | Path) -> None:
+    #: Backward-compat alias used by some test helpers (PoC era).
+    _UPSERT_SQL: str = _UPSERT_CANDLE_SQL
+
+    #: SQL to upsert instrument metadata (replace on name PK conflict).
+    _UPSERT_INSTRUMENT_SQL: str = """
+        INSERT OR REPLACE INTO instruments
+            (name, pip_location, min_trade_size, margin_rate, display_precision,
+             long_rate, short_rate, financing_days_of_week, fetched_at)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        archive_dir: str | Path | None = None,
+    ) -> None:
         self._db_path = str(db_path)
+        # Derive archive_dir from db_path unless explicitly provided.
+        self._archive_dir: Path | None
+        if archive_dir is not None:
+            self._archive_dir = Path(archive_dir)
+        elif self._db_path == ":memory:":
+            # For in-memory DBs, no default archive dir (caller must supply
+            # archive_dir if they want Parquet operations).
+            self._archive_dir = None
+        else:
+            self._archive_dir = Path(self._db_path).parent / "archive"
+
         self._conn: sqlite3.Connection = sqlite3.connect(
             self._db_path,
             # Explicitly NOT using detect_types — we parse TEXT timestamps
             # ourselves (see library_defaults note in taskgraph).
         )
-        self._create_table()
+        self._create_tables()
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def _create_table(self) -> None:
-        """Create the ``candles`` table if it does not already exist."""
-        self._conn.execute(self._CREATE_TABLE_SQL)
+    def _create_tables(self) -> None:
+        """Create the ``candles`` and ``instruments`` tables if needed."""
+        self._conn.execute(self._CREATE_CANDLES_SQL)
+        self._conn.execute(self._CREATE_INSTRUMENTS_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -120,7 +186,7 @@ class Store:
         self._conn.close()
 
     # ------------------------------------------------------------------
-    # Write
+    # Candle write
     # ------------------------------------------------------------------
 
     def upsert(self, rows: Iterable[CandleRow]) -> None:
@@ -152,14 +218,14 @@ class Store:
                 int(row.complete),         # SQLite stores bool as INTEGER
             )
             for row in rows
-            if row.complete                 # only complete candles (T-03 AC)
+            if row.complete                 # only complete candles
         ]
         if params:
-            self._conn.executemany(self._UPSERT_SQL, params)
+            self._conn.executemany(self._UPSERT_CANDLE_SQL, params)
             self._conn.commit()
 
     # ------------------------------------------------------------------
-    # Read
+    # Candle read (SQLite)
     # ------------------------------------------------------------------
 
     def load_candles(
@@ -229,8 +295,6 @@ class Store:
 
         if not rows:
             # Return an empty DataFrame with the correct schema and dtypes.
-            # pd.DataFrame(columns=...) defaults every column to object dtype,
-            # so we must coerce all columns explicitly to match the populated path.
             df = pd.DataFrame(columns=columns)
             df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
             float_cols = [
@@ -244,12 +308,8 @@ class Store:
         df = pd.DataFrame(rows, columns=columns)
 
         # Parse TEXT timestamps explicitly to datetime64[ns, UTC] (INV-03).
-        # pd.to_datetime defaults to timezone-unaware — must pass utc=True.
-        # Coerce to nanosecond resolution to match the AC dtype contract
-        # (pandas 2+ defaults to microseconds; we normalise to ns here).
         df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
 
-        # Ensure numeric columns have correct dtypes.
         float_cols = [
             "open_bid", "high_bid", "low_bid", "close_bid",
             "open_ask", "high_ask", "low_ask", "close_ask",
@@ -294,3 +354,276 @@ class Store:
             (instrument, granularity, start_str, end_str),
         )
         return {row[0] for row in cursor.fetchall()}
+
+    # ------------------------------------------------------------------
+    # Instrument metadata (SQLite)
+    # ------------------------------------------------------------------
+
+    def upsert_instruments(
+        self,
+        instruments: Iterable[InstrumentMeta],
+        fetched_at: datetime | None = None,
+    ) -> None:
+        """Cache instrument metadata to the ``instruments`` SQLite table.
+
+        Idempotent — re-fetching the universe simply replaces existing rows.
+
+        Args:
+            instruments: An iterable of ``InstrumentMeta`` instances.
+            fetched_at: UTC-aware timestamp recording when the metadata was
+                fetched.  Defaults to ``datetime.now(timezone.utc)`` if not
+                provided.
+        """
+        ts = fetched_at or datetime.now(timezone.utc)
+        ts_str = _to_rfc3339(ts)
+
+        params = [
+            (
+                m.name,
+                m.pip_location,
+                m.min_trade_size,
+                m.margin_rate,
+                m.display_precision,
+                m.long_rate,
+                m.short_rate,
+                json.dumps(m.financing_days_of_week),  # store list as JSON
+                ts_str,
+            )
+            for m in instruments
+        ]
+        if params:
+            self._conn.executemany(self._UPSERT_INSTRUMENT_SQL, params)
+            self._conn.commit()
+
+    def load_instruments(self) -> list[InstrumentMeta]:
+        """Load all cached instrument metadata from SQLite.
+
+        Returns:
+            A list of ``InstrumentMeta`` instances, one per row.  Returns an
+            empty list if no instruments have been cached yet.
+        """
+        cursor = self._conn.execute(
+            """
+            SELECT name, pip_location, min_trade_size, margin_rate,
+                   display_precision, long_rate, short_rate,
+                   financing_days_of_week
+            FROM   instruments
+            ORDER  BY name ASC
+            """
+        )
+        rows = cursor.fetchall()
+        result: list[InstrumentMeta] = []
+        for row in rows:
+            (
+                name,
+                pip_location,
+                min_trade_size,
+                margin_rate,
+                display_precision,
+                long_rate,
+                short_rate,
+                financing_days_json,
+            ) = row
+            result.append(
+                InstrumentMeta(
+                    name=name,
+                    pip_location=pip_location,
+                    min_trade_size=min_trade_size,
+                    margin_rate=margin_rate,
+                    display_precision=display_precision,
+                    long_rate=long_rate,
+                    short_rate=short_rate,
+                    financing_days_of_week=json.loads(financing_days_json),
+                )
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Parquet archive
+    # ------------------------------------------------------------------
+
+    def _parquet_path(self, instrument: str, granularity: str, date_str: str) -> Path:
+        """Return the Parquet file path for a given instrument, granularity, and date.
+
+        Layout: ``{archive_dir}/{instrument}/{granularity}/{date_str}.parquet``
+
+        Including the granularity in the path prevents collisions between
+        different granularities for the same instrument and date (e.g. H1 and
+        H4 on the same calendar day would otherwise write to the same file).
+
+        Args:
+            instrument: OANDA instrument identifier, e.g. ``"EUR_USD"``.
+            granularity: OANDA granularity string, e.g. ``"H1"``.
+            date_str: Date string in ``YYYY-MM-DD`` format.
+
+        Returns:
+            Absolute ``Path`` for the Parquet file.
+
+        Raises:
+            RuntimeError: If ``archive_dir`` was not configured (in-memory DB
+                with no explicit ``archive_dir`` supplied).
+        """
+        if self._archive_dir is None:
+            raise RuntimeError(
+                "No archive_dir configured.  Supply archive_dir= when "
+                "constructing Store for an in-memory database."
+            )
+        return self._archive_dir / instrument / granularity / f"{date_str}.parquet"
+
+    def write_parquet(
+        self,
+        instrument: str,
+        granularity: str,
+        df: pd.DataFrame,
+    ) -> None:
+        """Write a candle DataFrame to the Parquet archive.
+
+        Each Parquet file covers one calendar date (UTC) for one instrument +
+        granularity combination.  If a file for a given date already exists it
+        is overwritten (idempotent).
+
+        The DataFrame must contain a ``time`` column of dtype
+        ``datetime64[ns, UTC]``.  The ``granularity`` is stored as a column
+        so that files from different granularities partition correctly.
+
+        Args:
+            instrument: OANDA instrument identifier, e.g. ``"EUR_USD"``.
+            granularity: OANDA granularity string, e.g. ``"H1"``.
+            df: DataFrame in the ``load_candles`` contract (plus a ``time``
+                column of dtype ``datetime64[ns, UTC]``).
+
+        Raises:
+            RuntimeError: If ``archive_dir`` was not configured.
+            ValueError: If ``df`` does not contain a ``time`` column or
+                ``time`` dtype is not timezone-aware UTC.
+        """
+        if "time" not in df.columns:
+            raise ValueError("DataFrame must contain a 'time' column.")
+
+        # Check archive_dir is configured before doing anything else.
+        if self._archive_dir is None:
+            raise RuntimeError(
+                "No archive_dir configured.  Supply archive_dir= when "
+                "constructing Store for an in-memory database."
+            )
+
+        if df.empty:
+            return  # Nothing to write.
+
+        # Drop the granularity column if present — it is encoded in the path.
+        df = df.copy()
+        if "granularity" in df.columns:
+            df = df.drop(columns=["granularity"])
+
+        # Group by UTC date and write one file per date.
+        dates = df["time"].dt.date.unique()
+        for date in dates:
+            date_str = date.strftime("%Y-%m-%d")
+            path = self._parquet_path(instrument, granularity, date_str)
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+            day_df = df[df["time"].dt.date == date].copy()
+            table = pa.Table.from_pandas(day_df, preserve_index=False)
+            pq.write_table(table, path)  # type: ignore[no-untyped-call]
+
+    def load_parquet(
+        self,
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> pd.DataFrame:
+        """Load candles from the Parquet archive for a given range.
+
+        Reads only the daily Parquet files that overlap with [start, end],
+        then filters to the exact range.  Returns an empty DataFrame (with
+        the correct schema and dtypes) if no files exist for the range.
+
+        The returned DataFrame has the same dtype contract as
+        ``load_candles``: ``time`` is ``datetime64[ns, UTC]``, price columns
+        are ``float64``, ``volume`` is ``int64`` — preserving the UTC
+        timezone through the Parquet round-trip (INV-03, verified by tests).
+
+        Args:
+            instrument: OANDA instrument identifier.
+            granularity: OANDA granularity string.
+            start: Inclusive range start (UTC-aware).
+            end: Inclusive range end (UTC-aware).
+
+        Returns:
+            ``pd.DataFrame`` matching the ``load_candles`` dtype contract.
+
+        Raises:
+            RuntimeError: If ``archive_dir`` was not configured.
+            ValueError: If ``start`` or ``end`` are not UTC-aware.
+        """
+        if start.tzinfo is None or end.tzinfo is None:
+            raise ValueError(
+                "start and end must be UTC-aware datetimes (INV-03)."
+            )
+
+        if self._archive_dir is None:
+            raise RuntimeError(
+                "No archive_dir configured.  Supply archive_dir= when "
+                "constructing Store for an in-memory database."
+            )
+
+        # Enumerate the date range to find candidate Parquet files.
+        from datetime import timedelta
+
+        start_date = start.date()
+        end_date = end.date()
+        current = start_date
+        frames: list[pd.DataFrame] = []
+
+        while current <= end_date:
+            path = self._parquet_path(instrument, granularity, current.strftime("%Y-%m-%d"))
+            if path.exists():
+                day_df = pq.read_table(path).to_pandas()  # type: ignore[no-untyped-call]
+                # Ensure the time column is datetime64[ns, UTC] (pyarrow
+                # reads back with tz info but may use us resolution).
+                day_df["time"] = pd.to_datetime(
+                    day_df["time"], utc=True
+                ).astype("datetime64[ns, UTC]")
+                frames.append(day_df)
+            current += timedelta(days=1)
+
+        # Build the canonical column list (matches load_candles contract).
+        columns = [
+            "time",
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+            "volume",
+        ]
+
+        if not frames:
+            df = pd.DataFrame(columns=columns)
+            df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+            float_cols = [c for c in columns if c not in ("time", "volume")]
+            df[float_cols] = df[float_cols].astype("float64")
+            df["volume"] = df["volume"].astype("int64")
+            return df
+
+        df = pd.concat(frames, ignore_index=True)
+
+        # Filter to exact [start, end].  Granularity is encoded in the path, so
+        # no additional column filter is needed.
+        mask = (df["time"] >= pd.Timestamp(start)) & (df["time"] <= pd.Timestamp(end))
+        df = df[mask].copy()
+
+        # Keep only the canonical columns.
+        df = df[[c for c in columns if c in df.columns]].copy()
+
+        # Coerce dtypes to match the load_candles contract.
+        df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+        float_cols = [
+            "open_bid", "high_bid", "low_bid", "close_bid",
+            "open_ask", "high_ask", "low_ask", "close_ask",
+        ]
+        existing_float = [c for c in float_cols if c in df.columns]
+        df[existing_float] = df[existing_float].astype("float64")
+        if "volume" in df.columns:
+            df["volume"] = df["volume"].astype("int64")
+
+        df = df.sort_values("time").reset_index(drop=True)
+        return df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "oandapyV20>=0.6",
     "pandas>=2.0",
     "python-dateutil>=2.8",
+    "pyarrow>=14",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_data_layer_expansion.py
+++ b/tests/test_data_layer_expansion.py
@@ -564,26 +564,63 @@ class TestFetchAndCacheDualWrite:
         assert parquet_file.exists(), "Parquet file must be written on first fetch"
 
     def test_no_parquet_write_when_flag_false(self, tmp_path: Path) -> None:
-        """``write_parquet=False`` must skip the Parquet write entirely."""
-        db_path = tmp_path / "test.db"
-        archive_dir = tmp_path / "archive"
-        store = Store(db_path, archive_dir=archive_dir)
+        """``write_parquet=False`` must skip the Parquet write entirely.
+
+        Two-sided check: the same correct path that IS written when
+        ``write_parquet=True`` must NOT exist when ``write_parquet=False``.
+        """
+        # --- write_parquet=True: file must exist at the granularity-scoped path ---
+        db_path_true = tmp_path / "test_true.db"
+        archive_dir_true = tmp_path / "archive_true"
+        store_true = Store(db_path_true, archive_dir=archive_dir_true)
 
         t1 = _utc(2024, 5, 2, 10)
         t2 = _utc(2024, 5, 2, 11)
 
-        mock_client = MagicMock()
-        mock_client.get_candles.return_value = [
+        mock_client_true = MagicMock()
+        mock_client_true.get_candles.return_value = [
             _make_candle_row("EUR_USD", "H1", t1),
             _make_candle_row("EUR_USD", "H1", t2),
         ]
 
         fetch_and_cache(
-            mock_client, store, "EUR_USD", "H1", t1, t2, write_parquet=False
+            mock_client_true, store_true, "EUR_USD", "H1", t1, t2, write_parquet=True
         )
 
-        parquet_file = archive_dir / "EUR_USD" / "2024-05-02.parquet"
-        assert not parquet_file.exists(), "No Parquet file when write_parquet=False"
+        parquet_file_true = archive_dir_true / "EUR_USD" / "H1" / "2024-05-02.parquet"
+        assert parquet_file_true.exists(), (
+            "Parquet file must be written at "
+            "{archive_dir}/{instrument}/{granularity}/{date}.parquet "
+            "when write_parquet=True"
+        )
+
+        # --- write_parquet=False: the same correct path must NOT exist ---
+        db_path_false = tmp_path / "test_false.db"
+        archive_dir_false = tmp_path / "archive_false"
+        store_false = Store(db_path_false, archive_dir=archive_dir_false)
+
+        mock_client_false = MagicMock()
+        mock_client_false.get_candles.return_value = [
+            _make_candle_row("EUR_USD", "H1", t1),
+            _make_candle_row("EUR_USD", "H1", t2),
+        ]
+
+        fetch_and_cache(
+            mock_client_false,
+            store_false,
+            "EUR_USD",
+            "H1",
+            t1,
+            t2,
+            write_parquet=False,
+        )
+
+        parquet_file_false = archive_dir_false / "EUR_USD" / "H1" / "2024-05-02.parquet"
+        assert not parquet_file_false.exists(), (
+            "No Parquet file must exist at "
+            "{archive_dir}/{instrument}/{granularity}/{date}.parquet "
+            "when write_parquet=False"
+        )
 
     def test_cache_hit_makes_no_http_call(self, tmp_path: Path) -> None:
         """Second fetch_and_cache with same range must not call OANDA."""

--- a/tests/test_data_layer_expansion.py
+++ b/tests/test_data_layer_expansion.py
@@ -1,0 +1,660 @@
+"""Tests for P1A-T-01 data-layer-expansion.
+
+AC coverage:
+- ``list_instruments()`` returns validated ``InstrumentMeta`` (mocked OANDA).
+- ``pip_location`` correct for JPY pairs (−2) vs majors (−4).
+- Parquet round-trip preserves ``datetime64[ns, UTC]`` + float64/int64.
+- ``upsert_instruments`` + ``load_instruments`` round-trips metadata via SQLite.
+- ``fetch_and_cache`` with ``write_parquet=True`` writes to Parquet archive.
+- Gap-aware multi-pair fetch makes no redundant HTTP calls (cache-hit).
+- ``OandaAPIError`` is raised on 4xx/5xx from ``list_instruments``.
+- No OANDA token appears in any raised exception message (INV-08).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from pydantic import SecretStr
+
+from config.settings import Settings
+from data.candles import fetch_and_cache
+from data.oanda_client import (
+    InstrumentMeta,
+    OandaAPIError,
+    OandaClient,
+    _instrument_from_raw,
+)
+from data.store import Store
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_settings() -> Settings:
+    return Settings(
+        env="demo",
+        oanda_api_token=SecretStr("test-token-never-logged"),
+        oanda_account_id="101-001-12345678-001",
+    )
+
+
+def _raw_instrument(
+    name: str = "EUR_USD",
+    pip_location: int = -4,
+    margin_rate: str = "0.02",
+    display_precision: int = 5,
+    min_trade_size: str = "1",
+    long_rate: str = "-0.0002",
+    short_rate: str = "0.0001",
+    days_of_week: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal OANDA instruments response entry."""
+    if days_of_week is None:
+        days_of_week = [
+            {"dayOfWeek": "WEDNESDAY", "daysCharged": 3},
+            {"dayOfWeek": "FRIDAY", "daysCharged": 1},
+        ]
+    return {
+        "name": name,
+        "type": "CURRENCY",
+        "pipLocation": pip_location,
+        "marginRate": margin_rate,
+        "displayPrecision": display_precision,
+        "minimumTradeSize": min_trade_size,
+        "financing": {
+            "longRate": long_rate,
+            "shortRate": short_rate,
+            "financingDaysOfWeek": days_of_week,
+        },
+    }
+
+
+def _make_candle_row(
+    instrument: str,
+    granularity: str,
+    t: datetime,
+    bid: float = 1.1000,
+    ask: float = 1.1002,
+    volume: int = 100,
+) -> Any:
+    from data.oanda_client import CandleRow
+
+    return CandleRow(
+        instrument=instrument,
+        granularity=granularity,
+        time=t,
+        open_bid=bid,
+        high_bid=bid + 0.0005,
+        low_bid=bid - 0.0005,
+        close_bid=bid + 0.0001,
+        open_ask=ask,
+        high_ask=ask + 0.0005,
+        low_ask=ask - 0.0005,
+        close_ask=ask + 0.0001,
+        open_mid=(bid + ask) / 2,
+        high_mid=(bid + ask) / 2 + 0.0005,
+        low_mid=(bid + ask) / 2 - 0.0005,
+        close_mid=(bid + ask) / 2 + 0.0001,
+        volume=volume,
+        complete=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# InstrumentMeta model tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstrumentMeta:
+    def test_basic_construction(self) -> None:
+        m = InstrumentMeta(
+            name="EUR_USD",
+            pip_location=-4,
+            min_trade_size=1.0,
+            margin_rate=0.02,
+            display_precision=5,
+            long_rate=-0.0002,
+            short_rate=0.0001,
+            financing_days_of_week=[2, 4],
+        )
+        assert m.name == "EUR_USD"
+        assert m.pip_location == -4
+        assert m.long_rate == pytest.approx(-0.0002)
+        assert m.short_rate == pytest.approx(0.0001)
+        assert m.financing_days_of_week == [2, 4]
+
+    def test_string_coercion_for_rates(self) -> None:
+        """OANDA returns rates as decimal strings; they must be coerced."""
+        m = InstrumentMeta(
+            name="USD_JPY",
+            pip_location=-2,
+            min_trade_size="1",
+            margin_rate="0.02",
+            display_precision=3,
+            long_rate="-0.00015",
+            short_rate="0.00010",
+            financing_days_of_week=[2],
+        )
+        assert isinstance(m.long_rate, float)
+        assert isinstance(m.short_rate, float)
+        assert isinstance(m.min_trade_size, float)
+        assert isinstance(m.margin_rate, float)
+
+    def test_pip_location_jpy(self) -> None:
+        """JPY pairs must have pip_location == −2."""
+        raw = _raw_instrument(name="USD_JPY", pip_location=-2)
+        m = _instrument_from_raw(raw)
+        assert m.pip_location == -2
+
+    def test_pip_location_major(self) -> None:
+        """EUR_USD must have pip_location == −4."""
+        raw = _raw_instrument(name="EUR_USD", pip_location=-4)
+        m = _instrument_from_raw(raw)
+        assert m.pip_location == -4
+
+    def test_financing_days_parsed(self) -> None:
+        """financingDaysOfWeek dicts must map to int weekday numbers."""
+        raw = _raw_instrument(
+            days_of_week=[
+                {"dayOfWeek": "WEDNESDAY", "daysCharged": 3},
+                {"dayOfWeek": "FRIDAY", "daysCharged": 1},
+            ]
+        )
+        m = _instrument_from_raw(raw)
+        # WEDNESDAY = 2, FRIDAY = 4
+        assert 2 in m.financing_days_of_week
+        assert 4 in m.financing_days_of_week
+
+    def test_unknown_day_ignored(self) -> None:
+        """Unknown day strings should be silently dropped."""
+        raw = _raw_instrument(
+            days_of_week=[{"dayOfWeek": "HOLIDAY", "daysCharged": 1}]
+        )
+        m = _instrument_from_raw(raw)
+        assert m.financing_days_of_week == []
+
+
+# ---------------------------------------------------------------------------
+# OandaClient.list_instruments tests
+# ---------------------------------------------------------------------------
+
+
+class TestListInstruments:
+    def _mock_client_with_response(
+        self,
+        instruments: list[dict[str, Any]],
+    ) -> OandaClient:
+        """Build an OandaClient whose _api.request returns the given payload."""
+        settings = _make_settings()
+        client = OandaClient.__new__(OandaClient)
+        client._settings = settings
+
+        mock_api = MagicMock()
+        mock_api.request.return_value = {"instruments": instruments}
+        client._api = mock_api
+        return client
+
+    def test_returns_list_of_instrument_meta(self) -> None:
+        instruments = [
+            _raw_instrument("EUR_USD", pip_location=-4),
+            _raw_instrument("USD_JPY", pip_location=-2),
+        ]
+        client = self._mock_client_with_response(instruments)
+        result = client.list_instruments()
+        assert len(result) == 2
+        assert all(isinstance(m, InstrumentMeta) for m in result)
+
+    def test_filters_non_currency_types(self) -> None:
+        """Non-CURRENCY instruments (CFDs, metals) must be excluded."""
+        instruments = [
+            _raw_instrument("EUR_USD"),
+            {**_raw_instrument("BCO_USD"), "type": "CFD"},
+            {**_raw_instrument("XAU_USD"), "type": "METAL"},
+        ]
+        client = self._mock_client_with_response(instruments)
+        result = client.list_instruments()
+        assert len(result) == 1
+        assert result[0].name == "EUR_USD"
+
+    def test_pip_location_jpy_vs_major(self) -> None:
+        instruments = [
+            _raw_instrument("EUR_USD", pip_location=-4),
+            _raw_instrument("USD_JPY", pip_location=-2),
+        ]
+        client = self._mock_client_with_response(instruments)
+        result = client.list_instruments()
+        by_name = {m.name: m for m in result}
+        assert by_name["EUR_USD"].pip_location == -4
+        assert by_name["USD_JPY"].pip_location == -2
+
+    def test_raises_oanda_api_error_on_4xx(self) -> None:
+        from oandapyV20.exceptions import V20Error
+
+        settings = _make_settings()
+        client = OandaClient.__new__(OandaClient)
+        client._settings = settings
+
+        mock_api = MagicMock()
+        mock_api.request.side_effect = V20Error(401, "Unauthorised")
+        client._api = mock_api
+
+        with pytest.raises(OandaAPIError) as exc_info:
+            client.list_instruments()
+        assert exc_info.value.status_code == 401
+
+    def test_token_not_in_exception_message(self) -> None:
+        """INV-08: the API token must never appear in exception messages."""
+        from oandapyV20.exceptions import V20Error
+
+        token = "secret-token-12345"
+        settings = Settings(
+            env="demo",
+            oanda_api_token=SecretStr(token),
+            oanda_account_id="101-001-99999-001",
+        )
+        client = OandaClient.__new__(OandaClient)
+        client._settings = settings
+
+        mock_api = MagicMock()
+        mock_api.request.side_effect = V20Error(403, "Forbidden")
+        client._api = mock_api
+
+        with pytest.raises(OandaAPIError) as exc_info:
+            client.list_instruments()
+        assert token not in str(exc_info.value)
+
+    def test_empty_response(self) -> None:
+        """Empty instruments list is valid (no instruments on account)."""
+        client = self._mock_client_with_response([])
+        result = client.list_instruments()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Store instrument metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreInstruments:
+    def _store(self) -> Store:
+        return Store(":memory:")
+
+    def test_upsert_and_load_roundtrip(self) -> None:
+        store = self._store()
+        instruments = [
+            InstrumentMeta(
+                name="EUR_USD",
+                pip_location=-4,
+                min_trade_size=1.0,
+                margin_rate=0.02,
+                display_precision=5,
+                long_rate=-0.0002,
+                short_rate=0.0001,
+                financing_days_of_week=[2, 4],
+            ),
+            InstrumentMeta(
+                name="USD_JPY",
+                pip_location=-2,
+                min_trade_size=1.0,
+                margin_rate=0.02,
+                display_precision=3,
+                long_rate=-0.00015,
+                short_rate=0.0001,
+                financing_days_of_week=[2],
+            ),
+        ]
+        store.upsert_instruments(instruments)
+        loaded = store.load_instruments()
+        assert len(loaded) == 2
+        by_name = {m.name: m for m in loaded}
+        assert by_name["EUR_USD"].pip_location == -4
+        assert by_name["USD_JPY"].pip_location == -2
+        assert by_name["EUR_USD"].financing_days_of_week == [2, 4]
+
+    def test_upsert_is_idempotent(self) -> None:
+        store = self._store()
+        instr = InstrumentMeta(
+            name="GBP_USD",
+            pip_location=-4,
+            min_trade_size=1.0,
+            margin_rate=0.02,
+            display_precision=5,
+            long_rate=-0.0003,
+            short_rate=0.0002,
+            financing_days_of_week=[2],
+        )
+        store.upsert_instruments([instr])
+        # Upsert again with updated rate.
+        instr2 = instr.model_copy(update={"long_rate": -0.0004})
+        store.upsert_instruments([instr2])
+        loaded = store.load_instruments()
+        assert len(loaded) == 1
+        assert loaded[0].long_rate == pytest.approx(-0.0004)
+
+    def test_empty_store_returns_empty_list(self) -> None:
+        store = self._store()
+        assert store.load_instruments() == []
+
+    def test_float_types_preserved(self) -> None:
+        store = self._store()
+        instr = InstrumentMeta(
+            name="EUR_USD",
+            pip_location=-4,
+            min_trade_size=1.0,
+            margin_rate=0.02,
+            display_precision=5,
+            long_rate=-0.0002,
+            short_rate=0.0001,
+            financing_days_of_week=[2],
+        )
+        store.upsert_instruments([instr])
+        loaded = store.load_instruments()[0]
+        assert isinstance(loaded.long_rate, float)
+        assert isinstance(loaded.short_rate, float)
+        assert isinstance(loaded.margin_rate, float)
+        assert isinstance(loaded.min_trade_size, float)
+
+
+# ---------------------------------------------------------------------------
+# Parquet round-trip tests (INV-03 dtype contract)
+# ---------------------------------------------------------------------------
+
+
+class TestParquetRoundTrip:
+    def test_datetime_tz_preserved(self, tmp_path: Path) -> None:
+        """Parquet round-trip must preserve datetime64[ns, UTC] (INV-03)."""
+        store = Store(":memory:", archive_dir=tmp_path)
+        times = pd.to_datetime(
+            [
+                "2024-01-15T14:00:00Z",
+                "2024-01-15T15:00:00Z",
+                "2024-01-15T16:00:00Z",
+            ],
+            utc=True,
+        ).astype("datetime64[ns, UTC]")
+
+        df = pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": [1.08500, 1.08510, 1.08520],
+                "high_bid": [1.08600, 1.08610, 1.08620],
+                "low_bid": [1.08400, 1.08410, 1.08420],
+                "close_bid": [1.08550, 1.08560, 1.08570],
+                "open_ask": [1.08502, 1.08512, 1.08522],
+                "high_ask": [1.08602, 1.08612, 1.08622],
+                "low_ask": [1.08402, 1.08412, 1.08422],
+                "close_ask": [1.08552, 1.08562, 1.08572],
+                "volume": [100, 200, 150],
+            }
+        )
+
+        store.write_parquet("EUR_USD", "H1", df)
+        loaded = store.load_parquet(
+            "EUR_USD",
+            "H1",
+            start=_utc(2024, 1, 15, 14),
+            end=_utc(2024, 1, 15, 16),
+        )
+
+        assert str(loaded["time"].dtype) == "datetime64[ns, UTC]"
+        assert loaded["time"].dt.tz is not None
+        # Confirm the timezone is UTC
+        assert str(loaded["time"].dt.tz) == "UTC"
+
+    def test_float64_and_int64_dtypes_preserved(self, tmp_path: Path) -> None:
+        """Float columns must be float64; volume must be int64."""
+        store = Store(":memory:", archive_dir=tmp_path)
+        times = pd.to_datetime(["2024-02-01T00:00:00Z"], utc=True).astype(
+            "datetime64[ns, UTC]"
+        )
+        df = pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": [1.1000],
+                "high_bid": [1.1010],
+                "low_bid": [1.0990],
+                "close_bid": [1.1005],
+                "open_ask": [1.1002],
+                "high_ask": [1.1012],
+                "low_ask": [1.0992],
+                "close_ask": [1.1007],
+                "volume": [500],
+            }
+        )
+        df["volume"] = df["volume"].astype("int64")
+
+        store.write_parquet("GBP_USD", "H4", df)
+        loaded = store.load_parquet(
+            "GBP_USD",
+            "H4",
+            start=_utc(2024, 2, 1),
+            end=_utc(2024, 2, 1, 23),
+        )
+
+        for col in ["open_bid", "high_bid", "low_bid", "close_bid",
+                    "open_ask", "high_ask", "low_ask", "close_ask"]:
+            assert loaded[col].dtype == "float64", f"Expected float64 for {col}"
+        assert loaded["volume"].dtype == "int64"
+
+    def test_values_round_trip_correctly(self, tmp_path: Path) -> None:
+        """Write then read must produce identical values."""
+        store = Store(":memory:", archive_dir=tmp_path)
+        times = pd.to_datetime(
+            ["2024-03-10T10:00:00Z", "2024-03-10T11:00:00Z"],
+            utc=True,
+        ).astype("datetime64[ns, UTC]")
+        df = pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": [1.28100, 1.28200],
+                "high_bid": [1.28150, 1.28250],
+                "low_bid": [1.28050, 1.28150],
+                "close_bid": [1.28120, 1.28220],
+                "open_ask": [1.28102, 1.28202],
+                "high_ask": [1.28152, 1.28252],
+                "low_ask": [1.28052, 1.28152],
+                "close_ask": [1.28122, 1.28222],
+                "volume": [300, 400],
+            }
+        )
+
+        store.write_parquet("GBP_USD", "H1", df)
+        loaded = store.load_parquet(
+            "GBP_USD",
+            "H1",
+            start=_utc(2024, 3, 10, 10),
+            end=_utc(2024, 3, 10, 11),
+        )
+
+        assert len(loaded) == 2
+        assert list(loaded["open_bid"]) == pytest.approx([1.28100, 1.28200])
+        assert list(loaded["volume"]) == [300, 400]
+
+    def test_multi_date_partitioning(self, tmp_path: Path) -> None:
+        """Data spanning multiple dates must be split into per-date Parquet files."""
+        store = Store(":memory:", archive_dir=tmp_path)
+        times = pd.to_datetime(
+            [
+                "2024-04-01T22:00:00Z",  # April 1
+                "2024-04-02T00:00:00Z",  # April 2
+                "2024-04-02T01:00:00Z",  # April 2
+            ],
+            utc=True,
+        ).astype("datetime64[ns, UTC]")
+        df = pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": [1.0, 2.0, 3.0],
+                "high_bid": [1.1, 2.1, 3.1],
+                "low_bid": [0.9, 1.9, 2.9],
+                "close_bid": [1.05, 2.05, 3.05],
+                "open_ask": [1.01, 2.01, 3.01],
+                "high_ask": [1.11, 2.11, 3.11],
+                "low_ask": [0.91, 1.91, 2.91],
+                "close_ask": [1.06, 2.06, 3.06],
+                "volume": [100, 200, 300],
+            }
+        )
+
+        store.write_parquet("EUR_USD", "H1", df)
+
+        # Check files exist for both dates under the granularity sub-directory.
+        assert (tmp_path / "EUR_USD" / "H1" / "2024-04-01.parquet").exists()
+        assert (tmp_path / "EUR_USD" / "H1" / "2024-04-02.parquet").exists()
+
+    def test_load_parquet_empty_range(self, tmp_path: Path) -> None:
+        """load_parquet on a range with no Parquet files returns empty DataFrame."""
+        store = Store(":memory:", archive_dir=tmp_path)
+        loaded = store.load_parquet(
+            "EUR_USD", "H1", start=_utc(2024, 1, 1), end=_utc(2024, 1, 2)
+        )
+        assert loaded.empty
+        assert str(loaded["time"].dtype) == "datetime64[ns, UTC]"
+
+    def test_no_archive_dir_raises(self) -> None:
+        """RuntimeError if archive_dir not set and Parquet methods called."""
+        store = Store(":memory:")  # no archive_dir
+        df = pd.DataFrame(columns=["time"])
+        df["time"] = pd.to_datetime(df["time"], utc=True).astype("datetime64[ns, UTC]")
+        with pytest.raises(RuntimeError, match="archive_dir"):
+            store.write_parquet("EUR_USD", "H1", df)
+        with pytest.raises(RuntimeError, match="archive_dir"):
+            store.load_parquet("EUR_USD", "H1", _utc(2024, 1, 1), _utc(2024, 1, 2))
+
+
+# ---------------------------------------------------------------------------
+# fetch_and_cache dual-write tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndCacheDualWrite:
+    def test_writes_to_parquet_on_new_fetch(self, tmp_path: Path) -> None:
+        """When new rows are fetched, they must also be written to Parquet."""
+        db_path = tmp_path / "test.db"
+        store = Store(db_path, archive_dir=tmp_path / "archive")
+
+        t1 = _utc(2024, 5, 1, 10)
+        t2 = _utc(2024, 5, 1, 11)
+
+        mock_client = MagicMock()
+        mock_client.get_candles.return_value = [
+            _make_candle_row("EUR_USD", "H1", t1),
+            _make_candle_row("EUR_USD", "H1", t2),
+        ]
+
+        fetch_and_cache(
+            mock_client, store, "EUR_USD", "H1", t1, t2, write_parquet=True
+        )
+
+        parquet_file = tmp_path / "archive" / "EUR_USD" / "H1" / "2024-05-01.parquet"
+        assert parquet_file.exists(), "Parquet file must be written on first fetch"
+
+    def test_no_parquet_write_when_flag_false(self, tmp_path: Path) -> None:
+        """``write_parquet=False`` must skip the Parquet write entirely."""
+        db_path = tmp_path / "test.db"
+        archive_dir = tmp_path / "archive"
+        store = Store(db_path, archive_dir=archive_dir)
+
+        t1 = _utc(2024, 5, 2, 10)
+        t2 = _utc(2024, 5, 2, 11)
+
+        mock_client = MagicMock()
+        mock_client.get_candles.return_value = [
+            _make_candle_row("EUR_USD", "H1", t1),
+            _make_candle_row("EUR_USD", "H1", t2),
+        ]
+
+        fetch_and_cache(
+            mock_client, store, "EUR_USD", "H1", t1, t2, write_parquet=False
+        )
+
+        parquet_file = archive_dir / "EUR_USD" / "2024-05-02.parquet"
+        assert not parquet_file.exists(), "No Parquet file when write_parquet=False"
+
+    def test_cache_hit_makes_no_http_call(self, tmp_path: Path) -> None:
+        """Second fetch_and_cache with same range must not call OANDA."""
+        db_path = tmp_path / "test.db"
+        store = Store(db_path, archive_dir=tmp_path / "archive")
+
+        t1 = _utc(2024, 6, 1, 10)
+        t2 = _utc(2024, 6, 1, 11)
+
+        mock_client = MagicMock()
+        mock_client.get_candles.return_value = [
+            _make_candle_row("EUR_USD", "H1", t1),
+            _make_candle_row("EUR_USD", "H1", t2),
+        ]
+
+        # First call — fetches from OANDA.
+        fetch_and_cache(mock_client, store, "EUR_USD", "H1", t1, t2)
+        assert mock_client.get_candles.call_count == 1
+
+        # Second call — must be served entirely from SQLite cache.
+        fetch_and_cache(mock_client, store, "EUR_USD", "H1", t1, t2)
+        assert mock_client.get_candles.call_count == 1, (
+            "get_candles must not be called again for a fully-cached range"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parquet granularity isolation test
+# ---------------------------------------------------------------------------
+
+
+class TestParquetGranularityIsolation:
+    def test_h1_and_h4_do_not_bleed_into_each_other(self, tmp_path: Path) -> None:
+        """Different granularities for the same instrument must be isolated."""
+        store = Store(":memory:", archive_dir=tmp_path)
+
+        base_time = _utc(2024, 7, 15, 0)
+        times_h1 = pd.to_datetime(
+            [base_time + pd.Timedelta(hours=i) for i in range(3)], utc=True
+        ).astype("datetime64[ns, UTC]")
+        times_h4 = pd.to_datetime(
+            [base_time + pd.Timedelta(hours=i * 4) for i in range(2)], utc=True
+        ).astype("datetime64[ns, UTC]")
+
+        def _df(times: pd.DatetimeTZDtype) -> pd.DataFrame:
+            n = len(times)
+            return pd.DataFrame(
+                {
+                    "time": times,
+                    "open_bid": [1.0] * n,
+                    "high_bid": [1.1] * n,
+                    "low_bid": [0.9] * n,
+                    "close_bid": [1.05] * n,
+                    "open_ask": [1.01] * n,
+                    "high_ask": [1.11] * n,
+                    "low_ask": [0.91] * n,
+                    "close_ask": [1.06] * n,
+                    "volume": [100] * n,
+                }
+            )
+
+        store.write_parquet("EUR_USD", "H1", _df(times_h1))
+        store.write_parquet("EUR_USD", "H4", _df(times_h4))
+
+        loaded_h1 = store.load_parquet(
+            "EUR_USD", "H1", start=base_time, end=base_time + pd.Timedelta(hours=3)
+        )
+        loaded_h4 = store.load_parquet(
+            "EUR_USD", "H4", start=base_time, end=base_time + pd.Timedelta(hours=9)
+        )
+
+        # H1 should have 3 rows, H4 should have 2 rows.
+        assert len(loaded_h1) == 3
+        assert len(loaded_h4) == 2

--- a/tests/test_store_and_candles.py
+++ b/tests/test_store_and_candles.py
@@ -282,11 +282,13 @@ class TestCacheHit:
         end = t3
 
         # First call — should call client once.
-        df1 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end)
+        df1 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end,
+                              write_parquet=False)
         assert client.get_candles.call_count == 1
 
         # Second call — must NOT call client again.
-        df2 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end)
+        df2 = fetch_and_cache(client, mem_store, "EUR_USD", "H1", start, end,
+                              write_parquet=False)
         assert client.get_candles.call_count == 1, (
             "Second call for the same range must make ZERO HTTP requests (cache hit)"
         )
@@ -305,8 +307,10 @@ class TestCacheHit:
         start = t
         end = t
 
-        fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end)
-        df = fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end)
+        fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end,
+                        write_parquet=False)
+        df = fetch_and_cache(client, mem_store, "GBP_USD", "H1", start, end,
+                             write_parquet=False)
 
         assert str(df["time"].dtype) == "datetime64[ns, UTC]"
         for ts in df["time"]:
@@ -334,6 +338,7 @@ class TestPartialGapFill:
             client, mem_store, "EUR_USD", "H1",
             start=_utc(2024, 4, 1, 0),
             end=_utc(2024, 4, 1, 5),
+            write_parquet=False,
         )
 
         # Client was called exactly once (for the trailing gap).
@@ -370,6 +375,7 @@ class TestPartialGapFill:
             client, mem_store, "EUR_USD", "H1",
             start=_utc(2024, 4, 2, 0),
             end=_utc(2024, 4, 2, 5),
+            write_parquet=False,
         )
 
         # Client was called exactly once (for the leading gap).
@@ -424,6 +430,7 @@ class TestPartialGapFill:
             client, mem_store, "EUR_USD", "H1",
             start=_utc(2024, 6, 1),
             end=_utc(2024, 6, 2),
+            write_parquet=False,
         )
 
         # Only the complete candle should appear.
@@ -462,6 +469,7 @@ class TestFetchAndCacheValidation:
             client, mem_store, "GBP_USD", "H1",
             start=_utc(2024, 7, 4),
             end=_utc(2024, 7, 5),
+            write_parquet=False,
         )
 
         required = {


### PR DESCRIPTION
Closes #21.

## Summary

- **`InstrumentMeta`** pydantic v2 model with canonical financing fields (`long_rate`/`short_rate`/`financing_days_of_week`); OANDA wire-format string rates coerced to float at the boundary.
- **`OandaClient.list_instruments()`** via `AccountInstruments` endpoint; mirrors existing `get_candles` error/pagination pattern; filters to `CURRENCY` type only (INV-09: account-scoped).
- **`Store.upsert_instruments()` / `load_instruments()`** — SQLite `instruments` table for metadata caching; refreshable (idempotent upsert).
- **`Store.write_parquet()` / `load_parquet()`** — Parquet archive using `pyarrow`; layout `{archive_dir}/{instrument}/{granularity}/{YYYY-MM-DD}.parquet`; granularity encoded in path to prevent collisions. Round-trip verified: `datetime64[ns, UTC]` + `float64`/`int64` preserved (INV-03).
- **`fetch_and_cache`** gains `write_parquet=` flag (default `True`) for dual-write; SQLite remains source of truth for gap detection; Parquet is the bulk archive.
- **`pyarrow>=14`** added to `pyproject.toml`; `CLAUDE.md` Stack line updated.
- **26 new tests** in `tests/test_data_layer_expansion.py` covering all P1A-T-01 ACs.

## AC check results

```
pytest tests/test_data_layer_expansion.py -v  → 26 passed, exit 0
pytest -v  (full suite)  → 171 passed, exit 0
mypy data/  → Success: no issues found in 4 source files, exit 0
```

## Merge plan

`gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)