### PR TITLE
P1A-T-04: donchian-breakout

### DIFF
--- a/.claude/context/strategies.md
+++ b/.claude/context/strategies.md
@@ -84,3 +84,48 @@
 **pyproject.toml:** untouched (no new dep required).
 **CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+## P1A-T-04 — 2026-05-29 (feat/p1a-t-04)
+
+**What was done:**
+- Extended `strategies/trend.py` with `DonchianBreakout(Strategy)`, parameterised by
+  `channel_period: int` (classic values 20 and 55 tested).
+- Channel computed via `high_bid.rolling(channel_period).max().shift(1)` and
+  `low_bid.rolling(channel_period).min().shift(1)` — shift-by-1 excludes the current
+  bar so there is no look-ahead (close-based breakout per spec lean).
+- `stop_distance` = `_indicators.atr(df, 14)` at signal bar (shared helper, INV-11).
+- `target_distance` = `stop_distance × rr_ratio` (default 1.5).
+- `quality_score` = `excess / channel_width` clamped to [0,1], where excess is the
+  distance the close has moved beyond the channel edge and channel_width = ch_high − ch_low.
+- `generated_at` = bar close timestamp (UTC-aware, INV-03); never `datetime.now()`.
+- Updated `strategies/__init__.py` to re-export `DonchianBreakout` and `MACrossover`.
+- Created `tests/test_donchian_breakout.py` — 32 tests covering:
+  - Construction guards (zero/negative channel_period, rr_ratio).
+  - LONG on upward breakout; SHORT on downward breakout; no signal inside channel.
+  - ATR stop > 0; target = stop × rr_ratio; custom rr_ratio.
+  - quality_score ∈ [0,1]; monotonicity (larger breakout → higher score).
+  - INV-03: UTC-aware generated_at; matches bar timestamp in DataFrame.
+  - At most one signal per bar (no duplicate timestamps).
+  - No look-ahead (removing the breakout bar removes the signal).
+  - channel_period ∈ {20, 55} (parametrize).
+  - Edge cases: insufficient data, mutation guard, instrument/timeframe propagation,
+    missing required columns.
+
+**Key patterns / gotchas:**
+- Rolling channel uses `min_periods=channel_period` so the first `channel_period` bars
+  never produce NaN-masked-as-valid values; combined with `.shift(1)` the first valid
+  channel value is at index `channel_period` (i.e. the `channel_period+1`-th row).
+- Quality score denominator `channel_width = ch_high - ch_low` can be 0 on perfectly
+  flat data; guard returns 0.0 in that case.
+- Do NOT add `# type: ignore[assignment]` for the `bar_time` assignment — mypy rejects
+  it as unused on Python 3.12; use a plain assignment instead.
+
+**AC verification results:**
+- `pytest tests/test_donchian_breakout.py -v` → **32 passed**, exit 0
+- `pytest -v` (full suite) → **214 passed**, exit 0
+- `mypy strategies/` → **"Success: no issues found in 4 source files"**, exit 0
+
+**No new runtime dependencies added** (pandas + stdlib only).
+**pyproject.toml:** untouched (no new dep required).
+**CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -4,5 +4,6 @@ Contains the Strategy ABC, Signal model, Direction enum, and concrete strategy i
 """
 
 from strategies.base import Direction, Signal, Strategy
+from strategies.trend import DonchianBreakout, MACrossover
 
-__all__ = ["Direction", "Signal", "Strategy"]
+__all__ = ["Direction", "DonchianBreakout", "MACrossover", "Signal", "Strategy"]

--- a/strategies/trend.py
+++ b/strategies/trend.py
@@ -6,6 +6,13 @@ Generates signals on EMA crossovers:
 - Golden cross (fast EMA crosses ABOVE slow EMA) → LONG signal
 - Death cross  (fast EMA crosses BELOW slow EMA) → SHORT signal
 
+DonchianBreakout
+----------------
+Generates signals on Donchian channel breakouts:
+- Close above the prior channel_period-bar rolling max high → LONG signal
+- Close below the prior channel_period-bar rolling min low  → SHORT signal
+- No signal while price stays inside the channel.
+
 library_defaults (from poc-taskgraph.md):
   pandas.ewm(span=..., adjust=False)   — recursive EMA formulation.
   Default adjust=True gives a different result to the standard recursive EMA
@@ -185,3 +192,185 @@ class MACrossover(Strategy):
 
         return signals
 
+
+class DonchianBreakout(Strategy):
+    """Donchian channel breakout strategy.
+
+    Produces a signal when price closes outside the prior ``channel_period``-bar
+    Donchian channel (the rolling max of highs / rolling min of lows, each
+    shifted by 1 bar so the current bar is excluded — no look-ahead).
+
+    Signal rules (close-based):
+    - LONG  when ``close > channel_high_prev``  (close breaks above prior channel high)
+    - SHORT when ``close < channel_low_prev``   (close breaks below prior channel low)
+    - No signal while close stays inside the channel.
+    - At most one signal per bar (LONG takes priority if both conditions fire
+      simultaneously, which cannot happen in practice for a well-formed channel).
+
+    Parameters
+    ----------
+    channel_period:
+        Look-back in bars for the rolling high/low channel.  Classic values are
+        20 (standard Donchian) and 55 (Turtle system).  Must be >= 1.
+    rr_ratio:
+        Reward-to-risk ratio used to derive ``target_distance`` from
+        ``stop_distance``.  Default 1.5 (target = stop * 1.5).
+    instrument:
+        OANDA instrument identifier (e.g. ``"EUR_USD"``).
+    timeframe:
+        Granularity string (e.g. ``"H1"`` or ``"D"``).
+    atr_period:
+        Look-back for the shared ATR calculation.  Default 14 (INV-11).
+    """
+
+    def __init__(
+        self,
+        channel_period: int,
+        *,
+        rr_ratio: float = 1.5,
+        instrument: str = "",
+        timeframe: str = "",
+        atr_period: int = 14,
+    ) -> None:
+        if channel_period < 1:
+            raise ValueError(f"channel_period must be >= 1, got {channel_period}")
+        if rr_ratio <= 0:
+            raise ValueError(f"rr_ratio must be > 0, got {rr_ratio}")
+
+        self._channel_period = channel_period
+        self._rr_ratio = rr_ratio
+        self._instrument = instrument
+        self._timeframe = timeframe
+        self._atr_period = atr_period
+
+    # ------------------------------------------------------------------
+    # Strategy interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return f"DonchianBreakout({self._channel_period})"
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        """Scan the DataFrame for Donchian channel breakouts and return Signals.
+
+        At most one signal is produced per bar.  The DataFrame is never mutated.
+        The channel is computed using the prior ``channel_period`` bars only
+        (shifted by 1 bar) — no look-ahead.
+
+        Parameters
+        ----------
+        df:
+            Candle data with columns: ``time``, ``high_bid``, ``low_bid``,
+            ``close_bid`` (minimum required).  ``time`` must be UTC-aware.
+
+        Returns
+        -------
+        list[Signal]
+        """
+        df = df.copy()  # defensive copy — never mutate the caller's DataFrame
+
+        required = {"time", "high_bid", "low_bid", "close_bid"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f"DataFrame missing required columns: {missing}")
+
+        n = len(df)
+        # Need at least channel_period + 1 rows: channel_period for the rolling
+        # window and at least 1 bar beyond to evaluate the breakout.
+        if n < self._channel_period + 1:
+            return []
+
+        high = df["high_bid"].astype(float)
+        low = df["low_bid"].astype(float)
+        close = df["close_bid"].astype(float)
+
+        # Rolling channel over exactly channel_period bars, shifted by 1 so that
+        # bar i's channel is derived from bars [i-channel_period, i-1] (no look-ahead).
+        # min_periods=channel_period ensures we only get a value once the window is full.
+        channel_high: pd.Series[float] = (
+            high.rolling(self._channel_period, min_periods=self._channel_period)
+            .max()
+            .shift(1)
+        )
+        channel_low: pd.Series[float] = (
+            low.rolling(self._channel_period, min_periods=self._channel_period)
+            .min()
+            .shift(1)
+        )
+
+        # ATR(14) — standard True Range average (shared helper, INV-11).
+        atr_series = _atr(df, self._atr_period)
+
+        signals: list[Signal] = []
+
+        for i in range(1, n):
+            ch_high = channel_high.iloc[i]
+            ch_low = channel_low.iloc[i]
+
+            # Skip bars where the channel is not yet fully computed (NaN from shift+rolling).
+            if pd.isna(ch_high) or pd.isna(ch_low):
+                continue
+
+            curr_close = close.iloc[i]
+
+            # Determine breakout direction (close-based, lean from spec).
+            if curr_close > ch_high:
+                direction = Direction.LONG
+            elif curr_close < ch_low:
+                direction = Direction.SHORT
+            else:
+                # Inside the channel — no signal.
+                continue
+
+            # stop_distance = ATR(14) at signal bar (INV-11) — must be > 0.
+            atr_value = float(atr_series.iloc[i])
+            if atr_value <= 0 or pd.isna(atr_value):
+                continue
+
+            stop_distance = atr_value
+            target_distance = stop_distance * self._rr_ratio
+
+            # quality_score: normalised breakout strength in [0, 1].
+            # Measure how far close has moved beyond the channel edge relative to
+            # the channel width.  Channel width = ch_high - ch_low.
+            #   LONG:  excess = close - ch_high  (how far above the upper rail)
+            #   SHORT: excess = ch_low  - close  (how far below the lower rail)
+            channel_width = ch_high - ch_low
+            if channel_width > 0:
+                if direction == Direction.LONG:
+                    excess = curr_close - ch_high
+                else:
+                    excess = ch_low - curr_close
+                quality_score = float(min(excess / channel_width, 1.0))
+            else:
+                quality_score = 0.0
+
+            # generated_at: bar's close timestamp (INV-03 — never datetime.now()).
+            bar_time = df["time"].iloc[i]
+            if hasattr(bar_time, "to_pydatetime"):
+                generated_at: datetime = bar_time.to_pydatetime()
+            else:
+                generated_at = bar_time
+
+            # Ensure UTC-aware (INV-03).
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=timezone.utc)
+
+            entry_ref = float(curr_close)
+
+            signals.append(
+                Signal(
+                    instrument=self._instrument,
+                    direction=direction,
+                    entry_ref=entry_ref,
+                    stop_distance=stop_distance,
+                    target_distance=target_distance,
+                    strategy_name=self.name,
+                    timeframe=self._timeframe,
+                    quality_score=quality_score,
+                    generated_at=generated_at,
+                )
+            )
+
+        return signals

--- a/tests/test_donchian_breakout.py
+++ b/tests/test_donchian_breakout.py
@@ -1,0 +1,476 @@
+"""Tests for DonchianBreakout strategy in strategies/trend.py.
+
+Covers:
+- Construction guards (channel_period, rr_ratio)
+- LONG signal on close above prior channel_period-bar rolling max high
+- SHORT signal on close below prior channel_period-bar rolling min low
+- No signal inside the channel
+- stop_distance = ATR(14) at signal bar (> 0); target_distance = stop * rr_ratio
+- quality_score ∈ [0, 1]; derived from breakout strength
+- generated_at is the bar's close timestamp (UTC-aware, INV-03), never datetime.now()
+- At most one signal per bar
+- No look-ahead: signal uses channel from prior N bars (shifted by 1)
+- Tested at channel_period ∈ {20, 55} (classic Donchian / Turtle values)
+- No mutation of input DataFrame
+- Instrument and timeframe propagated to signals
+- Insufficient data returns empty list
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from strategies.base import Direction, Signal
+from strategies.trend import DonchianBreakout
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candles(
+    closes: list[float],
+    *,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+    start: datetime | None = None,
+    freq_hours: int = 1,
+) -> pd.DataFrame:
+    """Build a minimal synthetic OHLC DataFrame with UTC timestamps."""
+    n = len(closes)
+    if highs is None:
+        highs = [c * 1.001 for c in closes]
+    if lows is None:
+        lows = [c * 0.999 for c in closes]
+    if start is None:
+        start = _utc(2024, 1, 1)
+
+    times = [start + timedelta(hours=i * freq_hours) for i in range(n)]
+    df = pd.DataFrame(
+        {
+            "time": pd.to_datetime(times, utc=True),
+            "open_bid": closes,
+            "high_bid": highs,
+            "low_bid": lows,
+            "close_bid": closes,
+            "volume": [100] * n,
+        }
+    )
+    return df
+
+
+def _upward_breakout_df(channel_period: int = 20, warmup_extra: int = 10) -> pd.DataFrame:
+    """Synthetic data producing a clear upward Donchian breakout.
+
+    Steps:
+    1. ``channel_period + warmup_extra`` bars at a flat level (1.2000) — the
+       channel high settles at the flat level, i.e. max(high) ≈ 1.2012.
+    2. One final bar with a sharply higher close that exceeds the channel high.
+    """
+    n_flat = channel_period + warmup_extra
+    flat_price = 1.2000
+    # Keep highs and lows tight so the channel is well-defined
+    flat_closes = [flat_price] * n_flat
+    flat_highs = [flat_price * 1.001] * n_flat
+    flat_lows = [flat_price * 0.999] * n_flat
+
+    # Breakout bar: close well above the channel high
+    breakout_close = flat_price * 1.010  # +1% above flat, well above channel high
+    breakout_high = breakout_close * 1.001
+    breakout_low = breakout_close * 0.999
+
+    closes = flat_closes + [breakout_close]
+    highs = flat_highs + [breakout_high]
+    lows = flat_lows + [breakout_low]
+    return _make_candles(closes, highs=highs, lows=lows)
+
+
+def _downward_breakout_df(channel_period: int = 20, warmup_extra: int = 10) -> pd.DataFrame:
+    """Synthetic data producing a clear downward Donchian breakout."""
+    n_flat = channel_period + warmup_extra
+    flat_price = 1.2000
+    flat_closes = [flat_price] * n_flat
+    flat_highs = [flat_price * 1.001] * n_flat
+    flat_lows = [flat_price * 0.999] * n_flat
+
+    # Breakout bar: close well below the channel low
+    breakout_close = flat_price * 0.990  # -1%, well below channel low
+    breakout_high = breakout_close * 1.001
+    breakout_low = breakout_close * 0.999
+
+    closes = flat_closes + [breakout_close]
+    highs = flat_highs + [breakout_high]
+    lows = flat_lows + [breakout_low]
+    return _make_candles(closes, highs=highs, lows=lows)
+
+
+def _flat_channel_df(channel_period: int = 20, n: int = 200) -> pd.DataFrame:
+    """Flat data: price stays exactly at channel midpoint — no breakout fires."""
+    flat_price = 1.2000
+    closes = [flat_price] * n
+    return _make_candles(closes)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutConstruction:
+    def test_valid_construction_period_20(self) -> None:
+        s = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        assert s.name == "DonchianBreakout(20)"
+
+    def test_valid_construction_period_55(self) -> None:
+        s = DonchianBreakout(55, instrument="EUR_USD", timeframe="H1")
+        assert s.name == "DonchianBreakout(55)"
+
+    def test_zero_channel_period_raises(self) -> None:
+        with pytest.raises(ValueError, match="channel_period"):
+            DonchianBreakout(0)
+
+    def test_negative_channel_period_raises(self) -> None:
+        with pytest.raises(ValueError, match="channel_period"):
+            DonchianBreakout(-5)
+
+    def test_zero_rr_ratio_raises(self) -> None:
+        with pytest.raises(ValueError, match="rr_ratio"):
+            DonchianBreakout(20, rr_ratio=0.0)
+
+    def test_negative_rr_ratio_raises(self) -> None:
+        with pytest.raises(ValueError, match="rr_ratio"):
+            DonchianBreakout(20, rr_ratio=-1.0)
+
+    def test_name_contains_period(self) -> None:
+        for period in [20, 55]:
+            s = DonchianBreakout(period)
+            assert str(period) in s.name
+
+
+# ---------------------------------------------------------------------------
+# Signal generation — direction
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutSignals:
+    def test_upward_breakout_produces_long(self) -> None:
+        """Close above prior channel high → LONG signal."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        assert len(signals) >= 1, f"Expected LONG signal on upward breakout, got {signals}"
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1
+
+    def test_downward_breakout_produces_short(self) -> None:
+        """Close below prior channel low → SHORT signal."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _downward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        assert len(signals) >= 1, f"Expected SHORT signal on downward breakout, got {signals}"
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1
+
+    def test_no_signal_inside_channel(self) -> None:
+        """Price staying inside the channel must produce no signal."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _flat_channel_df(20, n=200)
+        signals = strategy.generate_signals(df)
+        assert signals == [], f"Expected no signals on flat data, got {len(signals)}"
+
+    def test_only_long_or_short_no_other_directions(self) -> None:
+        """Signals must be LONG or SHORT, never FLAT."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.direction in (Direction.LONG, Direction.SHORT)
+
+
+# ---------------------------------------------------------------------------
+# INV-11: stop / target / ATR
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutStopTarget:
+    def test_stop_distance_positive(self) -> None:
+        """stop_distance must be > 0 (ATR-based, INV-11)."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.stop_distance > 0, "stop_distance must be > 0"
+
+    def test_target_distance_positive(self) -> None:
+        """target_distance must be > 0."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.target_distance > 0
+
+    def test_target_equals_stop_times_rr_ratio(self) -> None:
+        """target_distance = stop_distance * rr_ratio (default 1.5)."""
+        strategy = DonchianBreakout(20, rr_ratio=1.5, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 1.5) < 1e-10, (
+                f"target={sig.target_distance} != stop={sig.stop_distance} * 1.5"
+            )
+
+    def test_custom_rr_ratio_applied(self) -> None:
+        strategy = DonchianBreakout(20, rr_ratio=2.0, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 2.0) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# quality_score
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutQualityScore:
+    def test_quality_score_in_range(self) -> None:
+        """quality_score must be in [0, 1]."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        for df in [_upward_breakout_df(20), _downward_breakout_df(20)]:
+            signals = strategy.generate_signals(df)
+            for sig in signals:
+                assert 0.0 <= sig.quality_score <= 1.0, (
+                    f"quality_score {sig.quality_score} out of [0,1]"
+                )
+
+    def test_larger_breakout_yields_higher_quality(self) -> None:
+        """A bigger close excess beyond the channel edge → higher quality_score."""
+        n_flat = 30
+        flat_price = 1.2000
+        flat_closes = [flat_price] * n_flat
+        flat_highs = [flat_price * 1.001] * n_flat
+        flat_lows = [flat_price * 0.999] * n_flat
+
+        # Small breakout
+        small_break = flat_price * 1.002
+        df_small = _make_candles(
+            flat_closes + [small_break],
+            highs=flat_highs + [small_break * 1.001],
+            lows=flat_lows + [small_break * 0.999],
+        )
+        # Large breakout
+        large_break = flat_price * 1.020
+        df_large = _make_candles(
+            flat_closes + [large_break],
+            highs=flat_highs + [large_break * 1.001],
+            lows=flat_lows + [large_break * 0.999],
+        )
+
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        signals_small = strategy.generate_signals(df_small)
+        signals_large = strategy.generate_signals(df_large)
+
+        assert signals_small, "Expected signal on small breakout"
+        assert signals_large, "Expected signal on large breakout"
+        assert signals_large[-1].quality_score > signals_small[-1].quality_score, (
+            "Larger breakout should yield higher quality_score"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-03: generated_at
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutTimestamp:
+    def test_generated_at_is_utc_aware(self) -> None:
+        """generated_at must be UTC-aware (INV-03)."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.generated_at.tzinfo is not None, "generated_at must be UTC-aware"
+
+    def test_generated_at_is_bar_timestamp_not_now(self) -> None:
+        """generated_at must be the bar's close timestamp, not datetime.now() (INV-03)."""
+        start = _utc(2024, 3, 1)
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        # Rebuild with a known start time
+        n = len(df)
+        df["time"] = pd.to_datetime(
+            [start + timedelta(hours=i) for i in range(n)], utc=True
+        )
+        signals = strategy.generate_signals(df)
+        now = datetime.now(timezone.utc)
+        for sig in signals:
+            # Must be strictly before test execution time (data is historical)
+            assert sig.generated_at < now
+            # Must be within the DataFrame's time range
+            assert df["time"].min().to_pydatetime() <= sig.generated_at
+            assert sig.generated_at <= df["time"].max().to_pydatetime()
+
+    def test_generated_at_matches_signal_bar_in_df(self) -> None:
+        """generated_at must exactly match the bar's timestamp in the DataFrame."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        df_times = set(df["time"].dt.to_pydatetime())
+        for sig in signals:
+            assert sig.generated_at in df_times, (
+                f"generated_at {sig.generated_at} not found in DataFrame times"
+            )
+
+
+# ---------------------------------------------------------------------------
+# At most one signal per bar
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutAtMostOneSignalPerBar:
+    def test_no_duplicate_timestamps(self) -> None:
+        """No two signals should share the same generated_at timestamp."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        timestamps = [s.generated_at for s in signals]
+        assert len(timestamps) == len(set(timestamps)), (
+            "Duplicate timestamps detected — multiple signals per bar"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No look-ahead check
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutNoLookAhead:
+    def test_channel_uses_prior_bars_not_current(self) -> None:
+        """Verify that removing the last bar (the breakout bar) eliminates the signal.
+
+        If the strategy used the current bar's high in the channel computation,
+        a large current bar would inflate the channel and suppress the signal.
+        With correct shift-by-1, the channel is fixed before the current bar,
+        and a breakout fires reliably.
+        """
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df_with_breakout = _upward_breakout_df(20)
+        df_without_breakout = df_with_breakout.iloc[:-1].copy()
+
+        signals_with = strategy.generate_signals(df_with_breakout)
+        signals_without = strategy.generate_signals(df_without_breakout)
+
+        long_with = [s for s in signals_with if s.direction == Direction.LONG]
+        long_without = [s for s in signals_without if s.direction == Direction.SHORT or s.direction == Direction.LONG]
+
+        assert len(long_with) >= 1, "Expected LONG on breakout bar"
+        # After removing the breakout bar there should be no new signal at that timestamp
+        breakout_time = long_with[-1].generated_at
+        without_at_breakout = [s for s in long_without if s.generated_at == breakout_time]
+        assert len(without_at_breakout) == 0, (
+            "Signal at breakout timestamp should not appear when breakout bar is absent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# channel_period parametrize: {20, 55}
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutClassicPeriods:
+    @pytest.mark.parametrize("channel_period", [20, 55])
+    def test_long_signal_at_classic_period(self, channel_period: int) -> None:
+        """LONG signal fires at both channel_period=20 and channel_period=55."""
+        strategy = DonchianBreakout(channel_period, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(channel_period)
+        signals = strategy.generate_signals(df)
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1, (
+            f"DonchianBreakout({channel_period}) should produce LONG on upward breakout"
+        )
+        for sig in long_signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+            assert 0.0 <= sig.quality_score <= 1.0
+
+    @pytest.mark.parametrize("channel_period", [20, 55])
+    def test_short_signal_at_classic_period(self, channel_period: int) -> None:
+        """SHORT signal fires at both channel_period=20 and channel_period=55."""
+        strategy = DonchianBreakout(channel_period, instrument="EUR_USD", timeframe="H1")
+        df = _downward_breakout_df(channel_period)
+        signals = strategy.generate_signals(df)
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1, (
+            f"DonchianBreakout({channel_period}) should produce SHORT on downward breakout"
+        )
+        for sig in short_signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+            assert 0.0 <= sig.quality_score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDonchianBreakoutEdgeCases:
+    def test_insufficient_data_returns_empty(self) -> None:
+        """DataFrame shorter than channel_period + 1 must return empty list."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _make_candles([1.2] * 15)  # fewer than 20+1=21
+        signals = strategy.generate_signals(df)
+        assert signals == []
+
+    def test_exactly_channel_period_plus_one_row_returns_empty_or_signal(self) -> None:
+        """With exactly channel_period + 1 rows, a breakout bar can produce a signal
+        only if the last bar closes above the (single-row) channel high."""
+        # With min_periods=channel_period, we need exactly channel_period bars
+        # in the rolling window before shift — at row channel_period (0-indexed),
+        # the shifted channel covers rows [0, channel_period-1].
+        channel_period = 20
+        strategy = DonchianBreakout(channel_period, instrument="EUR_USD", timeframe="H1")
+        df = _make_candles([1.2] * (channel_period + 1))
+        signals = strategy.generate_signals(df)
+        # Flat data: close == channel_high (the flat level), so no strict breakout.
+        assert signals == []
+
+    def test_does_not_mutate_input_df(self) -> None:
+        """generate_signals must not modify the caller's DataFrame."""
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        original_columns = set(df.columns)
+        original_shape = df.shape
+        _ = strategy.generate_signals(df)
+        assert set(df.columns) == original_columns
+        assert df.shape == original_shape
+
+    def test_instrument_and_timeframe_propagated(self) -> None:
+        strategy = DonchianBreakout(20, instrument="GBP_USD", timeframe="D")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.instrument == "GBP_USD"
+            assert sig.timeframe == "D"
+
+    def test_strategy_name_in_signal(self) -> None:
+        strategy = DonchianBreakout(20, instrument="EUR_USD", timeframe="H1")
+        df = _upward_breakout_df(20)
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.strategy_name == "DonchianBreakout(20)"
+
+    def test_missing_required_columns_raises(self) -> None:
+        strategy = DonchianBreakout(20)
+        df = pd.DataFrame({"time": [], "close_bid": []})
+        with pytest.raises(ValueError, match="missing required columns"):
+            strategy.generate_signals(df)


### PR DESCRIPTION
Closes #24.

## Summary

Adds `DonchianBreakout(Strategy)` to `strategies/trend.py`:

- **LONG** when `close > rolling_max(high, channel_period).shift(1)` — prior N-bar channel high, no look-ahead
- **SHORT** when `close < rolling_min(low, channel_period).shift(1)` — prior N-bar channel low, no look-ahead
- No signal while price stays inside the channel; at most one signal per bar
- `stop_distance` = `_indicators.atr(df, 14)` (shared helper, INV-11); `target_distance` = `stop × rr_ratio` (default 1.5)
- `quality_score` = normalised close excess beyond channel edge / channel width, clamped [0, 1]
- `generated_at` = bar close timestamp, UTC-aware (INV-03)
- Tested at `channel_period` ∈ {20, 55} (classic Donchian / Turtle values)

## Files changed

- `strategies/trend.py` — `DonchianBreakout` class added (≈160 lines)
- `strategies/__init__.py` — re-exports `DonchianBreakout`, `MACrossover`
- `tests/test_donchian_breakout.py` — 32 new tests (new file)
- `.claude/context/strategies.md` — session entry appended

## Verification

```
pytest tests/test_donchian_breakout.py -v   → 32 passed, exit 0
pytest -v (full suite)                       → 214 passed, exit 0
mypy strategies/                             → Success: no issues found in 4 source files, exit 0
```

No new runtime dependencies.