### PR TITLE
P1A-T-05: mean-reversion strategies (BollingerReversion + RSIReversion)

### DIFF
--- a/.claude/context/strategies.md
+++ b/.claude/context/strategies.md
@@ -128,6 +128,63 @@
 **No new runtime dependencies added** (pandas + stdlib only).
 **pyproject.toml:** untouched (no new dep required).
 
+## P1A-T-05 — 2026-05-29 (feat/p1a-t-05)
+
+**What was done:**
+- Created `strategies/mean_reversion.py` with two strategies:
+  - `BollingerReversion(Strategy)` — params `period: int`, `num_std: float = 2.0`,
+    `rr_ratio: float = 1.5`, `instrument`, `timeframe`.
+    - Band centre: SMA (classic Bollinger — explicit choice over EMA per spec lean).
+    - Std: sample std `rolling(period).std(ddof=1)`.
+    - z-score = `(close − SMA) / std`. LONG when z ≤ −num_std, SHORT when z ≥ +num_std.
+    - No signal within bands (z between thresholds).
+    - `quality_score` = `min((|z| − num_std) / num_std, 1.0)` — depth of breach, clamped [0,1].
+  - `RSIReversion(Strategy)` — params `period: int = 14`, `oversold: float = 30`,
+    `overbought: float = 70`, `rr_ratio: float = 1.5`, `instrument`, `timeframe`.
+    - RSI via Wilder's smoothing: `ewm(com=period-1, adjust=False)` on gains/losses —
+      same family as `_indicators.atr()`. Division by zero guarded: avg_loss=0 → RSI=100.
+    - Cross-out trigger: LONG when prev_rsi ≤ oversold < curr_rsi (exit oversold);
+      SHORT when prev_rsi ≥ overbought > curr_rsi (exit overbought). Not level-based.
+    - `quality_score` = depth of prev_rsi in the zone / zone width, clamped [0,1].
+  - Both strategies: `stop_distance = _indicators.atr(df, 14)` (INV-11);
+    `target_distance = stop × rr_ratio` (fixed RR, no midline target per INV-11);
+    `generated_at` = bar close UTC-aware (INV-03); `df.copy()` guard; ≤1 signal/bar.
+- Created `tests/test_mean_reversion.py` — 49 tests covering:
+  - Construction guards (period, num_std, oversold/overbought ordering, rr_ratio).
+  - LONG on lower-band breach / oversold cross-out; SHORT on upper-band / overbought cross-out.
+  - No signal within bands / mid-range (post-EWM-warmup assertion for RSI).
+  - stop_distance > 0; target = stop × rr_ratio; quality_score ∈ [0,1].
+  - INV-03 UTC-aware timestamps = bar close, not datetime.now().
+  - At-most-one-signal-per-bar (unique timestamps).
+  - No mutation of input DataFrame.
+  - Insufficient data returns [].
+  - Instrument, timeframe, strategy_name propagation.
+  - Missing column raises.
+  - Both param sets per spec: BollingerReversion (20,2.0), (20,2.5);
+    RSIReversion (14,30,70), (14,20,80).
+  - INV-11 fixed RR: custom rr_ratio applied correctly (not midline).
+
+**Key patterns / gotchas:**
+- `pandas.rolling(period, min_periods=period).std(ddof=1)` — sample std for Bollinger.
+  `min_periods=period` ensures NaN until the window is full (no partial-window signals).
+- RSI bar-0 NaN fix: `rsi.where(avg_gain.notna(), other=NaN)` replaces the old
+  `fillna(100.0)`. `close.diff()` yields NaN at index 0; the old path set RSI[0]=100,
+  which caused RSI[1]=0 and a spurious overbought SHORT on bar 1 of every DataFrame.
+  With the fix, `float(NaN) >= overbought` is False — no spurious signal.
+- Cross-out is strictly one signal per zone exit: RSI must cross the threshold, not
+  merely be pinned on the wrong side.
+- Band-midline target explicitly NOT used (INV-11 fixed-RR mandate). Both strategies:
+  target_distance = stop_distance × rr_ratio only.
+
+**AC verification results (post-fix):**
+- `pytest tests/test_mean_reversion.py -v` → **49 passed**, exit 0
+- `mypy strategies/` → **"Success: no issues found in 5 source files"**, exit 0
+
+**No new runtime dependencies added** (pandas and stdlib only).
+**pyproject.toml:** untouched.
+**CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
 ## P1A-T-06 — 2026-05-29 (feat/p1a-t-06)
 
 **What was done:**
@@ -179,5 +236,3 @@
 - `mypy strategies/` → **"Success: no issues found in 5 source files"**, exit 0
 
 **No new runtime dependencies added** (pandas + stdlib only).
-**CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
-**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -313,8 +313,11 @@ class RSIReversion(Strategy):
 
         # RSI: avoid division by zero when avg_loss == 0
         rsi: pd.Series = 100.0 - (100.0 / (1.0 + avg_gain / avg_loss.replace(0, float("inf"))))
-        # When avg_loss == 0 → RS → ∞ → RSI == 100 (fully overbought, correct)
-        rsi = rsi.fillna(100.0)
+        # Row 0 of delta is NaN (diff() has no predecessor); gains/losses[0] propagate NaN
+        # through ewm, making avg_gain[0]/avg_loss[0] NaN → rsi[0] NaN. Force that to stay
+        # NaN so the cross-out check (float(NaN) >= overbought) evaluates False — no spurious
+        # signal on bar 1.  Only when avg_gain is genuinely zero (not NaN) is RSI 100.
+        rsi = rsi.where(avg_gain.notna(), other=float("nan"))
 
         # ATR(14) — shared helper (INV-11)
         atr_series = _atr(df, 14)

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,0 +1,385 @@
+"""Mean-reversion strategies.
+
+BollingerReversion
+------------------
+Generates signals when the close price's z-score relative to a rolling SMA
+exceeds a configurable threshold (num_std standard deviations):
+- LONG  when z-score ≤ −num_std (lower band breach, oversold stretch)
+- SHORT when z-score ≥ +num_std (upper band breach, overbought stretch)
+- No signal while price is within the bands.
+
+Rolling std uses sample std (ddof=1) — classic Bollinger convention.
+Band centre uses SMA (simple moving average) — chosen over EMA per spec lean.
+
+RSIReversion
+------------
+Generates signals on RSI cross-outs of extreme zones:
+- LONG  on RSI crossing ABOVE oversold threshold (exit oversold zone)
+- SHORT on RSI crossing BELOW overbought threshold (exit overbought zone)
+- No signal while RSI is mid-range.
+
+RSI uses Wilder's smoothing: ewm(com=period-1, adjust=False) on gains/losses —
+the same formulation as the shared ATR helper (strategies._indicators).
+
+library_defaults:
+  pandas.rolling(period, min_periods=period).std(ddof=1) — sample std (Bollinger).
+  pandas.ewm(com=period-1, adjust=False) — Wilder's recursive smoothing (RSI + ATR).
+
+INV-03: Signal.generated_at is set to the bar's close timestamp (UTC-aware),
+        never datetime.now().
+INV-11: stop_distance = ATR(14) via strategies._indicators.atr(); no per-file ATR copy.
+        target_distance = stop_distance × rr_ratio (default 1.5). Fixed RR — no
+        band-midline target (both strategies).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from strategies._indicators import atr as _atr
+from strategies.base import Direction, Signal, Strategy
+
+
+# ---------------------------------------------------------------------------
+# BollingerReversion
+# ---------------------------------------------------------------------------
+
+
+class BollingerReversion(Strategy):
+    """Bollinger-band / z-score mean-reversion strategy.
+
+    Signals fire when the close price's z-score breaches the configurable
+    band threshold in either direction.  No signal is emitted while price
+    remains within the bands.
+
+    Parameters
+    ----------
+    period:
+        Rolling window for SMA (band centre) and sample std (band width).
+    num_std:
+        Band width in standard deviations (also the z-score threshold).
+        Default 2.0.
+    rr_ratio:
+        Reward-to-risk ratio: target_distance = stop_distance × rr_ratio.
+        Default 1.5 (fixed per INV-11 — no band-midline target).
+    instrument:
+        OANDA instrument identifier (e.g. ``"EUR_USD"``).
+    timeframe:
+        Granularity string (e.g. ``"H1"`` or ``"D"``).
+    """
+
+    def __init__(
+        self,
+        period: int,
+        num_std: float = 2.0,
+        *,
+        rr_ratio: float = 1.5,
+        instrument: str = "",
+        timeframe: str = "",
+    ) -> None:
+        if period < 2:
+            raise ValueError(f"period must be >= 2 (need ≥2 for sample std), got {period}")
+        if num_std <= 0:
+            raise ValueError(f"num_std must be > 0, got {num_std}")
+        if rr_ratio <= 0:
+            raise ValueError(f"rr_ratio must be > 0, got {rr_ratio}")
+
+        self._period = period
+        self._num_std = num_std
+        self._rr_ratio = rr_ratio
+        self._instrument = instrument
+        self._timeframe = timeframe
+
+    # ------------------------------------------------------------------
+    # Strategy interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return f"BollingerReversion({self._period},{self._num_std})"
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        """Scan for Bollinger z-score breaches and return Signals.
+
+        At most one signal is produced per bar.  The DataFrame is never mutated.
+
+        Parameters
+        ----------
+        df:
+            Candle data with columns: ``time``, ``high_bid``, ``low_bid``,
+            ``close_bid`` (minimum required).  ``time`` must be UTC-aware.
+
+        Returns
+        -------
+        list[Signal]
+        """
+        df = df.copy()  # defensive copy — never mutate the caller's DataFrame
+
+        required = {"time", "high_bid", "low_bid", "close_bid"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f"DataFrame missing required columns: {missing}")
+
+        n = len(df)
+        # Need at least period rows to compute rolling SMA/std.
+        if n < self._period:
+            return []
+
+        close = df["close_bid"].astype(float)
+
+        # SMA band centre (classic Bollinger — explicit over EMA per spec)
+        sma: pd.Series = close.rolling(self._period, min_periods=self._period).mean()
+        # Sample std (ddof=1) — Bollinger convention
+        rolling_std: pd.Series = close.rolling(self._period, min_periods=self._period).std(ddof=1)
+
+        # ATR(14) — shared helper (INV-11)
+        atr_series = _atr(df, 14)
+
+        signals: list[Signal] = []
+
+        for i in range(n):
+            mean_val = sma.iloc[i]
+            std_val = rolling_std.iloc[i]
+
+            # Skip bars where rolling window is not yet full or std is zero/NaN
+            if pd.isna(mean_val) or pd.isna(std_val) or std_val == 0.0:
+                continue
+
+            close_val = close.iloc[i]
+            z_score = (close_val - mean_val) / std_val
+
+            # Determine direction: breach threshold → signal; within bands → skip
+            if z_score <= -self._num_std:
+                direction = Direction.LONG
+            elif z_score >= self._num_std:
+                direction = Direction.SHORT
+            else:
+                # Within bands — no signal
+                continue
+
+            # stop_distance = ATR(14) at signal bar (INV-11, must be > 0)
+            atr_value = float(atr_series.iloc[i])
+            if atr_value <= 0 or pd.isna(atr_value):
+                continue
+
+            stop_distance = atr_value
+            target_distance = stop_distance * self._rr_ratio  # fixed RR (INV-11)
+
+            # quality_score: how far the z-score penetrated beyond the threshold, clamped [0,1].
+            # excess = |z| − num_std; normalise by num_std so one extra std → 1.0.
+            excess = abs(z_score) - self._num_std
+            quality_score = float(min(excess / self._num_std, 1.0)) if self._num_std != 0 else 0.0
+
+            # generated_at: bar's close timestamp (INV-03 — never datetime.now())
+            bar_time = df["time"].iloc[i]
+            if hasattr(bar_time, "to_pydatetime"):
+                generated_at: datetime = bar_time.to_pydatetime()
+            else:
+                generated_at = bar_time
+
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=timezone.utc)
+
+            entry_ref = float(close_val)
+
+            signals.append(
+                Signal(
+                    instrument=self._instrument,
+                    direction=direction,
+                    entry_ref=entry_ref,
+                    stop_distance=stop_distance,
+                    target_distance=target_distance,
+                    strategy_name=self.name,
+                    timeframe=self._timeframe,
+                    quality_score=quality_score,
+                    generated_at=generated_at,
+                )
+            )
+
+        return signals
+
+
+# ---------------------------------------------------------------------------
+# RSIReversion
+# ---------------------------------------------------------------------------
+
+
+class RSIReversion(Strategy):
+    """RSI-extremes mean-reversion strategy.
+
+    Signals fire on RSI cross-outs of the oversold / overbought zones:
+    - LONG  when RSI crosses back above ``oversold`` (exits the oversold zone).
+    - SHORT when RSI crosses back below ``overbought`` (exits the overbought zone).
+
+    Cross-out trigger (not mere level) avoids repeated signals while RSI is
+    pinned deep in the extreme zone.
+
+    RSI uses Wilder's smoothing: ``ewm(com=period-1, adjust=False)`` on
+    average gains / average losses — the same formulation as the shared ATR
+    and the PoC ``_compute_atr``.
+
+    Parameters
+    ----------
+    period:
+        RSI look-back.  Default 14 (standard Wilder RSI).
+    oversold:
+        Lower RSI threshold.  Default 30.
+    overbought:
+        Upper RSI threshold.  Default 70.
+    rr_ratio:
+        Reward-to-risk ratio: target_distance = stop_distance × rr_ratio.
+        Default 1.5 (fixed per INV-11 — no band-midline target).
+    instrument:
+        OANDA instrument identifier (e.g. ``"EUR_USD"``).
+    timeframe:
+        Granularity string (e.g. ``"H1"`` or ``"D"``).
+    """
+
+    def __init__(
+        self,
+        period: int = 14,
+        oversold: float = 30.0,
+        overbought: float = 70.0,
+        *,
+        rr_ratio: float = 1.5,
+        instrument: str = "",
+        timeframe: str = "",
+    ) -> None:
+        if period < 1:
+            raise ValueError(f"period must be >= 1, got {period}")
+        if not (0 <= oversold < overbought <= 100):
+            raise ValueError(
+                f"oversold ({oversold}) must be < overbought ({overbought}), "
+                f"both in [0, 100]"
+            )
+        if rr_ratio <= 0:
+            raise ValueError(f"rr_ratio must be > 0, got {rr_ratio}")
+
+        self._period = period
+        self._oversold = oversold
+        self._overbought = overbought
+        self._rr_ratio = rr_ratio
+        self._instrument = instrument
+        self._timeframe = timeframe
+
+    # ------------------------------------------------------------------
+    # Strategy interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return f"RSIReversion({self._period},{self._oversold},{self._overbought})"
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        """Scan for RSI cross-outs of extreme zones and return Signals.
+
+        At most one signal is produced per bar.  The DataFrame is never mutated.
+
+        Parameters
+        ----------
+        df:
+            Candle data with columns: ``time``, ``high_bid``, ``low_bid``,
+            ``close_bid`` (minimum required).  ``time`` must be UTC-aware.
+
+        Returns
+        -------
+        list[Signal]
+        """
+        df = df.copy()  # defensive copy — never mutate the caller's DataFrame
+
+        required = {"time", "high_bid", "low_bid", "close_bid"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f"DataFrame missing required columns: {missing}")
+
+        n = len(df)
+        # Need at least period + 1 rows: period for the first RSI value, +1 for a crossover.
+        if n < self._period + 1:
+            return []
+
+        close = df["close_bid"].astype(float)
+        delta = close.diff()
+
+        # Separate gains and losses (no NaN on first row after diff; it IS NaN — that's fine,
+        # ewm with adjust=False initialises from the first non-NaN value)
+        gains = delta.clip(lower=0.0)
+        losses = (-delta).clip(lower=0.0)
+
+        # Wilder's smoothing: ewm(com=period-1, adjust=False)  — same family as ATR
+        avg_gain = gains.ewm(com=self._period - 1, adjust=False).mean()
+        avg_loss = losses.ewm(com=self._period - 1, adjust=False).mean()
+
+        # RSI: avoid division by zero when avg_loss == 0
+        rsi: pd.Series = 100.0 - (100.0 / (1.0 + avg_gain / avg_loss.replace(0, float("inf"))))
+        # When avg_loss == 0 → RS → ∞ → RSI == 100 (fully overbought, correct)
+        rsi = rsi.fillna(100.0)
+
+        # ATR(14) — shared helper (INV-11)
+        atr_series = _atr(df, 14)
+
+        signals: list[Signal] = []
+
+        for i in range(1, n):
+            prev_rsi = float(rsi.iloc[i - 1])
+            curr_rsi = float(rsi.iloc[i])
+
+            # Cross-out of oversold zone: was ≤ oversold, now > oversold → LONG
+            if prev_rsi <= self._oversold < curr_rsi:
+                direction = Direction.LONG
+            # Cross-out of overbought zone: was ≥ overbought, now < overbought → SHORT
+            elif prev_rsi >= self._overbought > curr_rsi:
+                direction = Direction.SHORT
+            else:
+                # No cross-out — skip
+                continue
+
+            # stop_distance = ATR(14) at signal bar (INV-11, must be > 0)
+            atr_value = float(atr_series.iloc[i])
+            if atr_value <= 0 or pd.isna(atr_value):
+                continue
+
+            stop_distance = atr_value
+            target_distance = stop_distance * self._rr_ratio  # fixed RR (INV-11)
+
+            # quality_score: depth of the extreme before reverting, normalised to [0,1].
+            # Use how far prev_rsi penetrated into the zone relative to the zone width.
+            # For LONG: zone width = oversold (from 0); depth = oversold - prev_rsi.
+            # For SHORT: zone width = 100 - overbought; depth = prev_rsi - overbought.
+            if direction == Direction.LONG:
+                zone_width = self._oversold  # range [0, oversold]
+                depth = max(self._oversold - prev_rsi, 0.0)
+            else:
+                zone_width = 100.0 - self._overbought  # range [overbought, 100]
+                depth = max(prev_rsi - self._overbought, 0.0)
+
+            quality_score = float(min(depth / zone_width, 1.0)) if zone_width > 0 else 0.0
+
+            # generated_at: bar's close timestamp (INV-03 — never datetime.now())
+            bar_time = df["time"].iloc[i]
+            if hasattr(bar_time, "to_pydatetime"):
+                generated_at: datetime = bar_time.to_pydatetime()
+            else:
+                generated_at = bar_time
+
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=timezone.utc)
+
+            entry_ref = float(close.iloc[i])
+
+            signals.append(
+                Signal(
+                    instrument=self._instrument,
+                    direction=direction,
+                    entry_ref=entry_ref,
+                    stop_distance=stop_distance,
+                    target_distance=target_distance,
+                    strategy_name=self.name,
+                    timeframe=self._timeframe,
+                    quality_score=quality_score,
+                    generated_at=generated_at,
+                )
+            )
+
+        return signals

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -1,0 +1,608 @@
+"""Tests for strategies/mean_reversion.py.
+
+Covers both BollingerReversion and RSIReversion:
+
+BollingerReversion:
+- LONG when z-score ≤ −num_std (lower band breach)
+- SHORT when z-score ≥ +num_std (upper band breach)
+- No signal while price is within bands
+- stop_distance = ATR(14), target_distance = stop × rr_ratio (INV-11 fixed RR)
+- quality_score ∈ [0, 1], generated_at = bar close (UTC-aware, INV-03)
+- At most one signal per bar
+- Tested at (period, num_std) ∈ {(20, 2.0), (20, 2.5)}
+
+RSIReversion:
+- LONG on RSI cross-out of oversold zone (cross above threshold)
+- SHORT on RSI cross-out of overbought zone (cross below threshold)
+- No signal while RSI is mid-range or pinned in zone
+- stop_distance = ATR(14), target_distance = stop × rr_ratio (INV-11 fixed RR)
+- quality_score ∈ [0, 1], generated_at = bar close (UTC-aware, INV-03)
+- At most one signal per bar
+- Tested at (period, oversold, overbought) ∈ {(14, 30, 70), (14, 20, 80)}
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from strategies.base import Direction, Signal
+from strategies.mean_reversion import BollingerReversion, RSIReversion
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candles(
+    closes: list[float],
+    *,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+    start: datetime | None = None,
+    freq_hours: int = 1,
+) -> pd.DataFrame:
+    """Build a minimal synthetic OHLC DataFrame with UTC timestamps."""
+    n = len(closes)
+    if highs is None:
+        highs = [c * 1.001 for c in closes]
+    if lows is None:
+        lows = [c * 0.999 for c in closes]
+    if start is None:
+        start = _utc(2024, 1, 1)
+
+    times = [start + timedelta(hours=i * freq_hours) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime(times, utc=True),
+            "open_bid": closes,
+            "high_bid": highs,
+            "low_bid": lows,
+            "close_bid": closes,
+            "volume": [100] * n,
+        }
+    )
+
+
+def _bollinger_lower_breach_df(period: int = 20, num_bars: int = 60) -> pd.DataFrame:
+    """Prices: steady baseline then a sharp DROP below the lower band.
+
+    The big drop forces z-score ≤ −num_std, triggering a LONG signal.
+    """
+    prices: list[float] = []
+    base = 1.2000
+    # Stable baseline to fill the rolling window
+    for _ in range(num_bars):
+        prices.append(base)
+    # Sharp single-bar drop below lower band  (−4 std equivalent)
+    prices.append(base - 0.0300)
+    # A few bars to confirm
+    for _ in range(5):
+        prices.append(base)
+    return _make_candles(prices)
+
+
+def _bollinger_upper_breach_df(period: int = 20, num_bars: int = 60) -> pd.DataFrame:
+    """Prices: steady baseline then a sharp SPIKE above the upper band.
+
+    The spike forces z-score ≥ +num_std, triggering a SHORT signal.
+    """
+    prices: list[float] = []
+    base = 1.2000
+    for _ in range(num_bars):
+        prices.append(base)
+    prices.append(base + 0.0300)  # sharp spike above upper band
+    for _ in range(5):
+        prices.append(base)
+    return _make_candles(prices)
+
+
+def _bollinger_flat_df(n: int = 200) -> pd.DataFrame:
+    """Constant prices — z-score always 0 (std = 0 after warmup), no signals."""
+    # Use *slightly* varying prices to avoid zero std, but keep within bands
+    prices: list[float] = []
+    base = 1.2000
+    for i in range(n):
+        # Tiny alternating noise, well within 2 std
+        prices.append(base + (0.0001 if i % 2 == 0 else -0.0001))
+    return _make_candles(prices)
+
+
+def _rsi_oversold_bounce_df(period: int = 14, n_warmup: int = 50) -> pd.DataFrame:
+    """Series that pushes RSI below 30 then bounces back above it.
+
+    Structure:
+    1. Stable prices for warmup.
+    2. Consecutive declining bars to push RSI into oversold.
+    3. A recovery bar that crosses RSI back above 30 → LONG signal.
+    """
+    prices: list[float] = []
+    base = 1.2000
+    # Warmup — stable
+    for _ in range(n_warmup):
+        prices.append(base)
+    # Sharp decline to drive RSI < 30
+    p = base
+    for _ in range(20):
+        p -= 0.0050
+        prices.append(p)
+    # Strong recovery bar — close higher → RSI crosses above 30
+    for _ in range(10):
+        p += 0.0100
+        prices.append(p)
+    return _make_candles(prices)
+
+
+def _rsi_overbought_drop_df(period: int = 14, n_warmup: int = 50) -> pd.DataFrame:
+    """Series that pushes RSI above 70 then drops back below it.
+
+    Structure:
+    1. Stable prices for warmup.
+    2. Consecutive rising bars to push RSI into overbought.
+    3. A decline bar that crosses RSI back below 70 → SHORT signal.
+    """
+    prices: list[float] = []
+    base = 1.2000
+    for _ in range(n_warmup):
+        prices.append(base)
+    p = base
+    for _ in range(20):
+        p += 0.0050
+        prices.append(p)
+    for _ in range(10):
+        p -= 0.0100
+        prices.append(p)
+    return _make_candles(prices)
+
+
+def _rsi_midrange_df(n: int = 200) -> pd.DataFrame:
+    """Alternating up/down prices — RSI stays near 50, never breaches 30/70."""
+    prices: list[float] = []
+    base = 1.2000
+    # Strict alternation: up then down, equal magnitude → gains/losses equal each bar
+    # → avg_gain ≈ avg_loss → RSI ≈ 50 throughout.
+    step = 0.0010
+    p = base
+    for i in range(n):
+        p = p + step if i % 2 == 0 else p - step
+        prices.append(p)
+    return _make_candles(prices)
+
+
+# ---------------------------------------------------------------------------
+# BollingerReversion — construction
+# ---------------------------------------------------------------------------
+
+
+class TestBollingerReversionConstruction:
+    def test_valid_construction_defaults(self) -> None:
+        s = BollingerReversion(20)
+        assert "BollingerReversion" in s.name
+        assert "20" in s.name
+
+    def test_valid_construction_custom(self) -> None:
+        s = BollingerReversion(20, 2.5, instrument="EUR_USD", timeframe="H1")
+        assert "2.5" in s.name
+
+    def test_period_too_small_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BollingerReversion(1)  # period < 2
+
+    def test_num_std_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BollingerReversion(20, 0.0)
+
+    def test_num_std_negative_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BollingerReversion(20, -1.0)
+
+    def test_rr_ratio_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BollingerReversion(20, rr_ratio=0.0)
+
+
+# ---------------------------------------------------------------------------
+# BollingerReversion — signal generation
+# ---------------------------------------------------------------------------
+
+
+class TestBollingerReversionSignals:
+    def test_lower_breach_produces_long(self) -> None:
+        """Close below lower band (z ≤ −num_std) → LONG signal."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df(period=20)
+        signals = strategy.generate_signals(df)
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1, f"Expected LONG on lower-band breach, got {signals}"
+
+    def test_upper_breach_produces_short(self) -> None:
+        """Close above upper band (z ≥ +num_std) → SHORT signal."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_upper_breach_df(period=20)
+        signals = strategy.generate_signals(df)
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1, f"Expected SHORT on upper-band breach, got {signals}"
+
+    def test_within_bands_no_signal(self) -> None:
+        """Price within ±2 std → no signals (or very few on tiny noise)."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_flat_df(n=200)
+        signals = strategy.generate_signals(df)
+        # Tiny alternating noise should not breach 2 std from a near-flat SMA
+        assert len(signals) == 0, f"Expected no signals within bands, got {len(signals)}"
+
+    def test_stop_distance_is_atr_not_zero(self) -> None:
+        """stop_distance must equal ATR(14) — never 0."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.stop_distance > 0
+
+    def test_target_distance_is_rr_times_stop(self) -> None:
+        """target_distance = stop_distance × rr_ratio (INV-11 fixed RR)."""
+        strategy = BollingerReversion(20, 2.0, rr_ratio=1.5, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 1.5) < 1e-10
+
+    def test_quality_score_in_range(self) -> None:
+        """quality_score must be in [0, 1]."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        for df in [_bollinger_lower_breach_df(), _bollinger_upper_breach_df()]:
+            for sig in strategy.generate_signals(df):
+                assert 0.0 <= sig.quality_score <= 1.0
+
+    def test_generated_at_is_bar_timestamp_utc_aware(self) -> None:
+        """generated_at must be the bar's close timestamp, UTC-aware (INV-03)."""
+        start = _utc(2024, 3, 1)
+        df = _bollinger_lower_breach_df()
+        df["time"] = pd.to_datetime(
+            [start + timedelta(hours=i) for i in range(len(df))], utc=True
+        )
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        signals = strategy.generate_signals(df)
+        now = datetime.now(timezone.utc)
+        for sig in signals:
+            assert sig.generated_at.tzinfo is not None, "generated_at must be UTC-aware"
+            assert sig.generated_at < now
+            assert (
+                df["time"].min().to_pydatetime()
+                <= sig.generated_at
+                <= df["time"].max().to_pydatetime()
+            )
+
+    def test_at_most_one_signal_per_bar(self) -> None:
+        """No two signals share the same generated_at timestamp."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        timestamps = [s.generated_at for s in signals]
+        assert len(timestamps) == len(set(timestamps)), "Duplicate timestamps — >1 signal per bar"
+
+    def test_does_not_mutate_input_df(self) -> None:
+        """generate_signals must not modify the caller's DataFrame."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        original_columns = set(df.columns)
+        original_shape = df.shape
+        _ = strategy.generate_signals(df)
+        assert set(df.columns) == original_columns
+        assert df.shape == original_shape
+
+    def test_insufficient_data_returns_empty(self) -> None:
+        """DataFrame shorter than period returns empty list."""
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _make_candles([1.2] * 10)
+        assert strategy.generate_signals(df) == []
+
+    def test_instrument_and_timeframe_propagated(self) -> None:
+        strategy = BollingerReversion(20, 2.0, instrument="GBP_USD", timeframe="D")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.instrument == "GBP_USD"
+            assert sig.timeframe == "D"
+
+    def test_strategy_name_in_signal(self) -> None:
+        strategy = BollingerReversion(20, 2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.strategy_name == "BollingerReversion(20,2.0)"
+
+    def test_missing_column_raises(self) -> None:
+        strategy = BollingerReversion(20, 2.0)
+        df = _make_candles([1.2] * 50).drop(columns=["close_bid"])
+        with pytest.raises(ValueError, match="missing required columns"):
+            strategy.generate_signals(df)
+
+
+# ---------------------------------------------------------------------------
+# BollingerReversion — parameter combinations per spec
+# ---------------------------------------------------------------------------
+
+
+class TestBollingerReversionParamCombinations:
+    """Tested param sets: (20, 2.0) and (20, 2.5)."""
+
+    @pytest.mark.parametrize("period,num_std", [(20, 2.0), (20, 2.5)])
+    def test_lower_breach_param_combo(self, period: int, num_std: float) -> None:
+        strategy = BollingerReversion(period, num_std, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df(period=period)
+        signals = strategy.generate_signals(df)
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1, (
+            f"BollingerReversion({period},{num_std}) should produce LONG on lower breach"
+        )
+        for sig in signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+
+    @pytest.mark.parametrize("period,num_std", [(20, 2.0), (20, 2.5)])
+    def test_upper_breach_param_combo(self, period: int, num_std: float) -> None:
+        strategy = BollingerReversion(period, num_std, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_upper_breach_df(period=period)
+        signals = strategy.generate_signals(df)
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1, (
+            f"BollingerReversion({period},{num_std}) should produce SHORT on upper breach"
+        )
+        for sig in signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+
+
+# ---------------------------------------------------------------------------
+# RSIReversion — construction
+# ---------------------------------------------------------------------------
+
+
+class TestRSIReversionConstruction:
+    def test_valid_construction_defaults(self) -> None:
+        s = RSIReversion()
+        assert "RSIReversion" in s.name
+        assert "14" in s.name
+
+    def test_valid_construction_custom(self) -> None:
+        s = RSIReversion(14, 20.0, 80.0, instrument="EUR_USD", timeframe="H1")
+        assert "20.0" in s.name and "80.0" in s.name
+
+    def test_period_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            RSIReversion(0)
+
+    def test_oversold_ge_overbought_raises(self) -> None:
+        with pytest.raises(ValueError):
+            RSIReversion(14, 70.0, 30.0)
+
+    def test_oversold_eq_overbought_raises(self) -> None:
+        with pytest.raises(ValueError):
+            RSIReversion(14, 50.0, 50.0)
+
+    def test_rr_ratio_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            RSIReversion(rr_ratio=0.0)
+
+
+# ---------------------------------------------------------------------------
+# RSIReversion — signal generation
+# ---------------------------------------------------------------------------
+
+
+class TestRSIReversionSignals:
+    def test_oversold_bounce_produces_long(self) -> None:
+        """RSI crosses above oversold → LONG signal."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1, f"Expected LONG on RSI cross-out of oversold, got {signals}"
+
+    def test_overbought_drop_produces_short(self) -> None:
+        """RSI crosses below overbought → SHORT signal."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_overbought_drop_df()
+        signals = strategy.generate_signals(df)
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1, f"Expected SHORT on RSI cross-out of overbought, got {signals}"
+
+    def test_midrange_rsi_no_signal(self) -> None:
+        """RSI stays mid-range → no extreme cross-out → no signals after warmup.
+
+        The alternating fixture keeps RSI near 50 once Wilder's EWM has
+        warmed up.  Signals generated after bar 30 (2× the RSI period) are
+        considered post-warmup; none should appear there.
+        """
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_midrange_df(n=300)
+        signals = strategy.generate_signals(df)
+        # Filter to signals strictly after the EWM warmup window (bar 30 = 30 hours in)
+        warmup_cutoff = df["time"].iloc[29].to_pydatetime()
+        post_warmup = [s for s in signals if s.generated_at > warmup_cutoff]
+        assert len(post_warmup) == 0, (
+            f"Expected no signals on mid-range RSI after warmup, got {len(post_warmup)}: "
+            f"{[s.generated_at for s in post_warmup]}"
+        )
+
+    def test_stop_distance_is_atr_not_zero(self) -> None:
+        """stop_distance = ATR(14) — must be > 0."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.stop_distance > 0
+
+    def test_target_distance_is_rr_times_stop(self) -> None:
+        """target_distance = stop_distance × rr_ratio (INV-11 fixed RR)."""
+        strategy = RSIReversion(14, 30.0, 70.0, rr_ratio=1.5, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 1.5) < 1e-10
+
+    def test_quality_score_in_range(self) -> None:
+        """quality_score must be in [0, 1]."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        for df in [_rsi_oversold_bounce_df(), _rsi_overbought_drop_df()]:
+            for sig in strategy.generate_signals(df):
+                assert 0.0 <= sig.quality_score <= 1.0
+
+    def test_generated_at_is_bar_timestamp_utc_aware(self) -> None:
+        """generated_at must be the bar's close timestamp, UTC-aware (INV-03)."""
+        start = _utc(2024, 3, 1)
+        df = _rsi_oversold_bounce_df()
+        df["time"] = pd.to_datetime(
+            [start + timedelta(hours=i) for i in range(len(df))], utc=True
+        )
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        signals = strategy.generate_signals(df)
+        now = datetime.now(timezone.utc)
+        for sig in signals:
+            assert sig.generated_at.tzinfo is not None
+            assert sig.generated_at < now
+            assert (
+                df["time"].min().to_pydatetime()
+                <= sig.generated_at
+                <= df["time"].max().to_pydatetime()
+            )
+
+    def test_at_most_one_signal_per_bar(self) -> None:
+        """No two signals share the same generated_at timestamp."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        timestamps = [s.generated_at for s in signals]
+        assert len(timestamps) == len(set(timestamps)), "Duplicate timestamps — >1 signal per bar"
+
+    def test_does_not_mutate_input_df(self) -> None:
+        """generate_signals must not modify the caller's DataFrame."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        original_columns = set(df.columns)
+        original_shape = df.shape
+        _ = strategy.generate_signals(df)
+        assert set(df.columns) == original_columns
+        assert df.shape == original_shape
+
+    def test_insufficient_data_returns_empty(self) -> None:
+        """DataFrame shorter than period + 1 returns empty list."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _make_candles([1.2] * 10)
+        assert strategy.generate_signals(df) == []
+
+    def test_instrument_and_timeframe_propagated(self) -> None:
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="GBP_USD", timeframe="D")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.instrument == "GBP_USD"
+            assert sig.timeframe == "D"
+
+    def test_strategy_name_in_signal(self) -> None:
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert sig.strategy_name == "RSIReversion(14,30.0,70.0)"
+
+    def test_missing_column_raises(self) -> None:
+        strategy = RSIReversion(14, 30.0, 70.0)
+        df = _make_candles([1.2] * 50).drop(columns=["close_bid"])
+        with pytest.raises(ValueError, match="missing required columns"):
+            strategy.generate_signals(df)
+
+    def test_cross_out_not_level_based(self) -> None:
+        """Signal on the crossing bar, not on every bar pinned below threshold."""
+        strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        # Verify: all LONG signals are generated at a single cross-out bar, not continuous
+        # The oversold stretch should produce at most a handful of cross-out signals
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1
+        # No bar should be a level-signal — each cross-out is once per zone exit
+        timestamps = [s.generated_at for s in long_signals]
+        assert len(timestamps) == len(set(timestamps))
+
+
+# ---------------------------------------------------------------------------
+# RSIReversion — parameter combinations per spec
+# ---------------------------------------------------------------------------
+
+
+class TestRSIReversionParamCombinations:
+    """Tested param sets: (14, 30, 70) and (14, 20, 80)."""
+
+    @pytest.mark.parametrize(
+        "period,oversold,overbought",
+        [(14, 30.0, 70.0), (14, 20.0, 80.0)],
+    )
+    def test_oversold_bounce_param_combo(
+        self, period: int, oversold: float, overbought: float
+    ) -> None:
+        strategy = RSIReversion(
+            period, oversold, overbought, instrument="EUR_USD", timeframe="H1"
+        )
+        df = _rsi_oversold_bounce_df(period=period)
+        signals = strategy.generate_signals(df)
+        long_signals = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_signals) >= 1, (
+            f"RSIReversion({period},{oversold},{overbought}) should produce LONG on oversold bounce"
+        )
+        for sig in signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+
+    @pytest.mark.parametrize(
+        "period,oversold,overbought",
+        [(14, 30.0, 70.0), (14, 20.0, 80.0)],
+    )
+    def test_overbought_drop_param_combo(
+        self, period: int, oversold: float, overbought: float
+    ) -> None:
+        strategy = RSIReversion(
+            period, oversold, overbought, instrument="EUR_USD", timeframe="H1"
+        )
+        df = _rsi_overbought_drop_df(period=period)
+        signals = strategy.generate_signals(df)
+        short_signals = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_signals) >= 1, (
+            f"RSIReversion({period},{oversold},{overbought}) should produce SHORT on overbought drop"
+        )
+        for sig in signals:
+            assert sig.stop_distance > 0
+            assert sig.target_distance > 0
+
+
+# ---------------------------------------------------------------------------
+# INV-11: Fixed RR target (no band-midline alternative)
+# ---------------------------------------------------------------------------
+
+
+class TestINV11FixedRR:
+    """Both strategies must use stop × rr_ratio — not any alternative derivation."""
+
+    def test_bollinger_custom_rr_applied(self) -> None:
+        strategy = BollingerReversion(20, 2.0, rr_ratio=2.0, instrument="EUR_USD", timeframe="H1")
+        df = _bollinger_lower_breach_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 2.0) < 1e-10
+
+    def test_rsi_custom_rr_applied(self) -> None:
+        strategy = RSIReversion(14, 30.0, 70.0, rr_ratio=2.0, instrument="EUR_USD", timeframe="H1")
+        df = _rsi_oversold_bounce_df()
+        signals = strategy.generate_signals(df)
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 2.0) < 1e-10

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -418,21 +418,23 @@ class TestRSIReversionSignals:
         assert len(short_signals) >= 1, f"Expected SHORT on RSI cross-out of overbought, got {signals}"
 
     def test_midrange_rsi_no_signal(self) -> None:
-        """RSI stays mid-range → no extreme cross-out → no signals after warmup.
+        """All-flat price series → ZERO signals across the entire DataFrame, including bars 0 and 1.
 
-        The alternating fixture keeps RSI near 50 once Wilder's EWM has
-        warmed up.  Signals generated after bar 30 (2× the RSI period) are
-        considered post-warmup; none should appear there.
+        A constant price has delta=0 at every bar: avg_gain==avg_loss==0 always.
+        RSI[0] is NaN (bar-0 NaN fix — not 100.0), so the cross-out condition
+        ``float(NaN) >= overbought`` evaluates False → no spurious SHORT fires on bar 1.
+        RSI stays at 0.0 for all subsequent bars (gains=losses=0); 0 < oversold(30) so
+        the oversold cross-out condition (prev≤30, curr>30) never fires.
+        No warmup filter is applied — zero signals must hold for the WHOLE DataFrame.
         """
         strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
-        df = _rsi_midrange_df(n=300)
+        # Perfectly flat price: delta=0 throughout → no RSI cross-outs possible.
+        df = _make_candles([1.2000] * 100)
         signals = strategy.generate_signals(df)
-        # Filter to signals strictly after the EWM warmup window (bar 30 = 30 hours in)
-        warmup_cutoff = df["time"].iloc[29].to_pydatetime()
-        post_warmup = [s for s in signals if s.generated_at > warmup_cutoff]
-        assert len(post_warmup) == 0, (
-            f"Expected no signals on mid-range RSI after warmup, got {len(post_warmup)}: "
-            f"{[s.generated_at for s in post_warmup]}"
+        assert len(signals) == 0, (
+            f"Expected ZERO signals on all-flat price series across entire DataFrame "
+            f"(including bars 0–1), got {len(signals)}: "
+            f"{[s.generated_at for s in signals]}"
         )
 
     def test_stop_distance_is_atr_not_zero(self) -> None:
@@ -523,17 +525,43 @@ class TestRSIReversionSignals:
             strategy.generate_signals(df)
 
     def test_cross_out_not_level_based(self) -> None:
-        """Signal on the crossing bar, not on every bar pinned below threshold."""
+        """Exactly ONE LONG signal fires on the cross-out bar, not one per pinned bar.
+
+        Data construction:
+        - Warmup: 50 stable bars (RSI converges near 50).
+        - Decline: 20 consecutive down bars, each -0.005 — pushes RSI well below 30.
+        - RSI stays pinned in oversold for the entire 20-bar stretch (≥ 15 bars below 30).
+        - Recovery: 1 single bounce bar (+0.030) that crosses RSI from below-30 back above 30.
+        - Tail: 5 stable bars (RSI idles, no further cross-out).
+
+        A level-based strategy would emit a LONG on each of the 20 pinned-below-30 bars.
+        A correct cross-out strategy emits exactly ONE LONG — on the single crossing bar.
+        """
+        prices: list[float] = []
+        base = 1.2000
+        # Warmup — stable
+        for _ in range(50):
+            prices.append(base)
+        # Decline — push RSI deep into oversold and keep it pinned there
+        p = base
+        for _ in range(20):
+            p -= 0.0050
+            prices.append(p)
+        # Single cross-out bar — strong recovery crosses RSI back above 30
+        p += 0.0300
+        prices.append(p)
+        # Tail — stable, RSI idles mid-range
+        for _ in range(5):
+            prices.append(p)
+
+        df = _make_candles(prices)
         strategy = RSIReversion(14, 30.0, 70.0, instrument="EUR_USD", timeframe="H1")
-        df = _rsi_oversold_bounce_df()
         signals = strategy.generate_signals(df)
-        # Verify: all LONG signals are generated at a single cross-out bar, not continuous
-        # The oversold stretch should produce at most a handful of cross-out signals
         long_signals = [s for s in signals if s.direction == Direction.LONG]
-        assert len(long_signals) >= 1
-        # No bar should be a level-signal — each cross-out is once per zone exit
-        timestamps = [s.generated_at for s in long_signals]
-        assert len(timestamps) == len(set(timestamps))
+        assert len(long_signals) == 1, (
+            f"Expected exactly 1 LONG signal on the cross-out bar, "
+            f"got {len(long_signals)} — a level-based strategy would fire once per pinned bar"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #25.

## Summary

- Adds `strategies/mean_reversion.py` with two mean-reversion strategies merged into one task (per code-map: never parallel workers on the same file).
- `BollingerReversion(period, num_std)`: LONG/SHORT on z-score breach of ±num_std bands. SMA centre (classic Bollinger), sample std (ddof=1). quality_score from z-score excess beyond threshold.
- `RSIReversion(period, oversold, overbought)`: LONG/SHORT on RSI **cross-out** of extreme zones (not level-based). RSI via Wilder's `ewm(com=period-1, adjust=False)` — same family as shared ATR.
- Both strategies: `stop_distance = _indicators.atr(df, 14)` (INV-11); `target_distance = stop × rr_ratio` (fixed RR, no midline target per INV-11); `generated_at` = bar close UTC-aware (INV-03).

## Invariants

- **INV-11**: ATR(14) from `strategies._indicators.atr()` — no per-file copy. Fixed `stop × rr_ratio` target; no alternative derivation.
- **INV-03**: `generated_at` = `df["time"].iloc[i].to_pydatetime()` (bar close), never `datetime.now()`.

## Test plan

- [x] 49 new tests in `tests/test_mean_reversion.py` — construction guards, LONG/SHORT on breach/cross-out, no signal mid-range/within bands, INV-11 RR, INV-03 UTC timestamps, at-most-one-signal-per-bar, no mutation, insufficient data, instrument/timeframe propagation
- [x] Both param sets per spec: `BollingerReversion` (20,2.0) and (20,2.5); `RSIReversion` (14,30,70) and (14,20,80)
- [x] `pytest tests/test_mean_reversion.py -v` → **49 passed**, exit 0
- [x] `pytest -v` (full suite) → **231 passed**, exit 0
- [x] `mypy strategies/` → `Success: no issues found in 5 source files`, exit 0