### PR TITLE
P1A-T-06: roc-momentum

### DIFF
--- a/.claude/context/strategies.md
+++ b/.claude/context/strategies.md
@@ -127,5 +127,57 @@
 
 **No new runtime dependencies added** (pandas + stdlib only).
 **pyproject.toml:** untouched (no new dep required).
+
+## P1A-T-06 — 2026-05-29 (feat/p1a-t-06)
+
+**What was done:**
+- Created `strategies/momentum.py`:
+  - `ROCMomentum(Strategy)` parameterised by `roc_period`, `roc_threshold`,
+    `atr_filter_period`, `atr_stop_period` (default 14), `rr_ratio` (default 1.5),
+    `volatility_filter` (default True).
+  - ROC = `close.pct_change(roc_period)`.  LONG when ROC >= +roc_threshold AND
+    volatility confirms; SHORT when ROC <= -roc_threshold AND volatility confirms.
+  - **Volatility-confirmation gate:** `current ATR > rolling_mean(ATR, atr_filter_period)`.
+    Strictly greater — ATR == mean (constant spread) does NOT confirm.  Gate is
+    controllable via `volatility_filter` flag for testing and tuning.
+  - `stop_distance` = ATR(14) via `strategies._indicators.atr()` (INV-11).
+  - `target_distance` = `stop_distance * rr_ratio`.
+  - `quality_score` = `min(1.0, (|ROC| - threshold) / threshold)` ∈ [0,1].
+  - `generated_at` = bar close timestamp (UTC-aware, INV-03).
+  - At most one signal per bar.
+- Created `tests/test_momentum.py` — 40 tests covering:
+  - Construction guards (roc_period, roc_threshold, atr_filter_period, rr_ratio).
+  - Empty/insufficient data edge cases, flat data, no-mutation guarantee.
+  - LONG on positive ROC above threshold; SHORT on negative ROC below threshold;
+    no signal below threshold; boundary behaviour.
+  - INV-11: stop_distance > 0, target = stop × rr_ratio, custom rr_ratio.
+  - INV-03: generated_at UTC-aware, matches bar close timestamp.
+  - quality_score in [0,1], increases with ROC magnitude, capped at 1.
+  - Volatility gate: ON suppresses signals on constant-spread data (ATR == mean);
+    OFF allows same signals; ON allows signals when spread widens (ATR > mean).
+  - Key AC: filter provably changes signal count at both canonical param sets:
+    (roc_period=10, roc_threshold=0.005) and (roc_period=20, roc_threshold=0.01).
+
+**Key patterns / gotchas:**
+- Volatility gate condition is `ATR > rolling_mean(ATR, atr_filter_period)` —
+  strict inequality. When spread is constant, ATR converges to the constant and
+  rolling mean matches exactly → gate is closed (ATR > mean is False).
+- Test data for gate-closed scenario: flat warm-up bars + gradual per-bar drift
+  with fixed spread.  ROC exceeds threshold; ATR stays flat and equals mean → gate closed.
+- Test data for gate-open scenario: same drift but H-L spread widens 4× at drift
+  bars → ATR rises while rolling mean lags → ATR > mean holds → gate opens.
+- `close.pct_change(roc_period)` uses float division; `flat_close * (1 + threshold)`
+  gives ROC fractionally below threshold due to floating-point. Use
+  `threshold * 1.01` for clear above-threshold test data.
+- The ATR computed for the volatility gate uses `atr_stop_period` (14) not a
+  separate period — the same ATR series used for the stop also drives the gate,
+  keeping the logic consistent.
+
+**AC verification results:**
+- `pytest tests/test_momentum.py -v` → **40 passed**, exit 0
+- `pytest -v` (full suite) → **222 passed, 81 warnings**, exit 0
+- `mypy strategies/` → **"Success: no issues found in 5 source files"**, exit 0
+
+**No new runtime dependencies added** (pandas + stdlib only).
 **CLAUDE.md trigger-table:** not edited (no new CLI command or stack change).
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -1,0 +1,216 @@
+"""ROC Momentum strategy.
+
+Generates LONG/SHORT signals when the rate-of-change of the close price
+crosses ±roc_threshold AND a volatility-confirmation gate passes (current
+ATR exceeds its rolling mean — range expansion).
+
+INV-03: generated_at = bar close timestamp (UTC-aware).
+INV-11: stop_distance = ATR(14) at the signal bar (>0);
+        target_distance = stop_distance × rr_ratio (default 1.5).
+D-02: DataFrame columns include time (UTC-aware), open_bid, high_bid,
+      low_bid, close_bid, volume.
+
+Volatility confirmation:
+    current ATR > rolling_mean(ATR, atr_filter_period)
+
+    The gate uses k=1.0 (i.e. strictly above the rolling mean).  A bar
+    where ATR == rolling mean does NOT confirm (range-neutral, not expansion).
+
+ROC threshold units: percent (instrument-agnostic).
+    roc_threshold=0.005 means ±0.5 % change over roc_period bars.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+from strategies._indicators import atr as _atr
+from strategies.base import Direction, Signal, Strategy
+
+
+class ROCMomentum(Strategy):
+    """Rate-of-change momentum strategy with ATR volatility-confirmation gate.
+
+    Parameters
+    ----------
+    instrument:
+        OANDA instrument identifier, e.g. ``"EUR_USD"``.
+    timeframe:
+        Granularity string, e.g. ``"H1"`` or ``"D"``.
+    roc_period:
+        Number of bars over which ROC is computed.
+        ROC = close.pct_change(roc_period).
+    roc_threshold:
+        Minimum absolute ROC required for a signal (fraction, not percent).
+        E.g. 0.005 = 0.5 %.
+    atr_filter_period:
+        Rolling window (bars) for the ATR rolling mean used in the
+        volatility-confirmation gate.  Typical: 20–50.
+    atr_stop_period:
+        ATR period used for stop_distance (INV-11).  Default 14.
+    rr_ratio:
+        Reward-to-risk ratio.  target_distance = stop_distance × rr_ratio.
+        Default 1.5.
+    volatility_filter:
+        If True (default), apply the ATR-expansion gate — suppress signals
+        when ATR ≤ rolling-mean ATR.  Set False to disable and test the
+        gate's impact.
+    """
+
+    def __init__(
+        self,
+        instrument: str,
+        timeframe: str,
+        roc_period: int,
+        roc_threshold: float,
+        atr_filter_period: int,
+        atr_stop_period: int = 14,
+        rr_ratio: float = 1.5,
+        volatility_filter: bool = True,
+    ) -> None:
+        if roc_period < 1:
+            raise ValueError(f"roc_period must be >= 1, got {roc_period}")
+        if roc_threshold <= 0:
+            raise ValueError(f"roc_threshold must be > 0, got {roc_threshold}")
+        if atr_filter_period < 1:
+            raise ValueError(f"atr_filter_period must be >= 1, got {atr_filter_period}")
+        if atr_stop_period < 1:
+            raise ValueError(f"atr_stop_period must be >= 1, got {atr_stop_period}")
+        if rr_ratio <= 0:
+            raise ValueError(f"rr_ratio must be > 0, got {rr_ratio}")
+
+        self._instrument = instrument
+        self._timeframe = timeframe
+        self._roc_period = roc_period
+        self._roc_threshold = roc_threshold
+        self._atr_filter_period = atr_filter_period
+        self._atr_stop_period = atr_stop_period
+        self._rr_ratio = rr_ratio
+        self._volatility_filter = volatility_filter
+
+    # ------------------------------------------------------------------
+    # Strategy protocol
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return (
+            f"ROCMomentum(roc={self._roc_period},"
+            f"thr={self._roc_threshold},"
+            f"atr_filter={self._atr_filter_period},"
+            f"vol_filter={self._volatility_filter})"
+        )
+
+    def generate_signals(self, df: pd.DataFrame) -> list[Signal]:
+        """Generate ROC momentum signals with optional volatility gate.
+
+        Parameters
+        ----------
+        df:
+            Candle DataFrame (D-02).  At minimum: ``time`` (UTC-aware),
+            ``high_bid``, ``low_bid``, ``close_bid``.
+
+        Returns
+        -------
+        list[Signal]
+            At most one signal per bar.  Returns an empty list when no bar
+            in ``df`` satisfies both the momentum and (if enabled) the
+            volatility-confirmation criteria.
+        """
+        if len(df) == 0:
+            return []
+
+        work = df.copy()
+
+        # ---- ROC = percentage change of close over roc_period bars ----
+        close = work["close_bid"].astype(float)
+        roc = close.pct_change(self._roc_period)
+
+        # ---- ATR for stop (INV-11) ----
+        atr_stop = _atr(work, self._atr_stop_period)
+
+        # ---- ATR for volatility gate ----
+        atr_filter = _atr(work, self._atr_stop_period)
+        # Rolling mean uses atr_filter_period; min_periods=1 avoids leading NaN
+        atr_rolling_mean = atr_filter.rolling(
+            window=self._atr_filter_period, min_periods=1
+        ).mean()
+
+        signals: list[Signal] = []
+
+        for i in range(len(work)):
+            roc_val = roc.iloc[i]
+            atr_stop_val = atr_stop.iloc[i]
+            atr_filter_val = atr_filter.iloc[i]
+            atr_mean_val = atr_rolling_mean.iloc[i]
+
+            # Skip if any required value is NaN or ATR stop is non-positive
+            if (
+                pd.isna(roc_val)
+                or pd.isna(atr_stop_val)
+                or pd.isna(atr_filter_val)
+                or pd.isna(atr_mean_val)
+                or atr_stop_val <= 0
+            ):
+                continue
+
+            # ---- Volatility-confirmation gate ----
+            # current ATR strictly > rolling mean → range expansion
+            volatility_confirmed = (not self._volatility_filter) or (
+                atr_filter_val > atr_mean_val
+            )
+            if not volatility_confirmed:
+                continue
+
+            # ---- Momentum gate ----
+            if roc_val >= self._roc_threshold:
+                direction = Direction.LONG
+            elif roc_val <= -self._roc_threshold:
+                direction = Direction.SHORT
+            else:
+                continue  # below threshold — no signal
+
+            # ---- Build signal ----
+            stop_distance = float(atr_stop_val)
+            target_distance = stop_distance * self._rr_ratio
+
+            # quality_score: normalise excess momentum to [0, 1]
+            # excess = |ROC| - threshold; scaled by threshold so 2× threshold = 1.0
+            excess = abs(roc_val) - self._roc_threshold
+            quality_score = min(1.0, excess / self._roc_threshold)
+
+            # generated_at = bar close timestamp (INV-03)
+            bar_time = work["time"].iloc[i]
+            if isinstance(bar_time, pd.Timestamp):
+                generated_at: datetime = bar_time.to_pydatetime()
+                if generated_at.tzinfo is None:
+                    generated_at = generated_at.replace(tzinfo=timezone.utc)
+            else:
+                generated_at = bar_time
+
+            entry_ref = float(close.iloc[i])
+
+            signals.append(
+                Signal(
+                    instrument=self._instrument,
+                    direction=direction,
+                    entry_ref=entry_ref,
+                    stop_distance=stop_distance,
+                    target_distance=target_distance,
+                    strategy_name=self.name,
+                    timeframe=self._timeframe,
+                    quality_score=quality_score,
+                    generated_at=generated_at,
+                )
+            )
+
+        return signals
+
+    # ----------------------------------------------------------------
+    # Make subclass concrete (abc.ABC already enforced via Strategy)
+    # ----------------------------------------------------------------
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -1,0 +1,777 @@
+"""Tests for strategies/momentum.py — ROCMomentum.
+
+AC coverage (P1A-T-06):
+- ROC = close.pct_change(roc_period); LONG/SHORT when it crosses ±roc_threshold.
+- Volatility-confirmation gate suppresses signals when ATR ≤ rolling-mean ATR.
+- No signal when momentum below threshold OR volatility does not confirm.
+- stop_distance = ATR(14) at signal bar (>0); target_distance = stop × rr_ratio.
+- quality_score ∈ [0, 1].
+- At most one signal per bar; generated_at = bar close (UTC-aware, INV-03).
+- Tested at (roc_period, roc_threshold) ∈ {(10, 0.005), (20, 0.01)}.
+- Volatility filter on vs off provably changes behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+from strategies.base import Direction, Signal
+from strategies.momentum import ROCMomentum
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candles(
+    closes: list[float],
+    *,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+    start: datetime | None = None,
+    freq_hours: int = 1,
+) -> pd.DataFrame:
+    """Build a minimal synthetic OHLC DataFrame with UTC timestamps."""
+    n = len(closes)
+    if highs is None:
+        highs = [c * 1.001 for c in closes]
+    if lows is None:
+        lows = [c * 0.999 for c in closes]
+    if start is None:
+        start = _utc(2024, 1, 1)
+    times = [start + timedelta(hours=freq_hours * i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime(times, utc=True),
+            "open_bid": closes,
+            "high_bid": highs,
+            "low_bid": lows,
+            "close_bid": closes,
+            "volume": [100] * n,
+        }
+    )
+
+
+def _flat_then_surge(
+    n_flat: int,
+    flat_close: float,
+    surge_pct: float,
+    *,
+    n_after: int = 5,
+    spread: float = 0.001,
+    atr_flat: float | None = None,
+) -> pd.DataFrame:
+    """Build a DataFrame with n_flat flat bars followed by a surge.
+
+    If atr_flat is given, the flat bars have that spread (high-low) and
+    subsequent bars widen to 3× that spread — so ATR will exceed rolling
+    mean at the surge bar, making the volatility gate open.
+
+    If atr_flat is None, spread is used uniformly and the gate is borderline.
+    """
+    closes_flat = [flat_close] * n_flat
+    surge_close = flat_close * (1 + surge_pct)
+    closes_after = [surge_close] * n_after
+
+    closes = closes_flat + closes_after
+
+    highs = [c * (1 + spread) for c in closes]
+    lows = [c * (1 - spread) for c in closes]
+
+    if atr_flat is not None:
+        # Wide spread on surge bars — range expansion
+        for i in range(n_flat, n_flat + n_after):
+            highs[i] = closes[i] + atr_flat * 3
+            lows[i] = closes[i] - atr_flat * 3
+
+    return _make_candles(closes, highs=highs, lows=lows)
+
+
+_DEFAULT_PARAMS = dict(
+    instrument="EUR_USD",
+    timeframe="H1",
+    roc_period=10,
+    roc_threshold=0.005,
+    atr_filter_period=20,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+class TestROCMomentumConstruction:
+    def test_valid_construction(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        assert strat._roc_period == 10
+        assert strat._roc_threshold == 0.005
+        assert strat._atr_filter_period == 20
+
+    def test_name_contains_key_params(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        assert "ROCMomentum" in strat.name
+        assert "10" in strat.name
+        assert "0.005" in strat.name
+
+    def test_invalid_roc_period_zero(self) -> None:
+        with pytest.raises(ValueError, match="roc_period"):
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_period": 0})
+
+    def test_invalid_roc_threshold_zero(self) -> None:
+        with pytest.raises(ValueError, match="roc_threshold"):
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": 0.0})
+
+    def test_invalid_roc_threshold_negative(self) -> None:
+        with pytest.raises(ValueError, match="roc_threshold"):
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": -0.01})
+
+    def test_invalid_atr_filter_period_zero(self) -> None:
+        with pytest.raises(ValueError, match="atr_filter_period"):
+            ROCMomentum(**{**_DEFAULT_PARAMS, "atr_filter_period": 0})
+
+    def test_invalid_rr_ratio_zero(self) -> None:
+        with pytest.raises(ValueError, match="rr_ratio"):
+            ROCMomentum(**{**_DEFAULT_PARAMS, "rr_ratio": 0.0})
+
+    def test_default_rr_ratio_is_1_5(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        assert strat._rr_ratio == 1.5
+
+    def test_default_volatility_filter_on(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        assert strat._volatility_filter is True
+
+
+# ---------------------------------------------------------------------------
+# Empty / insufficient data
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_empty_dataframe_returns_no_signals(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        df = _make_candles([])
+        assert strat.generate_signals(df) == []
+
+    def test_too_few_bars_returns_no_signals(self) -> None:
+        """Fewer bars than roc_period → ROC is all-NaN → no signals."""
+        strat = ROCMomentum(**_DEFAULT_PARAMS)  # roc_period=10
+        df = _make_candles([1.0] * 9)
+        assert strat.generate_signals(df) == []
+
+    def test_flat_data_no_signal(self) -> None:
+        """Constant close → ROC = 0 → always below threshold."""
+        strat = ROCMomentum(**_DEFAULT_PARAMS, volatility_filter=False)
+        df = _make_candles([1.2000] * 50)
+        assert strat.generate_signals(df) == []
+
+    def test_does_not_mutate_input_df(self) -> None:
+        strat = ROCMomentum(**_DEFAULT_PARAMS)
+        df = _make_candles([1.0 + i * 0.001 for i in range(60)])
+        original_columns = set(df.columns)
+        original_shape = df.shape
+        strat.generate_signals(df)
+        assert set(df.columns) == original_columns
+        assert df.shape == original_shape
+
+
+# ---------------------------------------------------------------------------
+# Signal direction (vol filter OFF to isolate ROC logic)
+# ---------------------------------------------------------------------------
+
+class TestSignalDirection:
+    """Tests with volatility_filter=False to test purely the momentum gate."""
+
+    def _make_roc_surge(
+        self,
+        surge_pct: float,
+        roc_period: int = 10,
+        roc_threshold: float = 0.005,
+    ) -> tuple[ROCMomentum, pd.DataFrame]:
+        """Return (strategy, df) where bar index roc_period has a clean ROC == surge_pct."""
+        # Build: roc_period flat bars, then one bar at surge, then trailing flat
+        n_flat = roc_period
+        flat_close = 1.2000
+        surge_close = flat_close * (1.0 + surge_pct)
+        closes = [flat_close] * n_flat + [surge_close] + [surge_close] * 5
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        return strat, df
+
+    def test_long_signal_on_positive_roc_above_threshold(self) -> None:
+        strat, df = self._make_roc_surge(surge_pct=0.010, roc_threshold=0.005)
+        signals = strat.generate_signals(df)
+        long_sigs = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_sigs) >= 1
+
+    def test_short_signal_on_negative_roc_below_threshold(self) -> None:
+        # Decline: n_flat bars then drop
+        n_flat = 10
+        flat_close = 1.2000
+        drop_close = flat_close * (1.0 - 0.010)
+        closes = [flat_close] * n_flat + [drop_close] + [drop_close] * 5
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        short_sigs = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_sigs) >= 1
+
+    def test_no_signal_when_roc_below_threshold(self) -> None:
+        """ROC = 0.2% which is below threshold=0.5% → no signal."""
+        strat, df = self._make_roc_surge(surge_pct=0.002, roc_threshold=0.005)
+        signals = strat.generate_signals(df)
+        assert signals == []
+
+    def test_signal_at_threshold_boundary(self) -> None:
+        """ROC just above threshold triggers LONG; just below does not.
+
+        NOTE: floating-point arithmetic means `flat_close * (1 + threshold)` gives
+        a ROC fractionally below `threshold` (pct_change uses division, not
+        multiplication).  We use surge_pct = threshold * 1.01 to sit safely above
+        the boundary and verify the ≥ condition.
+        """
+        # Surge of 1.01× threshold → ROC just above threshold → LONG
+        strat_above, df_above = self._make_roc_surge(
+            surge_pct=0.005 * 1.01, roc_threshold=0.005
+        )
+        signals_above = strat_above.generate_signals(df_above)
+        long_sigs = [s for s in signals_above if s.direction == Direction.LONG]
+        assert len(long_sigs) >= 1, "ROC just above threshold should produce LONG"
+
+        # Surge of 0.99× threshold → ROC just below threshold → no LONG
+        strat_below, df_below = self._make_roc_surge(
+            surge_pct=0.005 * 0.99, roc_threshold=0.005
+        )
+        signals_below = strat_below.generate_signals(df_below)
+        assert signals_below == [], "ROC just below threshold should produce no signal"
+
+    def test_instrument_propagated_to_signal(self) -> None:
+        strat, df = self._make_roc_surge(surge_pct=0.010)
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0
+        assert all(s.instrument == "EUR_USD" for s in signals)
+
+    def test_timeframe_propagated_to_signal(self) -> None:
+        strat, df = self._make_roc_surge(surge_pct=0.010)
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0
+        assert all(s.timeframe == "H1" for s in signals)
+
+    def test_at_most_one_signal_per_bar(self) -> None:
+        """Indices of signal generated_at timestamps must be unique."""
+        n_flat = 10
+        flat_close = 1.2000
+        # Multiple consecutive surge bars
+        closes = [flat_close] * n_flat + [flat_close * 1.02] * 20
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        timestamps = [s.generated_at for s in signals]
+        assert len(timestamps) == len(set(timestamps)), "Duplicate bar timestamps in signals"
+
+
+# ---------------------------------------------------------------------------
+# INV-11: stop and target distances
+# ---------------------------------------------------------------------------
+
+class TestInv11:
+    def _get_signals_no_vol_filter(
+        self,
+        roc_period: int = 10,
+        roc_threshold: float = 0.005,
+        rr_ratio: float = 1.5,
+    ) -> list[Signal]:
+        n_flat = roc_period
+        flat_close = 1.2000
+        surge_close = flat_close * (1.0 + roc_threshold * 3)
+        closes = [flat_close] * n_flat + [surge_close] * 20
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=20,
+            rr_ratio=rr_ratio,
+            volatility_filter=False,
+        )
+        return strat.generate_signals(df)
+
+    def test_stop_distance_positive(self) -> None:
+        signals = self._get_signals_no_vol_filter()
+        assert len(signals) > 0
+        assert all(s.stop_distance > 0 for s in signals)
+
+    def test_target_distance_equals_stop_times_rr_ratio(self) -> None:
+        signals = self._get_signals_no_vol_filter(rr_ratio=1.5)
+        assert len(signals) > 0
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 1.5) < 1e-12
+
+    def test_custom_rr_ratio(self) -> None:
+        signals = self._get_signals_no_vol_filter(rr_ratio=2.0)
+        assert len(signals) > 0
+        for sig in signals:
+            assert abs(sig.target_distance - sig.stop_distance * 2.0) < 1e-12
+
+    def test_target_distance_positive(self) -> None:
+        signals = self._get_signals_no_vol_filter()
+        assert all(s.target_distance > 0 for s in signals)
+
+
+# ---------------------------------------------------------------------------
+# INV-03: UTC-aware generated_at
+# ---------------------------------------------------------------------------
+
+class TestInv03:
+    def test_generated_at_is_utc_aware(self) -> None:
+        """generated_at must carry timezone info (UTC, INV-03)."""
+        n_flat = 10
+        flat_close = 1.2000
+        surge_close = flat_close * 1.020
+        closes = [flat_close] * n_flat + [surge_close] * 5
+        df = _make_candles(closes, start=_utc(2025, 6, 1))
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0
+        for sig in signals:
+            assert sig.generated_at.tzinfo is not None, "generated_at must be UTC-aware"
+
+    def test_generated_at_matches_bar_close_time(self) -> None:
+        """generated_at must equal the bar's time column value, not datetime.now()."""
+        n_flat = 10
+        flat_close = 1.2000
+        surge_close = flat_close * 1.020
+        closes = [flat_close] * n_flat + [surge_close] + [surge_close] * 4
+        start = _utc(2025, 3, 10, 9)
+        df = _make_candles(closes, start=start)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0
+        # All generated_at timestamps must appear in the df time column
+        df_times = set(df["time"].dt.to_pydatetime().tolist())
+        for sig in signals:
+            assert sig.generated_at in df_times, (
+                f"generated_at {sig.generated_at} not found in df time column"
+            )
+
+
+# ---------------------------------------------------------------------------
+# quality_score
+# ---------------------------------------------------------------------------
+
+class TestQualityScore:
+    def test_quality_score_in_range(self) -> None:
+        n_flat = 10
+        flat_close = 1.2000
+        # Vary surge magnitude
+        for surge_pct in [0.006, 0.010, 0.020, 0.050]:
+            closes = [flat_close] * n_flat + [flat_close * (1 + surge_pct)] * 10
+            df = _make_candles(closes)
+            strat = ROCMomentum(
+                instrument="EUR_USD",
+                timeframe="H1",
+                roc_period=10,
+                roc_threshold=0.005,
+                atr_filter_period=20,
+                volatility_filter=False,
+            )
+            for sig in strat.generate_signals(df):
+                assert 0.0 <= sig.quality_score <= 1.0, (
+                    f"quality_score {sig.quality_score} out of [0,1] for surge_pct={surge_pct}"
+                )
+
+    def test_quality_score_increases_with_roc_magnitude(self) -> None:
+        """Larger ROC → higher (or equal) quality score."""
+        def _get_qs(surge_pct: float) -> float:
+            n_flat = 10
+            flat_close = 1.2000
+            closes = [flat_close] * n_flat + [flat_close * (1 + surge_pct)] * 10
+            df = _make_candles(closes)
+            strat = ROCMomentum(
+                instrument="EUR_USD",
+                timeframe="H1",
+                roc_period=10,
+                roc_threshold=0.005,
+                atr_filter_period=20,
+                volatility_filter=False,
+            )
+            signals = strat.generate_signals(df)
+            return max(s.quality_score for s in signals) if signals else 0.0
+
+        qs_small = _get_qs(0.006)
+        qs_large = _get_qs(0.020)
+        assert qs_large >= qs_small, "Larger surge should produce >= quality score"
+
+    def test_quality_score_capped_at_1(self) -> None:
+        """A very large ROC should be clamped to 1.0."""
+        n_flat = 10
+        flat_close = 1.2000
+        closes = [flat_close] * n_flat + [flat_close * 2.0] * 10  # 100% surge
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0
+        assert all(s.quality_score <= 1.0 for s in signals)
+
+
+# ---------------------------------------------------------------------------
+# Volatility-confirmation gate — prove filter changes behaviour
+# ---------------------------------------------------------------------------
+
+class TestVolatilityGate:
+    """AC requirement: test with filter ON and OFF to prove it changes behaviour."""
+
+    def _make_low_vol_drift(
+        self,
+        roc_period: int = 10,
+        roc_threshold: float = 0.005,
+        atr_filter_period: int = 20,
+    ) -> pd.DataFrame:
+        """Create a DataFrame where ROC exceeds threshold BUT ATR does NOT exceed mean.
+
+        Strategy: flat warm-up bars, then a *gradual* steady drift (constant per-bar
+        step with a fixed H-L spread).  Because spread never changes, ATR converges
+        to the constant spread value and then equals its own rolling mean exactly
+        (ATR > mean is False → volatility gate stays CLOSED).
+
+        ROC exceeds threshold because the cumulative 10-bar drift exceeds
+        roc_threshold.  The per-bar step is chosen to produce ROC ≈ 1.5×threshold
+        after roc_period bars.
+        """
+        n_flat = roc_period + atr_filter_period + 10  # generous warm-up
+        flat_close = 1.2000
+
+        # per-bar step so that 10-bar cumulative ROC ≈ 1.5 × roc_threshold
+        # ROC = (close_N - close_{N-roc_period}) / close_{N-roc_period}
+        # drift_per_bar * roc_period / flat_close ≈ roc_threshold * 1.5
+        drift_per_bar = flat_close * roc_threshold * 1.5 / roc_period
+
+        # constant spread — ATR will equal the rolling mean exactly (never above)
+        spread = 0.0010
+
+        closes = [flat_close] * n_flat
+        for _ in range(20):  # enough drift bars
+            closes.append(closes[-1] + drift_per_bar)
+
+        highs = [c + spread for c in closes]
+        lows = [c - spread for c in closes]
+
+        return _make_candles(closes, highs=highs, lows=lows)
+
+    def _make_expanding_vol_drift(
+        self,
+        roc_period: int = 10,
+        roc_threshold: float = 0.005,
+        atr_filter_period: int = 20,
+    ) -> pd.DataFrame:
+        """Create a DataFrame where ROC exceeds threshold AND ATR expands above mean.
+
+        Strategy: warm-up with moderate spread; then gradual drift bars where the
+        H-L spread widens to 4× the warm-up spread.  The ATR rises while rolling
+        mean lags → ATR > mean holds → volatility gate OPENS.
+        """
+        n_flat = roc_period + atr_filter_period + 10
+        flat_close = 1.2000
+        drift_per_bar = flat_close * roc_threshold * 1.5 / roc_period
+
+        moderate_spread = 0.0010
+        wide_spread = 0.0040  # 4× wider
+
+        closes = [flat_close] * n_flat
+        for _ in range(20):
+            closes.append(closes[-1] + drift_per_bar)
+
+        highs = []
+        lows = []
+        for i, c in enumerate(closes):
+            if i >= n_flat:
+                highs.append(c + wide_spread)
+                lows.append(c - wide_spread)
+            else:
+                highs.append(c + moderate_spread)
+                lows.append(c - moderate_spread)
+
+        return _make_candles(closes, highs=highs, lows=lows)
+
+    def test_vol_filter_on_suppresses_constant_spread_signals(self) -> None:
+        """With filter ON: signals suppressed when ATR equals (not exceeds) rolling mean.
+
+        When H-L spread is constant, ATR converges to that constant and its rolling
+        mean is identical — ATR > mean is False → gate stays closed.
+        """
+        df = self._make_low_vol_drift()
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=True,
+        )
+        signals = strat.generate_signals(df)
+        assert signals == [], (
+            "Volatility gate (ON) should suppress signals when ATR == rolling-mean ATR "
+            "(constant spread, no range expansion)"
+        )
+
+    def test_vol_filter_off_allows_constant_spread_signals(self) -> None:
+        """With filter OFF: same constant-spread data that was suppressed now produces signals."""
+        df = self._make_low_vol_drift()
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0, (
+            "Volatility gate (OFF) should allow signals when ROC exceeds threshold"
+        )
+
+    def test_vol_filter_on_allows_expanding_vol_signals(self) -> None:
+        """With filter ON: signals produced when ATR genuinely expands above mean."""
+        df = self._make_expanding_vol_drift()
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=True,
+        )
+        signals = strat.generate_signals(df)
+        assert len(signals) > 0, (
+            "Volatility gate (ON) should allow signals when ATR expands above rolling mean"
+        )
+
+    def test_filter_changes_signal_count(self) -> None:
+        """Key behavioural-difference test: filter ON vs OFF on identical data.
+
+        Uses constant-spread drift data (gate closed when ON, open when OFF).
+        filter=OFF produces signals; filter=ON suppresses them.
+        """
+        df = self._make_low_vol_drift()
+
+        strat_on = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=True,
+        )
+        strat_off = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+
+        count_on = len(strat_on.generate_signals(df))
+        count_off = len(strat_off.generate_signals(df))
+
+        assert count_off > count_on, (
+            f"Filter should reduce signal count: off={count_off}, on={count_on}"
+        )
+
+    def test_filter_changes_signal_count_expanding_vol(self) -> None:
+        """On expanding-vol data, both filter ON and OFF should produce signals."""
+        df = self._make_expanding_vol_drift()
+
+        strat_on = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=True,
+        )
+        strat_off = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=10,
+            roc_threshold=0.005,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+
+        signals_on = strat_on.generate_signals(df)
+        signals_off = strat_off.generate_signals(df)
+
+        assert len(signals_on) > 0, "Filter ON: should produce signals on expanding vol"
+        assert len(signals_off) > 0, "Filter OFF: should produce signals on expanding vol"
+
+
+# ---------------------------------------------------------------------------
+# Parameter combinations: (10, 0.005) and (20, 0.01)
+# ---------------------------------------------------------------------------
+
+class TestParameterCombinations:
+    """Tested at (roc_period, roc_threshold) ∈ {(10, 0.005), (20, 0.01)} per spec."""
+
+    @pytest.mark.parametrize(
+        "roc_period,roc_threshold,surge_pct",
+        [
+            (10, 0.005, 0.012),  # 1.2% surge vs 0.5% threshold
+            (20, 0.010, 0.025),  # 2.5% surge vs 1.0% threshold
+        ],
+    )
+    def test_long_signal_produced(
+        self, roc_period: int, roc_threshold: float, surge_pct: float
+    ) -> None:
+        n_flat = roc_period
+        flat_close = 1.2000
+        surge_close = flat_close * (1.0 + surge_pct)
+        closes = [flat_close] * n_flat + [surge_close] * 10
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        long_sigs = [s for s in signals if s.direction == Direction.LONG]
+        assert len(long_sigs) >= 1, (
+            f"Expected LONG signal for roc_period={roc_period}, "
+            f"roc_threshold={roc_threshold}, surge_pct={surge_pct}"
+        )
+
+    @pytest.mark.parametrize(
+        "roc_period,roc_threshold,drop_pct",
+        [
+            (10, 0.005, 0.012),
+            (20, 0.010, 0.025),
+        ],
+    )
+    def test_short_signal_produced(
+        self, roc_period: int, roc_threshold: float, drop_pct: float
+    ) -> None:
+        n_flat = roc_period
+        flat_close = 1.2000
+        drop_close = flat_close * (1.0 - drop_pct)
+        closes = [flat_close] * n_flat + [drop_close] * 10
+        df = _make_candles(closes)
+        strat = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=20,
+            volatility_filter=False,
+        )
+        signals = strat.generate_signals(df)
+        short_sigs = [s for s in signals if s.direction == Direction.SHORT]
+        assert len(short_sigs) >= 1, (
+            f"Expected SHORT signal for roc_period={roc_period}, "
+            f"roc_threshold={roc_threshold}, drop_pct={drop_pct}"
+        )
+
+    @pytest.mark.parametrize(
+        "roc_period,roc_threshold",
+        [(10, 0.005), (20, 0.010)],
+    )
+    def test_vol_filter_on_vs_off_at_param_set(
+        self, roc_period: int, roc_threshold: float
+    ) -> None:
+        """For each canonical param set, verify filter ON vs OFF changes behaviour.
+
+        Uses constant-spread gradual drift so ROC exceeds threshold but ATR never
+        exceeds its rolling mean (no range expansion) → filter=ON suppresses.
+        """
+        atr_filter_period = 20
+        n_flat = roc_period + atr_filter_period + 10
+        flat_close = 1.2000
+
+        # Gradual per-bar drift: 10-bar cumulative ROC ≈ 1.5 × roc_threshold
+        drift_per_bar = flat_close * roc_threshold * 1.5 / roc_period
+        # Fixed spread: ATR converges to constant → ATR == rolling mean (not > )
+        spread = 0.0010
+
+        closes = [flat_close] * n_flat
+        for _ in range(20):
+            closes.append(closes[-1] + drift_per_bar)
+
+        highs = [c + spread for c in closes]
+        lows = [c - spread for c in closes]
+        df = _make_candles(closes, highs=highs, lows=lows)
+
+        strat_on = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=atr_filter_period,
+            volatility_filter=True,
+        )
+        strat_off = ROCMomentum(
+            instrument="EUR_USD",
+            timeframe="H1",
+            roc_period=roc_period,
+            roc_threshold=roc_threshold,
+            atr_filter_period=atr_filter_period,
+            volatility_filter=False,
+        )
+
+        count_on = len(strat_on.generate_signals(df))
+        count_off = len(strat_off.generate_signals(df))
+
+        assert count_off > count_on, (
+            f"roc_period={roc_period}, roc_threshold={roc_threshold}: "
+            f"filter=OFF ({count_off}) should exceed filter=ON ({count_on})"
+        )


### PR DESCRIPTION
Closes #26.

## Summary

New `strategies/momentum.py` implementing `ROCMomentum(Strategy)` — rate-of-change momentum with an ATR volatility-confirmation gate.

- **ROC** = `close.pct_change(roc_period)`. LONG when ROC ≥ +roc_threshold AND volatility confirms; SHORT when ROC ≤ −roc_threshold AND volatility confirms; no signal otherwise.
- **Volatility gate**: `current ATR > rolling_mean(ATR, atr_filter_period)` (strict — range expansion only). Controlled by `volatility_filter` flag (default True).
- **INV-11**: `stop_distance` = ATR(14) via shared `_indicators.atr()`; `target_distance` = `stop × rr_ratio` (default 1.5). Both strictly positive.
- **INV-03**: `generated_at` = bar close timestamp (UTC-aware).
- `quality_score` = `min(1.0, (|ROC| − threshold) / threshold)` ∈ [0, 1].

## Tests (40 new in `tests/test_momentum.py`)

Covers construction guards, LONG/SHORT direction, INV-11 stop/target, INV-03 UTC, quality_score, at-most-one-per-bar, no-mutation, and the AC-required behavioural proof:
- Filter ON **suppresses** signals on constant-spread drift data (ATR == rolling mean → gate closed).
- Filter OFF **allows** the same signals.
- Verified at both canonical param sets: `(roc_period=10, roc_threshold=0.005)` and `(roc_period=20, roc_threshold=0.01)`.

## Verification

```
pytest tests/test_momentum.py -v       → 40 passed, exit 0
pytest -v (full suite)                 → 222 passed, 81 warnings, exit 0
mypy strategies/                       → Success: no issues found in 5 source files, exit 0
```

No new runtime dependencies. `pyproject.toml` and `CLAUDE.md` untouched.

**Merge plan**: `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).