### PR TITLE
P1A-T-03: swap-cost-model

### DIFF
--- a/.claude/context/backtest.md
+++ b/.claude/context/backtest.md
@@ -124,3 +124,90 @@ approved_set_entry=None)` without raising in all failure modes: no windows, nega
 window, total OOS trades < 5.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P1A-T-03 — 2026-05-29 (feat/p1a-t-03)
+
+**What was done — D-03 swap deferral LIFTED; INV-06 now fully satisfied (all four cost categories):**
+- `backtest/costs.py`:
+  - `CostParams`: **removed** the `swap_pips` field AND the `_swap_must_be_zero` pydantic validator
+    (guard site #1, gone). **Added** `swap_long_rate: float` (default 0.0, no sign constraint —
+    negative = positive carry), `swap_short_rate: float`, `commission_pips: float = 0.0` (`ge=0`).
+    `spread_pips` stays `gt=0` (the INV-06 floor).
+  - `apply_costs` final signature: `apply_costs(entry_price, exit_price, direction, spread_pips,
+    slippage_pips, pip_value, swap_long_rate, swap_short_rate, holding_days: int, commission_pips=0.0)
+    -> CostResult`. The legacy `swap_pips` param AND the inline `if swap_pips != 0.0: raise` guard
+    (was costs.py:159 — guard site #2) are **both gone**.
+  - Financing = `daily_rate × holding_days`, rate selected by direction (long→`swap_long_rate`,
+    short→`swap_short_rate`). `commission_pips + swap_pips` folded onto the **exit leg** signed so the
+    engine's existing `net PnL = f(net_entry, net_exit)` is reduced by exactly that charge —
+    direction-aware and sign-correct (positive carry improves net).
+  - `total_cost_pips = spread_pips + slippage_pips + commission_pips + swap_pips` (only the swap term
+    can be negative). **`CostResult.total_cost_pips` lost its `ge=0.0` Field constraint** because
+    positive carry can drive total cost negative — INTENTIONAL. The strictly-positive floor is now
+    `spread+slippage+commission`, asserted in tests, not in the model schema.
+  - `swap_modelled = (swap_long_rate != 0.0 or swap_short_rate != 0.0)` — flips True whenever financing
+    DATA is supplied, independent of `holding_days` (so a same-bar hold with rates set is still honestly
+    labelled True with zero swap charged).
+  - Added `holding_days < 0` guard (a negative span is a bug).
+- `backtest/engine.py`:
+  - New static helper `_holding_days(entry_time, exit_time)`: `entry_time/exit_time .astimezone(utc).date()`
+    then `(exit_date - entry_date).days`. **INV-03**: UTC calendar-date boundaries crossed, NOT a
+    wall-clock 24h delta — so an H1 trade 23:00→01:00 next day counts as 1 overnight. Same-UTC-date
+    close → 0 → zero swap.
+  - `_close_trade` takes `holding_days` and passes `swap_long_rate`/`swap_short_rate`/`holding_days`/
+    `commission_pips` from `self._cost_params` into `apply_costs`. Both call sites (stop/target exit
+    and end-of-data close) compute `holding_days` via the helper.
+  - `metadata["swap_modelled"]` now reflects reality (`rate != 0` on either side); added
+    `swap_long_rate`/`swap_short_rate`/`commission_pips` to metadata.
+- **Field-name mapping** (AMBIGUOUS-01): the rename `InstrumentMeta.long_rate → CostParams.swap_long_rate`
+  happens at the engine boundary where the *caller* constructs `CostParams`. The engine reads the
+  `swap_*` names; no production code in this branch constructs `CostParams` from `InstrumentMeta` yet —
+  that wiring is the T-08 runner's job. `scripts/poc_run.py` constructs spread-only `CostParams`
+  (financing defaults 0) → still `swap_modelled=False`, PoC integration test unaffected.
+- `metrics.py` / `walkforward.py` / `__init__.py`: updated stale "always False (D-03)" docstrings — the
+  `swap_modelled` label already propagated correctly from metadata (`bool(metadata.get(...))` /
+  `oos_metrics[-1].swap_modelled`), so NO logic change was needed there, only honest prose.
+
+**Tests (`tests/test_backtest_engine.py`):**
+- Updated `test_apply_costs_invariants` to pass the new required financing args (zero → still the
+  spread-only floor property).
+- **Removed `test_apply_costs_rejects_swap` and replaced** (not deleted silently) with
+  `test_apply_costs_financing_no_longer_raises` — proves BOTH guard sites are gone (apply_costs +
+  CostParams construction with financing). AC: "guard removed and tests updated, not deleted silently".
+- Renamed `test_cost_params_rejects_zero_spread_and_swap` → `test_cost_params_rejects_zero_spread`
+  (spread>0 still enforced; financing rates of any sign accepted; commission ge=0).
+- New property test `test_apply_costs_inv06_floor_with_financing` (hypothesis, rates ∈ [-0.5,0.5],
+  holding_days ∈ [0,30]): the `spread+slippage` floor stays strictly > 0 across the whole financing
+  domain INCLUDING positive carry, and `total_cost == floor + rate×days`. **This is the INV-06 defence.**
+- `test_apply_costs_same_bar_zero_swap` (0 holding days → 0 swap, both directions).
+- `test_apply_costs_financing_direction_aware` (long uses long_rate, short uses short_rate; net PnL
+  drops by exactly the charge).
+- `test_apply_costs_positive_carry_improves_net`, `test_apply_costs_commission_per_round_trip`,
+  `test_apply_costs_rejects_negative_holding_days`.
+- **Engine-level:** `test_known_trade_regression_zero_financing_matches_poc` — the backward-compat AC,
+  PoC net 12.0 / gross 15.0 / cost 3.0 reproduced exactly at zero financing. And
+  `test_engine_holding_days_from_utc_dates_charges_swap` — entry bar Jan-1, exit bar Jan-3 →
+  holding_days 2 → swap 0.5×2=1.0 → net 11.0, gross unchanged 15.0, `swap_modelled` True (INV-03 path).
+
+**Key gotchas:**
+- `CostResult.total_cost_pips` `ge=0.0` constraint had to be DROPPED — positive carry is a legitimate
+  negative cost. The INV-06 guarantee moved from "total cost > 0" to "spread+slippage+commission floor
+  > 0" (which is what the invariant actually protects: the *spread path* is never free).
+- Charge is folded onto the EXIT leg as a price offset (`(commission+swap) × pip_value`), sign mirrored
+  per direction, so the engine's net-PnL-from-net-prices math stays untouched. Did NOT add a separate
+  swap field to `Trade` (cost_pips already carries it; net prices already reflect it).
+- No production `InstrumentMeta → CostParams` wiring on this branch — deliberately deferred to T-08
+  (the runner is the single construction point per the spec's boundary-mapping ruling).
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_backtest_engine.py -q` → 20 passed
+- `python -m pytest -q` (full suite) → 190 passed, 81 warnings (pre-existing low-trade-count
+  UserWarnings, unrelated), exit 0
+- `python -m mypy backtest/` → "Success: no issues found in 5 source files", exit 0
+- `python -m mypy backtest/ tests/test_backtest_engine.py` → "Success: no issues found in 6 source files", exit 0
+
+**New dependency:** NONE (dateutil already present; `datetime.timezone` is stdlib). CLAUDE.md Stack: N/A.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -3,7 +3,7 @@
 Contains the event-driven backtest engine, cost model, metrics calculator, and
 walk-forward validation engine.
 
-- ``costs``       : ``apply_costs`` + ``CostResult`` + ``CostParams`` (spread + slippage; swap deferred, D-03).
+- ``costs``       : ``apply_costs`` + ``CostResult`` + ``CostParams`` (spread + slippage + commission + swap; all four INV-06 cost categories).
 - ``engine``      : ``BacktestEngine`` + ``Trade`` + ``BacktestResult`` — strict chronological,
                     no look-ahead, defensive-copy of the caller's DataFrame.
 - ``metrics``     : ``compute_metrics`` + ``Metrics`` — Sharpe, Sortino, max drawdown, win rate, etc.

--- a/backtest/costs.py
+++ b/backtest/costs.py
@@ -1,39 +1,62 @@
-"""Cost model for the backtest engine (POC-T-05).
+"""Cost model for the backtest engine (POC-T-05; swap lifted in P1A-T-03).
 
 This module is the enforcement point for **INV-06**: a backtest result is only
-valid if it models real trading costs.  For the PoC we model two of the four
-cost categories:
+valid if it models real trading costs.  Phase 1A (P1A-T-03) lifts the PoC's
+swap deferral (D-03), so all four INV-06 cost categories are now modelled:
 
   1. **Spread** — half the spread is paid on each leg (entry + exit).  A long
      buys at the ask (entry worsened upward) and sells at the bid (exit
      worsened downward); a short is the mirror image.
   2. **Slippage** — a pip offset applied adversely on stop/target fills (market
      fills, not limit entries).
+  3. **Commission** — an optional per-round-trip charge in pips
+     (``commission_pips``, default 0.0 for spread-only accounts).
+  4. **Swap / overnight financing** — ``swap = daily_rate × holding_days`` on
+     the direction's side (long → ``swap_long_rate``, short →
+     ``swap_short_rate``).  ``holding_days`` is the calendar-day count between
+     the entry and exit bar UTC dates, computed by the engine.  A position
+     closed same-bar (0 holding days) accrues zero swap.
 
-The remaining two categories are deliberately **not** modelled in the PoC:
+The D-03 deferral is gone: the legacy ``swap_pips`` field, its pydantic
+validator, and the inline ``apply_costs`` guard have all been removed (both
+guard sites — not just one).  ``CostResult.swap_modelled`` is now ``True``
+whenever financing is applied.
 
-  - **Commission** — out of scope for the PoC instruments (spread-only account).
-  - **Swap / overnight financing** — DEFERRED per decision **D-03**.  Every
-    output carries ``swap_modelled=False`` and ``apply_costs`` only accepts
-    ``swap_pips=0.0``.  A non-zero ``swap_pips`` is rejected so that no caller
-    can silently believe swap is being modelled when it is not.
+Sign convention for financing
+-----------------------------
+``swap_long_rate`` / ``swap_short_rate`` are *daily costs in pips*: a positive
+rate is a charge that worsens net PnL, a negative rate is positive carry that
+improves it.  The per-trade financing charge is
+``swap_pips = rate × holding_days`` (rate selected by direction).  It is folded
+into ``net_exit`` adversely-signed so that, after the engine's
+``net PnL = f(net_entry, net_exit)`` computation, net PnL is reduced by exactly
+``swap_pips`` for a long and likewise for a short — direction-aware and
+sign-correct for both charge and carry.
 
-Why a zero-cost trade is impossible (INV-06)
---------------------------------------------
-``total_cost_pips`` is computed as ``spread_pips + slippage_pips`` — a value
-that depends **only** on the cost parameters, never on the price path or the
-trade direction.  For any ``spread_pips > 0`` *or* ``slippage_pips > 0`` the sum
-is strictly > 0.  The half-spread / slippage offsets are always applied on the
-*adverse* side of each leg, so the net entry/exit prices can only ever move PnL
-*against* the trade — never in its favour.  Consequently ``net PnL <= gross
-PnL`` is structurally guaranteed, and a cost-free round trip cannot occur unless
-the caller explicitly passes zero spread *and* zero slippage (which the
-backtest engine never does — see ``CostParams`` validation in ``engine.py``).
+Why a zero-cost *spread path* is impossible (INV-06)
+----------------------------------------------------
+The **spread + slippage + commission floor** is computed as
+``spread_pips + slippage_pips + commission_pips`` — a value that depends
+**only** on the cost parameters, never on the price path, the trade direction,
+or the financing rate.  For any ``spread_pips > 0`` *or* ``slippage_pips > 0``
+that floor is strictly > 0, and ``CostParams`` enforces ``spread_pips > 0`` so
+the engine can never run cost-free.  The half-spread / slippage offsets are
+always applied on the *adverse* side of each leg, so they move net PnL against
+the trade.
+
+Financing is **additive on top of** that floor: a positive-carry side (negative
+``rate``) reduces the *net* cost but is reported in a separate, possibly
+negative ``swap_pips`` term — it is never subtracted out of the
+strictly-positive spread+slippage floor.  ``total_cost_pips`` is therefore
+``spread_pips + slippage_pips + commission_pips + swap_pips`` where only the
+swap term can be negative; the floor guarantees the spread path itself is never
+free.  ``gross PnL ≥ net PnL`` holds for any non-positive-carry trade, and
+positive carry can only improve net — it can never make the spread leg free.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from strategies.base import Direction
 
@@ -48,18 +71,24 @@ class CostResult(BaseModel):
         slippage — see below) has been applied.  This is the price the trade is
         *actually* considered to have filled at.
     net_exit:
-        Exit price after the adverse half-spread and exit slippage.
+        Exit price after the adverse half-spread, exit slippage, commission, and
+        overnight financing — all folded in on the exit leg so the engine's
+        ``net PnL = f(net_entry, net_exit)`` reflects every cost category.
     total_cost_pips:
-        Total cost of the round trip, expressed in pips.  Strictly > 0 whenever
-        either ``spread_pips`` or ``slippage_pips`` is non-zero (INV-06).
+        Total cost of the round trip, in pips:
+        ``spread_pips + slippage_pips + commission_pips + swap_pips``.  The
+        spread+slippage+commission portion is strictly > 0 whenever
+        ``spread_pips`` or ``slippage_pips`` is non-zero (INV-06); the
+        ``swap_pips`` term may be negative for a positive-carry trade.
     swap_modelled:
-        Always ``False`` for the PoC (D-03).  Present so downstream metrics and
-        approved-set entries can carry the honest label.
+        ``True`` whenever financing was applied (the normal Phase-1 path);
+        ``False`` only when ``apply_costs`` is run with both financing rates at
+        ``0.0`` (the backward-compatible spread-only path).
     """
 
     net_entry: float
     net_exit: float
-    total_cost_pips: float = Field(..., ge=0.0)
+    total_cost_pips: float
     swap_modelled: bool = False
 
 
@@ -73,33 +102,30 @@ class CostParams(BaseModel):
         Must be > 0 (a zero-spread backtest is fiction — INV-06).
     slippage_pips:
         Pip offset applied adversely on stop and target (market) fills.
-        Must be >= 0; combined with a positive spread the total cost is always
-        > 0.  Slippage alone (with zero spread) would also be > 0, but the
-        engine additionally requires a positive spread.
+        Must be >= 0; combined with a positive spread the spread+slippage floor
+        is always > 0.
     pip_value:
         Price increment of one pip for the instrument, e.g. ``0.0001`` for most
         FX majors and ``0.01`` for JPY pairs.  Used to convert between price
         units and pips.  Must be > 0.
-    swap_pips:
-        DEFERRED (D-03).  Must remain 0.0.
+    swap_long_rate:
+        Daily overnight financing for a **long** position, in pips per day
+        (mapped from ``InstrumentMeta.long_rate`` at the engine boundary).
+        Positive = a charge; negative = positive carry.  No sign constraint.
+    swap_short_rate:
+        Daily overnight financing for a **short** position, in pips per day
+        (mapped from ``InstrumentMeta.short_rate``).  Same sign convention.
+    commission_pips:
+        Per-round-trip commission in pips.  Defaults to ``0.0`` (spread-only
+        accounts).  Must be >= 0.
     """
 
     spread_pips: float = Field(..., gt=0.0)
     slippage_pips: float = Field(0.0, ge=0.0)
     pip_value: float = Field(..., gt=0.0)
-    swap_pips: float = Field(0.0)
-
-    @model_validator(mode="after")
-    def _swap_must_be_zero(self) -> "CostParams":
-        # D-03: swap is not implemented. Reject any attempt to pass a non-zero
-        # value rather than silently ignoring it (which would let a caller
-        # believe swap was modelled when it was not).
-        if self.swap_pips != 0.0:
-            raise ValueError(
-                "swap_pips must be 0.0 — swap/financing is deferred (D-03). "
-                "Every output is labelled swap_modelled=False."
-            )
-        return self
+    swap_long_rate: float = Field(0.0)
+    swap_short_rate: float = Field(0.0)
+    commission_pips: float = Field(0.0, ge=0.0)
 
 
 def apply_costs(
@@ -109,9 +135,12 @@ def apply_costs(
     spread_pips: float,
     slippage_pips: float,
     pip_value: float,
-    swap_pips: float = 0.0,
+    swap_long_rate: float,
+    swap_short_rate: float,
+    holding_days: int,
+    commission_pips: float = 0.0,
 ) -> CostResult:
-    """Apply spread + slippage costs to a single round-trip trade.
+    """Apply spread + slippage + commission + swap to a round-trip trade.
 
     Parameters
     ----------
@@ -125,26 +154,39 @@ def apply_costs(
         Full spread in pips.  Half is added to a long entry / subtracted from a
         long exit (opposite for a short).
     slippage_pips:
-        Pip offset applied adversely on the stop/target exit fill.  For the PoC
-        slippage is charged on the exit leg (stop/target are the market fills;
-        entry is treated as a controlled next-open fill).
+        Pip offset applied adversely on the stop/target exit fill (stop/target
+        are the market fills; entry is treated as a controlled next-open fill).
     pip_value:
         Price increment of one pip (e.g. ``0.0001`` or ``0.01`` for JPY).
-    swap_pips:
-        DEFERRED (D-03) — must be 0.0.
+    swap_long_rate:
+        Daily financing for a long, in pips/day.  Used when ``direction`` is
+        ``LONG``.  Positive = charge, negative = carry.
+    swap_short_rate:
+        Daily financing for a short, in pips/day.  Used when ``direction`` is
+        ``SHORT``.
+    holding_days:
+        Calendar days the position was held (entry→exit UTC dates), computed by
+        the engine.  ``0`` for a same-bar / intraday close → zero swap.  Must be
+        >= 0.
+    commission_pips:
+        Per-round-trip commission in pips (default 0.0).  Must be >= 0.
 
     Returns
     -------
     CostResult
-        ``net_entry``, ``net_exit``, ``total_cost_pips`` (strictly > 0 for any
-        non-zero spread or slippage), and ``swap_modelled=False``.
+        ``net_entry``, ``net_exit`` (with all costs folded onto the exit leg),
+        ``total_cost_pips`` (spread + slippage + commission + swap; the
+        spread+slippage+commission portion is strictly > 0 for any non-zero
+        spread/slippage), and ``swap_modelled`` (``True`` when financing was
+        applied, i.e. when either rate is non-zero).
 
     Raises
     ------
     ValueError
-        If ``direction`` is ``FLAT``, if ``pip_value <= 0``, if either
-        ``spread_pips`` or ``slippage_pips`` is negative, or if ``swap_pips`` is
-        non-zero (D-03).
+        If ``direction`` is ``FLAT``, if ``pip_value <= 0``, if ``spread_pips``,
+        ``slippage_pips``, or ``commission_pips`` is negative, or if
+        ``holding_days`` is negative.  (Non-zero financing no longer raises —
+        the D-03 guard is gone.)
     """
     if direction not in (Direction.LONG, Direction.SHORT):
         raise ValueError(
@@ -156,35 +198,51 @@ def apply_costs(
         raise ValueError(f"spread_pips must be >= 0, got {spread_pips}.")
     if slippage_pips < 0.0:
         raise ValueError(f"slippage_pips must be >= 0, got {slippage_pips}.")
-    if swap_pips != 0.0:
-        # D-03: swap is deferred. Reject loudly rather than silently dropping it.
-        raise ValueError(
-            "swap_pips must be 0.0 — swap/financing is deferred (D-03)."
-        )
+    if commission_pips < 0.0:
+        raise ValueError(f"commission_pips must be >= 0, got {commission_pips}.")
+    if holding_days < 0:
+        raise ValueError(f"holding_days must be >= 0, got {holding_days}.")
+
+    # Financing = daily rate × holding days, on the direction's side. A same-bar
+    # close (holding_days == 0) accrues exactly zero swap. swap_modelled flips
+    # True whenever financing data is supplied (either rate non-zero).
+    daily_rate = (
+        swap_long_rate if direction is Direction.LONG else swap_short_rate
+    )
+    swap_pips = daily_rate * holding_days
+    swap_modelled = swap_long_rate != 0.0 or swap_short_rate != 0.0
 
     half_spread_price = (spread_pips / 2.0) * pip_value
     slippage_price = slippage_pips * pip_value
+    # Commission + swap are flat pip charges (not tied to a price level). Fold
+    # them onto the exit leg, signed so that net PnL is reduced by exactly
+    # (commission_pips + swap_pips). A positive swap (charge) worsens net PnL; a
+    # negative swap (carry) improves it. This keeps the engine's existing
+    # net-PnL-from-net-prices computation correct and direction-aware.
+    flat_charge_price = (commission_pips + swap_pips) * pip_value
 
     if direction is Direction.LONG:
         # Long: buy at the ask (entry up by half-spread), sell at the bid
         # (exit down by half-spread). Slippage on a long exit (stop/target is a
-        # sell) fills *lower* — adverse.
+        # sell) fills *lower* — adverse. A charge lowers the long's net exit.
         net_entry = entry_price + half_spread_price
-        net_exit = exit_price - half_spread_price - slippage_price
+        net_exit = exit_price - half_spread_price - slippage_price - flat_charge_price
     else:  # Direction.SHORT
         # Short: sell at the bid (entry down by half-spread), buy back at the
         # ask (exit up by half-spread). Slippage on a short exit (a buy) fills
-        # *higher* — adverse.
+        # *higher* — adverse. A charge raises the short's net exit (its PnL is
+        # entry - exit, so a higher exit reduces PnL by the charge).
         net_entry = entry_price - half_spread_price
-        net_exit = exit_price + half_spread_price + slippage_price
+        net_exit = exit_price + half_spread_price + slippage_price + flat_charge_price
 
-    # Total cost is path-independent: full spread (half per leg) + slippage on
-    # the exit fill. Strictly > 0 for any non-zero spread or slippage (INV-06).
-    total_cost_pips = spread_pips + slippage_pips
+    # Total cost: the strictly-positive spread+slippage+commission floor plus
+    # the financing term (which may be negative for positive carry). The floor
+    # alone is > 0 for any non-zero spread or slippage (INV-06).
+    total_cost_pips = spread_pips + slippage_pips + commission_pips + swap_pips
 
     return CostResult(
         net_entry=net_entry,
         net_exit=net_exit,
         total_cost_pips=total_cost_pips,
-        swap_modelled=False,
+        swap_modelled=swap_modelled,
     )

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -36,7 +36,7 @@ caller's frame.  All timestamps in the output are sourced from the bar data
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -83,8 +83,9 @@ class BacktestResult(BaseModel):
         Cumulative **net** PnL in pips, indexed by bar close time (UTC).  One
         point per bar; flat across bars with no realised PnL.
     metadata:
-        Run metadata including ``swap_modelled=False`` (D-03), instrument,
-        granularity, bar count, and the cost parameters used.
+        Run metadata including ``swap_modelled`` (``True`` when financing
+        rates were supplied — P1A-T-03), instrument, granularity, bar count,
+        and the cost parameters used (spread, slippage, financing, commission).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -132,9 +133,12 @@ class BacktestEngine:
         The candle store (T-03).  ``run`` loads candles via
         ``store.load_candles`` and operates on a defensive copy.
     cost_params:
-        Spread + slippage configuration.  Required, not optional — a backtest
-        without costs is invalid (INV-06).  ``CostParams`` enforces
-        ``spread_pips > 0``, so the engine can never run cost-free.
+        Spread + slippage + commission + financing configuration.  The engine
+        maps ``InstrumentMeta.long_rate``/``short_rate`` into
+        ``CostParams.swap_long_rate``/``swap_short_rate`` at construction (done
+        by the caller / runner).  Required, not optional — a backtest without
+        costs is invalid (INV-06).  ``CostParams`` enforces ``spread_pips > 0``,
+        so the engine can never run cost-free.
 
     Notes
     -----
@@ -223,9 +227,12 @@ class BacktestEngine:
                 exit_info = self._resolve_fill(position, bar_high, bar_low)
                 if exit_info is not None:
                     gross_exit_level, exit_reason = exit_info
+                    holding_days = self._holding_days(
+                        position.entry_time, bar_time
+                    )
                     trade = self._close_trade(
                         position, bar_time, gross_exit_level, exit_reason,
-                        pip_value,
+                        pip_value, holding_days,
                     )
                     trades.append(trade)
                     realised_net_pips += trade.pnl_net_pips
@@ -252,8 +259,10 @@ class BacktestEngine:
         if position is not None and n > 0:
             final_time = self._bar_time(times, n - 1)
             final_close = float(closes[n - 1])
+            holding_days = self._holding_days(position.entry_time, final_time)
             trade = self._close_trade(
-                position, final_time, final_close, "end_of_data", pip_value
+                position, final_time, final_close, "end_of_data", pip_value,
+                holding_days,
             )
             trades.append(trade)
             realised_net_pips += trade.pnl_net_pips
@@ -263,16 +272,27 @@ class BacktestEngine:
 
         equity_curve = self._build_equity_curve(times, equity_values)
 
+        # swap_modelled is True whenever financing data was supplied (either
+        # rate non-zero) — the honest INV-06 label. It is False only when the
+        # engine is run with both rates at 0.0 (the backward-compatible
+        # spread-only path), regardless of how many trades held overnight.
+        swap_modelled = (
+            self._cost_params.swap_long_rate != 0.0
+            or self._cost_params.swap_short_rate != 0.0
+        )
         metadata = {
             "instrument": instrument,
             "granularity": granularity,
             "bar_count": n,
             "trade_count": len(trades),
             "strategy_name": strategy.name,
-            "swap_modelled": False,  # D-03 — honest label on every result.
+            "swap_modelled": swap_modelled,
             "spread_pips": self._cost_params.spread_pips,
             "slippage_pips": self._cost_params.slippage_pips,
             "pip_value": pip_value,
+            "swap_long_rate": self._cost_params.swap_long_rate,
+            "swap_short_rate": self._cost_params.swap_short_rate,
+            "commission_pips": self._cost_params.commission_pips,
         }
 
         return BacktestResult(
@@ -290,6 +310,23 @@ class BacktestEngine:
         # pandas Timestamp → python datetime, preserving tz (UTC).
         result: datetime = ts.to_pydatetime()
         return result
+
+    @staticmethod
+    def _holding_days(entry_time: datetime, exit_time: datetime) -> int:
+        """Calendar overnight count between entry and exit bar UTC dates.
+
+        INV-03: both timestamps are UTC-aware datetimes sourced from bar data
+        (never wall-clock). The financing-day count is the number of UTC date
+        boundaries crossed — ``(exit_date - entry_date).days`` — so a position
+        opened and closed within the same UTC date (an intraday / same-bar
+        close) returns ``0`` and accrues no swap, while one held overnight
+        returns the number of overnight rollovers. Normalising to UTC dates (not
+        a wall-clock 24h delta) means an H1 trade from 23:00 to 01:00 the next
+        day correctly counts as one overnight hold.
+        """
+        entry_date = entry_time.astimezone(timezone.utc).date()
+        exit_date = exit_time.astimezone(timezone.utc).date()
+        return (exit_date - entry_date).days
 
     @staticmethod
     def _signal_for_bar(
@@ -381,8 +418,14 @@ class BacktestEngine:
         gross_exit_level: float,
         exit_reason: str,
         pip_value: float,
+        holding_days: int,
     ) -> Trade:
-        """Apply costs and build the completed ``Trade`` record."""
+        """Apply costs and build the completed ``Trade`` record.
+
+        ``holding_days`` is the calendar-day count between the entry and exit
+        bar UTC dates (see :meth:`_holding_days`); it drives the overnight
+        financing charge (``rate × holding_days`` on the direction's side).
+        """
         # Slippage applies only on stop/target (market) fills, NOT on an
         # end-of-data close at the bar's close price.
         slippage = (
@@ -398,7 +441,10 @@ class BacktestEngine:
             spread_pips=self._cost_params.spread_pips,
             slippage_pips=slippage,
             pip_value=pip_value,
-            swap_pips=0.0,  # D-03
+            swap_long_rate=self._cost_params.swap_long_rate,
+            swap_short_rate=self._cost_params.swap_short_rate,
+            holding_days=holding_days,
+            commission_pips=self._cost_params.commission_pips,
         )
 
         gross_pips = self._pnl_pips(

--- a/backtest/metrics.py
+++ b/backtest/metrics.py
@@ -62,8 +62,9 @@ class Metrics(BaseModel):
     trade_count:
         Total number of completed trades in this result.
     swap_modelled:
-        Carried through from ``BacktestResult.metadata["swap_modelled"]``
-        (INV-06).  ``False`` in the PoC — swap costs are deferred (D-03).
+        Carried through unchanged from ``BacktestResult.metadata["swap_modelled"]``
+        (INV-06).  ``True`` when the run supplied financing rates (the normal
+        Phase-1 path, P1A-T-03); ``False`` only on a spread-only run.
     """
 
     sharpe_ratio: float

--- a/backtest/walkforward.py
+++ b/backtest/walkforward.py
@@ -28,10 +28,12 @@ Approval criteria
 An empty approved set is a valid, non-error result — the caller must handle it
 gracefully (INV-10: no strategy runs live without a passed validation).
 
-INV-06 / D-03 label propagation
+INV-06 swap label propagation
 ---------------------------------
-``ApprovedSetEntry.swap_modelled`` is always ``False`` for the PoC — sourced
-from the underlying ``BacktestResult.metadata`` of the most recent OOS window.
+``ApprovedSetEntry.swap_modelled`` is sourced unchanged from the underlying
+``BacktestResult.metadata`` of the most recent OOS window — ``True`` when
+financing rates were supplied (the normal Phase-1 path, P1A-T-03), ``False``
+only on a spread-only run.
 """
 
 from __future__ import annotations
@@ -83,8 +85,9 @@ class ApprovedSetEntry(BaseModel):
     oos_trade_count_total:
         Sum of OOS trade counts across all test windows.
     swap_modelled:
-        Propagated from the underlying backtest metadata (INV-06).
-        Always ``False`` in the PoC (D-03).
+        Propagated unchanged from the underlying backtest metadata (INV-06).
+        ``True`` when financing was modelled (the normal Phase-1 path,
+        P1A-T-03); ``False`` only on a spread-only run.
     """
 
     instrument: str
@@ -253,7 +256,7 @@ class WalkForwardValidator:
         total_trades = sum(m.trade_count for m in oos_metrics)
 
         # swap_modelled propagated from the last OOS window's backtest metadata
-        # (INV-06, D-03).  Always False in the PoC.
+        # (INV-06).  True when financing was modelled (P1A-T-03).
         swap_modelled = oos_metrics[-1].swap_modelled
 
         return ApprovedSetEntry(

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -309,13 +309,17 @@ def test_apply_costs_invariants(
         spread_pips=spread,
         slippage_pips=slippage,
         pip_value=PIP,
+        swap_long_rate=0.0,
+        swap_short_rate=0.0,
+        holding_days=0,
     )
     assert isinstance(res, CostResult)
+    # No financing rate supplied → swap not modelled (backward-compat path).
     assert res.swap_modelled is False
     if spread > 0 or slippage > 0:
         assert res.total_cost_pips > 0.0
 
-    # Net PnL <= gross PnL (costs never help).
+    # Net PnL <= gross PnL (costs never help when there is no positive carry).
     if direction is Direction.LONG:
         gross = exit_price - entry
         net = res.net_exit - res.net_entry
@@ -325,18 +329,208 @@ def test_apply_costs_invariants(
     assert net <= gross + 1e-12
 
 
-def test_apply_costs_rejects_swap() -> None:
-    """D-03: any non-zero swap_pips is rejected loudly."""
-    with pytest.raises(ValueError, match="swap"):
-        apply_costs(1.10, 1.11, Direction.LONG, 2.0, 1.0, PIP, swap_pips=0.5)
+@settings(max_examples=120)
+@given(
+    spread=st.floats(min_value=0.1, max_value=5.0),
+    slippage=st.floats(min_value=0.0, max_value=3.0),
+    entry=st.floats(min_value=1.05, max_value=1.15),
+    move=st.floats(min_value=-0.005, max_value=0.005),
+    direction=st.sampled_from([Direction.LONG, Direction.SHORT]),
+    long_rate=st.floats(min_value=-0.5, max_value=0.5),
+    short_rate=st.floats(min_value=-0.5, max_value=0.5),
+    holding_days=st.integers(min_value=0, max_value=30),
+)
+def test_apply_costs_inv06_floor_with_financing(
+    spread: float,
+    slippage: float,
+    entry: float,
+    move: float,
+    direction: Direction,
+    long_rate: float,
+    short_rate: float,
+    holding_days: int,
+) -> None:
+    """INV-06 across the financing domain: the spread+slippage+commission floor
+    is strictly > 0 for any non-zero spread/slippage even when positive carry
+    (negative rate) makes the *net* cheaper. Financing never makes the spread
+    path cost-free."""
+    exit_price = entry + move
+    res = apply_costs(
+        entry_price=entry,
+        exit_price=exit_price,
+        direction=direction,
+        spread_pips=spread,
+        slippage_pips=slippage,
+        pip_value=PIP,
+        swap_long_rate=long_rate,
+        swap_short_rate=short_rate,
+        holding_days=holding_days,
+    )
+    # The strictly-positive cost floor is independent of the (possibly negative)
+    # financing term — INV-06's spread+slippage guarantee is never weakened.
+    floor = spread + slippage
+    assert floor > 0.0
+    rate = long_rate if direction is Direction.LONG else short_rate
+    expected_swap = rate * holding_days
+    assert res.total_cost_pips == pytest.approx(floor + expected_swap)
+    # swap_modelled flips True only when a financing rate was supplied.
+    assert res.swap_modelled is (long_rate != 0.0 or short_rate != 0.0)
 
 
-def test_cost_params_rejects_zero_spread_and_swap() -> None:
-    """CostParams enforces spread > 0 and swap == 0 (INV-06 + D-03)."""
+def test_apply_costs_financing_no_longer_raises() -> None:
+    """Both D-03 guard sites are gone: passing financing rates and a non-zero
+    holding period no longer raises (the inline guard and the validator are
+    removed)."""
+    res = apply_costs(
+        1.10,
+        1.11,
+        Direction.LONG,
+        2.0,
+        1.0,
+        PIP,
+        swap_long_rate=0.5,
+        swap_short_rate=-0.3,
+        holding_days=3,
+    )
+    # Long financing = 0.5 × 3 = 1.5 pips on top of spread(2) + slippage(1).
+    assert res.total_cost_pips == pytest.approx(2.0 + 1.0 + 1.5)
+    assert res.swap_modelled is True
+    # And CostParams construction with financing rates is accepted (the
+    # pydantic _swap_must_be_zero validator is gone).
+    CostParams(
+        spread_pips=2.0,
+        slippage_pips=1.0,
+        pip_value=PIP,
+        swap_long_rate=0.5,
+        swap_short_rate=-0.3,
+        commission_pips=0.2,
+    )
+
+
+def test_apply_costs_same_bar_zero_swap() -> None:
+    """holding_days == 0 (same-bar / intraday close) → zero financing, even
+    with non-zero rates supplied."""
+    for direction in (Direction.LONG, Direction.SHORT):
+        res = apply_costs(
+            entry_price=1.10,
+            exit_price=1.105,
+            direction=direction,
+            spread_pips=2.0,
+            slippage_pips=1.0,
+            pip_value=PIP,
+            swap_long_rate=0.9,
+            swap_short_rate=0.7,
+            holding_days=0,
+        )
+        # Floor only — no swap accrued.
+        assert res.total_cost_pips == pytest.approx(3.0)
+        # Rates were supplied, so the model *is* honestly labelled as modelled.
+        assert res.swap_modelled is True
+
+
+def test_apply_costs_financing_direction_aware() -> None:
+    """Financing uses long_rate for longs and short_rate for shorts; charge =
+    rate × holding_days; the engine net PnL is reduced by exactly that charge."""
+    long_res = apply_costs(
+        entry_price=1.10,
+        exit_price=1.10,
+        direction=Direction.LONG,
+        spread_pips=0.0001,  # negligible floor so we isolate the swap term
+        slippage_pips=0.0,
+        pip_value=PIP,
+        swap_long_rate=0.4,
+        swap_short_rate=9.9,  # must be ignored for a long
+        holding_days=5,
+    )
+    short_res = apply_costs(
+        entry_price=1.10,
+        exit_price=1.10,
+        direction=Direction.SHORT,
+        spread_pips=0.0001,
+        slippage_pips=0.0,
+        pip_value=PIP,
+        swap_long_rate=9.9,  # must be ignored for a short
+        swap_short_rate=0.6,
+        holding_days=5,
+    )
+    # Long uses long_rate (0.4 × 5 = 2.0); short uses short_rate (0.6 × 5 = 3.0).
+    assert long_res.total_cost_pips - 0.0001 == pytest.approx(2.0)
+    assert short_res.total_cost_pips - 0.0001 == pytest.approx(3.0)
+    # Net PnL impact: charge folded onto the exit leg, so net PnL drops by the
+    # full charge (in pips) versus a zero-rate baseline.
+    long_pnl = (long_res.net_exit - long_res.net_entry) / PIP
+    base_long = apply_costs(
+        1.10, 1.10, Direction.LONG, 0.0001, 0.0, PIP,
+        swap_long_rate=0.0, swap_short_rate=0.0, holding_days=5,
+    )
+    base_long_pnl = (base_long.net_exit - base_long.net_entry) / PIP
+    assert base_long_pnl - long_pnl == pytest.approx(2.0)
+
+
+def test_apply_costs_positive_carry_improves_net() -> None:
+    """A positive-carry side (negative rate) reduces net cost / improves net PnL
+    but the spread+slippage floor stays strictly positive (INV-06)."""
+    res = apply_costs(
+        entry_price=1.10,
+        exit_price=1.10,
+        direction=Direction.LONG,
+        spread_pips=2.0,
+        slippage_pips=1.0,
+        pip_value=PIP,
+        swap_long_rate=-0.5,  # positive carry
+        swap_short_rate=0.0,
+        holding_days=4,
+    )
+    # total cost = floor(3.0) + (-0.5 × 4 = -2.0) = 1.0 — reduced, still the
+    # spread path itself is not free (floor was 3.0 > 0).
+    assert res.total_cost_pips == pytest.approx(1.0)
+    assert (2.0 + 1.0) > 0.0  # the floor
+
+
+def test_apply_costs_commission_per_round_trip() -> None:
+    """Commission (when > 0) is charged once per round trip, additively."""
+    res = apply_costs(
+        entry_price=1.10,
+        exit_price=1.10,
+        direction=Direction.SHORT,
+        spread_pips=2.0,
+        slippage_pips=0.0,
+        pip_value=PIP,
+        swap_long_rate=0.0,
+        swap_short_rate=0.0,
+        holding_days=0,
+        commission_pips=0.7,
+    )
+    assert res.total_cost_pips == pytest.approx(2.0 + 0.7)
+
+
+def test_apply_costs_rejects_negative_holding_days() -> None:
+    """Negative holding_days is a bug, not a valid input."""
+    with pytest.raises(ValueError, match="holding_days"):
+        apply_costs(
+            1.10, 1.11, Direction.LONG, 2.0, 1.0, PIP,
+            swap_long_rate=0.5, swap_short_rate=0.0, holding_days=-1,
+        )
+
+
+def test_cost_params_rejects_zero_spread() -> None:
+    """CostParams still enforces spread > 0 (INV-06 floor). The D-03
+    swap-must-be-zero validator is gone — financing rates are now accepted."""
     with pytest.raises(ValueError):
         CostParams(spread_pips=0.0, slippage_pips=1.0, pip_value=PIP)
+    # Financing rates of any sign are accepted (no validator rejection).
+    params = CostParams(
+        spread_pips=2.0,
+        slippage_pips=1.0,
+        pip_value=PIP,
+        swap_long_rate=1.0,
+        swap_short_rate=-1.0,
+    )
+    assert params.swap_long_rate == 1.0
+    assert params.swap_short_rate == -1.0
+    # Commission must be non-negative.
     with pytest.raises(ValueError):
-        CostParams(spread_pips=2.0, slippage_pips=1.0, pip_value=PIP, swap_pips=1.0)
+        CostParams(spread_pips=2.0, pip_value=PIP, commission_pips=-0.1)
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +594,85 @@ def test_known_trade_exact_pnl() -> None:
     # Entry time is bar 1's timestamp (next-bar entry, no look-ahead).
     assert t.entry_time == bars[1]["time"]
     assert t.exit_time == bars[2]["time"]
+    # Backward-compat: no financing supplied → swap not modelled.
+    assert result.metadata["swap_modelled"] is False
+
+
+def _known_trade_bars() -> list[Bar]:
+    """The hand-crafted long-target bars from test_known_trade_exact_pnl,
+    reused as the regression baseline and the financing fixture."""
+    return [
+        {"time": EPOCH, "open": 1.09990, "high": 1.10010,
+         "low": 1.09980, "close": 1.10000},
+        {"time": EPOCH + timedelta(hours=1), "open": 1.10000,
+         "high": 1.10090, "low": 1.09990, "close": 1.10050},
+        {"time": EPOCH + timedelta(hours=2), "open": 1.10050,
+         "high": 1.10200, "low": 1.10040, "close": 1.10180},
+    ]
+
+
+def test_known_trade_regression_zero_financing_matches_poc() -> None:
+    """Regression: with swap_long_rate = swap_short_rate = 0 and commission = 0,
+    the engine reproduces the PoC spread+slippage numbers byte-for-byte (the
+    backward-compatibility AC). Same fixture as test_known_trade_exact_pnl."""
+    bars = _known_trade_bars()
+    store = _make_store_from_bars(bars)
+    strat = FixedSignalStrategy(
+        signal_bar=0, direction=Direction.LONG,
+        stop_distance=0.0010, target_distance=0.0015,
+    )
+    result = BacktestEngine(
+        store,
+        CostParams(
+            spread_pips=2.0, slippage_pips=1.0, pip_value=PIP,
+            swap_long_rate=0.0, swap_short_rate=0.0, commission_pips=0.0,
+        ),
+    ).run(strat, "EUR_USD", "H1", EPOCH, bars[-1]["time"])
+    t = result.trades[0]
+    # Identical to the PoC baseline.
+    assert round(t.pnl_net_pips, 5) == 12.00000
+    assert round(t.pnl_pips, 5) == 15.00000
+    assert round(t.cost_pips, 5) == 3.00000
+    assert result.metadata["swap_modelled"] is False
+
+
+def test_engine_holding_days_from_utc_dates_charges_swap() -> None:
+    """INV-03: the engine derives holding_days from entry/exit bar UTC dates and
+    charges rate × days. Same intra-day trade as the baseline but the exit bar
+    is on a later UTC date, so financing is charged and swap_modelled is True.
+
+    The trade is opened on bar 1 (Jan-1) and the target-breaching exit bar is
+    placed two calendar days later → holding_days == 2 → long swap = 0.5×2 = 1.0
+    pip on top of the 3.0-pip floor → net PnL drops from 12.0 to 11.0."""
+    bars: list[Bar] = [
+        {"time": EPOCH, "open": 1.09990, "high": 1.10010,
+         "low": 1.09980, "close": 1.10000},
+        # entry bar — Jan 1
+        {"time": EPOCH + timedelta(hours=1), "open": 1.10000,
+         "high": 1.10090, "low": 1.09990, "close": 1.10050},
+        # exit bar — Jan 3 (2 UTC date boundaries crossed from the entry bar)
+        {"time": EPOCH + timedelta(days=2, hours=1), "open": 1.10050,
+         "high": 1.10200, "low": 1.10040, "close": 1.10180},
+    ]
+    store = _make_store_from_bars(bars)
+    strat = FixedSignalStrategy(
+        signal_bar=0, direction=Direction.LONG,
+        stop_distance=0.0010, target_distance=0.0015,
+    )
+    result = BacktestEngine(
+        store,
+        CostParams(
+            spread_pips=2.0, slippage_pips=1.0, pip_value=PIP,
+            swap_long_rate=0.5, swap_short_rate=0.0,
+        ),
+    ).run(strat, "EUR_USD", "H1", EPOCH, bars[-1]["time"])
+    t = result.trades[0]
+    # entry bar Jan 1, exit bar Jan 3 → 2 financing days; long rate 0.5/day.
+    assert round(t.cost_pips, 5) == 4.00000  # 2 + 1 + (0.5 × 2)
+    assert round(t.pnl_net_pips, 5) == 11.00000  # 12.0 baseline − 1.0 swap
+    assert round(t.pnl_pips, 5) == 15.00000  # gross unchanged
+    assert t.pnl_pips >= t.pnl_net_pips  # INV-06 gross ≥ net
+    assert result.metadata["swap_modelled"] is True
 
 
 def test_known_short_trade_stop_wins_tie() -> None:


### PR DESCRIPTION
Closes #23.

Lifts the PoC swap deferral (D-03) and satisfies **INV-06** in full — all four cost categories (spread, slippage, commission, swap) now modelled.

## Changes
**`backtest/costs.py`**
- `CostParams`: removed `swap_pips` field **and** the `_swap_must_be_zero` validator; added `swap_long_rate`, `swap_short_rate`, `commission_pips: float = 0.0`. `spread_pips` stays `gt=0` (the INV-06 floor).
- `apply_costs(entry_price, exit_price, direction, spread_pips, slippage_pips, pip_value, swap_long_rate, swap_short_rate, holding_days: int, commission_pips=0.0)` — the legacy `swap_pips` param **and** the inline guard (old costs.py:159) are both gone.
- Financing = `rate × holding_days` on the direction's side (long→`swap_long_rate`, short→`swap_short_rate`); commission per round trip. Both folded onto the exit leg so net PnL drops by exactly the charge.
- `swap_modelled = True` whenever a financing rate is supplied.

**`backtest/engine.py`**
- `_holding_days`: calendar days between entry/exit bar **UTC dates** (INV-03). Same-date close → 0 → zero swap.
- Passes financing + `holding_days` into `apply_costs` at both exit sites; metadata carries the honest `swap_modelled`.

## Correctness (INV-06)
The strictly-positive floor is now `spread + slippage + commission` and is independent of the (possibly negative) financing term — positive carry can reduce *net* but never makes the *spread path* free. `gross ≥ net` preserved for any non-positive-carry trade.

## AC verification
- `pytest tests/test_backtest_engine.py -q` → 20 passed
- `pytest -q` (full) → 190 passed, exit 0
- `mypy backtest/` → Success, exit 0

Both D-03 guard sites removed; the rejection tests were replaced (not deleted silently) with guard-removal coverage. PoC spread+slippage numbers reproduced exactly at zero financing (backward-compat regression test).

No new dependencies.