### PR TITLE
P1A-T-08: full-universe backtest runner

### DIFF
--- a/.claude/context/runner.md
+++ b/.claude/context/runner.md
@@ -76,3 +76,78 @@ EXIT: 0
 ("python scripts/poc_run.py — end-to-end PoC..."). Confirmed match; no update needed.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P1A-T-08 — 2026-05-29 (feat/p1a-t-08) — full-universe runner, the capstone/join
+
+**What was done:**
+- New top-level `cli.py` with a `backtest` argparse subcommand (no new dep). Registered as a
+  console entry point `fathom = "cli:main"` in `pyproject.toml` (`[project.scripts]` +
+  `[tool.setuptools] py-modules = ["cli"]` so the single-file module installs). `fathom backtest`
+  is now a real command (CLAUDE.md Commands moved it from "Phase 2+ not built" to "Phase 1A current").
+- Args: `--instruments ALL|EUR_USD,...`, `--timeframes H1,H4,D`, `--strategies all|<keys>`,
+  `--workers N`, `--db-path`, `--history-years`, `--dry-run`.
+- **Universe discovery:** `ALL` → live `OandaClient.list_instruments()` (cached via
+  `Store.upsert_instruments`); `--dry-run ALL` → cached `Store.load_instruments()` only (NO HTTP,
+  Settings/OandaClient never constructed). Explicit `--instruments` list used verbatim.
+- **Six strategies** instantiated from a registry (`macrossover, donchian, bollinger, rsi, roc,
+  session`) with a documented default param grid (`_default_param_grid()`). ROCMomentum takes
+  `instrument`/`timeframe` positionally — handled in `_build_strategy`.
+- **Per-tf window config (D-P1-2 ruling):** `WINDOW_CONFIG` dict — H1=12/3, H4=18/6, D=24/6.
+  Each combo carries its tf's train/test months; passed straight into `WalkForwardValidator.run`.
+  Strict per-window gate unchanged (it lives in WalkForwardValidator).
+- **InstrumentMeta→CostParams mapping (the T-03-deferred boundary, owned here):**
+  `_instrument_costs(store)` maps `long_rate→swap_long_rate`, `short_rate→swap_short_rate`, and
+  `pip_value = 10**pip_location` (−4→0.0001, −2→0.01 JPY). `spread_pips=1.5`, `slippage_pips=0.5`,
+  `commission_pips=0.0` are documented defaults. Fallback for uncached instruments: JPY-aware
+  pip_value, financing 0.0 (→ swap_modelled=False, honest about absent data).
+- **INV-12 single-writer:** module-level worker `_run_combo(spec)` opens its OWN `Store`, runs the
+  validator, returns `Optional[ApprovedSetEntry]`, and NEVER writes. Parent fans out via
+  `ProcessPoolExecutor.map` (or serial when `--workers 1`), collects EVERY result first, sorts by
+  (strategy_name, instrument, granularity), then writes the full batch in ONE
+  `Store.write_approved_set(...)` (single `executemany` + one `commit`).
+- **approved_set table (INV-10 gate):** added to `data/store.py` — `_CREATE_APPROVED_SET_SQL`
+  mirrors `ApprovedSetEntry` (strategy_name, instrument, **granularity**, oos_sharpe_mean,
+  oos_trade_count_total, swap_modelled) + a DB-only `run_timestamp` (UTC RFC 3339). PK is
+  (run_timestamp, strategy_name, instrument, granularity). `ApprovedSetEntry` pydantic model is
+  UNCHANGED — run_timestamp is supplied at `write_approved_set` (DRIFT-03). New `write_approved_set`
+  (single-tx batch) + `load_approved_set` (Phase 2 reads this) methods.
+- **Engine docstring fix:** `backtest/engine.py:181` no longer says "including swap_modelled=False"
+  (financing flips it True since T-03).
+- **Empty approved set → exit 0** with a clear stdout message (INV-10: empty = no signals).
+
+**Key patterns / gotchas:**
+- **ProcessPoolExecutor + monkeypatch don't mix across the process boundary:** a child re-imports
+  `cli` fresh and won't see a parent-side `monkeypatch.setattr(cli, "_run_combo", ...)`. So the
+  INV-12 spy test runs `--workers 1` (serial path, in-process — patch applies); the determinism
+  `--workers 1 vs 4` test uses the REAL worker on real cached daily candles.
+- **store→walkforward circular import avoided:** `Store.write_approved_set` types its param via a
+  `TYPE_CHECKING`-only import of `ApprovedSetEntry` (store→walkforward→engine→store would cycle at
+  runtime); it uses only attribute access, so no runtime import is needed.
+- **Determinism** is guaranteed by: fixed sorted combo order + `map` preserving order + an explicit
+  parent-side sort before write. `--workers 1` and `--workers 4` persist identical tables.
+- Worker silences the expected `compute_metrics` low-trade-count UserWarning (a full-universe scan
+  runs many short windows; it's per-combo noise, not actionable — does NOT change approvals).
+- `--dry-run` over an empty store creates the (empty) approved_set table and exits 0.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/integration/test_backtest_runner.py -q` → 11 passed, exit 0
+- `python -m pytest -q` (full suite) → 360 passed, 85 warnings (pre-existing low-trade UserWarnings),
+  exit 0
+- `python -m mypy cli.py data/store.py backtest/engine.py tests/integration/test_backtest_runner.py`
+  → "Success: no issues found in 4 source files", exit 0
+- `python -m mypy .` (whole tree) → 53 errors, ALL in `tests/test_momentum.py` +
+  `tests/test_breakout.py` — **pre-existing on origin/main** (confirmed by running mypy on a pristine
+  origin/main worktree: identical 53). Surfaced by env mypy 2.1.0 (merged context was on 1.8;
+  `pyproject.toml` pins only `mypy>=1.8`). NOT introduced by T-08; out of this task's scope.
+- `fathom backtest --dry-run --db-path /tmp/x.db --instruments EUR_USD,GBP_USD,USD_JPY --timeframes H1,H4,D`
+  → "...Approved set is empty (a valid result)." exit 0.
+
+**No new dependencies** (argparse, concurrent.futures stdlib). `pyproject.toml`: added
+`[project.scripts] fathom` + `py-modules=["cli"]` (packaging only, not a dependency).
+
+**CLAUDE.md:** Commands section updated — `fathom backtest` is now a current Phase 1A command with
+its full arg list; PoC runner marked superseded.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,16 @@ Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python
 ## Common Commands
 
 ```bash
-# PoC (current)
+# Phase 1A (current)
+fathom backtest               # full-universe walk-forward → persist approved_set table (P1A-T-08)
+#   fathom backtest [--instruments ALL|EUR_USD,...] [--timeframes H1,H4,D]
+#                   [--strategies all|macrossover,donchian,bollinger,rsi,roc,session]
+#                   [--workers N] [--db-path PATH] [--history-years N] [--dry-run]
+
+# PoC (superseded by `fathom backtest`)
 python scripts/poc_run.py     # end-to-end PoC: fetch candles → backtest → approved-set table
 
 # Phase 2+ (not yet built)
-fathom backtest               # run full backtest suite, write approved-set
 fathom scan                   # refresh data, run approved strategies, rank candidates
 fathom watchlist              # output ranked watchlist (called by Hermes)
 fathom chart <pair>           # render candle chart with overlays

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -178,7 +178,9 @@ class BacktestEngine:
         -------
         BacktestResult
             Trades, equity curve (cumulative net pips), and metadata
-            (including ``swap_modelled=False``).
+            (including ``swap_modelled`` — ``True`` when financing rates were
+            supplied via ``CostParams``, ``False`` only on a spread-only run;
+            P1A-T-03 lifted the D-03 swap deferral).
         """
         raw = self._store.load_candles(instrument, granularity, start, end)
         # Defensive copy — never mutate the caller's / store's frame.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,746 @@
+"""Fathom CLI — ``fathom backtest`` (P1A-T-08, the Phase 1A capstone).
+
+The full-universe backtest runner: it walk-forward-validates **every**
+requested (strategy × instrument × timeframe) combination and persists the
+resulting approved-set table to SQLite.  That table is the **INV-10 gate** —
+Phase 2's ranker loads it and refuses to operate if it is empty.
+
+This module composes already-tested Phase 1A pieces:
+
+* ``OandaClient.list_instruments()`` / ``Store.load_instruments()`` — universe
+  discovery (or an explicit ``--instruments`` list).
+* The six shipped strategies (``MACrossover``, ``DonchianBreakout``,
+  ``BollingerReversion``, ``RSIReversion``, ``ROCMomentum``,
+  ``SessionRangeBreakout``), each instantiated with a documented default param
+  grid.
+* ``BacktestEngine`` + the swap-aware ``CostParams`` (P1A-T-03) — every result
+  is INV-06-valid (``swap_modelled=True`` wherever financing data is supplied).
+* ``WalkForwardValidator`` with the strict per-window gate (every OOS window:
+  Sharpe > 0 AND ≥ 5 trades), carried unchanged from the PoC.
+
+Concurrency model (INV-12, single-writer / parent-serialized)
+-------------------------------------------------------------
+Each combo is embarrassingly parallel, so the runner fans out over a
+``concurrent.futures.ProcessPoolExecutor``.  **Worker processes never touch the
+database for writing** — each worker opens its OWN read connection to the
+candle store, runs the validator, and returns a picklable ``ApprovedSetEntry``
+(or ``None``) to the parent.  The PARENT collects *every* future first, then
+performs ALL inserts in ONE transaction via ``Store.write_approved_set``.  A
+partially-failed concurrent write (which INV-10 could not distinguish from a
+legitimately small approved set) is therefore impossible.
+
+Determinism
+-----------
+The approved set is independent of ``--workers``: the combo list is built in a
+fixed, sorted order; ``ProcessPoolExecutor.map`` preserves input order; and the
+parent additionally sorts the collected entries by
+``(strategy_name, instrument, granularity)`` before writing.  ``--workers 1``
+and ``--workers 4`` produce byte-identical tables.
+
+Per-timeframe window sizing (D-P1-2 ruling)
+-------------------------------------------
+The daily timeframe was structurally starved on 3-month test windows in the
+PoC (0–2 trades), so slower timeframes get longer windows:
+
+    H1 → train 12m / test 3m
+    H4 → train 18m / test 6m
+    D  → train 24m / test 6m
+
+INV-03 (all timestamps UTC RFC 3339) and INV-08 (never log the token/account
+ID) are enforced throughout.
+
+Usage
+-----
+    fathom backtest [--instruments ALL|EUR_USD,...] [--timeframes H1,H4,D]
+                    [--strategies all|macrossover,donchian,...]
+                    [--workers N] [--db-path PATH] [--history-years N]
+                    [--dry-run]
+
+An empty approved set is a valid, exit-0 result (INV-10: empty means "no
+signals", not "all signals").
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from backtest.costs import CostParams
+from backtest.engine import BacktestEngine
+from backtest.walkforward import ApprovedSetEntry, WalkForwardValidator
+from data.store import Store
+from strategies.base import Strategy
+from strategies.breakout import SessionRangeBreakout
+from strategies.mean_reversion import BollingerReversion, RSIReversion
+from strategies.momentum import ROCMomentum
+from strategies.trend import DonchianBreakout, MACrossover
+
+# ---------------------------------------------------------------------------
+# Logging — UTC RFC 3339 timestamps (INV-03)
+# ---------------------------------------------------------------------------
+
+
+class _UTCFormatter(logging.Formatter):
+    """Emit log records with UTC RFC 3339 timestamps (INV-03)."""
+
+    def formatTime(  # noqa: N802 (logging API name)
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _configure_logging() -> None:
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(_UTCFormatter("%(asctime)s [%(levelname)s] %(message)s"))
+    root = logging.getLogger()
+    # Idempotent: don't stack handlers if called twice (e.g. in tests).
+    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+        root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+
+_log = logging.getLogger(__name__)
+
+
+def _utc_now_rfc3339() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Per-timeframe walk-forward window config (D-P1-2 ruling)
+# ---------------------------------------------------------------------------
+# Slower timeframes get longer train/test windows so the daily timeframe is
+# not structurally starved (the PoC's daily combos got 0–2 trades on 3-month
+# windows). The strict per-window gate (Sharpe>0 AND >=5 trades) is unchanged.
+
+
+@dataclass(frozen=True)
+class WindowConfig:
+    train_months: int
+    test_months: int
+
+
+WINDOW_CONFIG: dict[str, WindowConfig] = {
+    "H1": WindowConfig(train_months=12, test_months=3),
+    "H4": WindowConfig(train_months=18, test_months=6),
+    "D": WindowConfig(train_months=24, test_months=6),
+}
+
+#: History to fetch/scan per timeframe must comfortably exceed the longest
+#: train+test span so at least one window forms. The default below (3 years)
+#: covers D (24m+6m = 30m) with margin; overridable via --history-years.
+_DEFAULT_HISTORY_YEARS = 3
+
+
+# ---------------------------------------------------------------------------
+# Strategy param grids (documented defaults — one combo each unless noted)
+# ---------------------------------------------------------------------------
+# A "strategy spec" is a (key, label, kwargs) tuple. Kwargs are plain JSON-able
+# values so the spec is trivially picklable; the worker rebuilds the strategy
+# from the registry below. Each entry produces one strategy instance per
+# (instrument, timeframe). Expand the lists here to widen the grid.
+
+_StrategyFactory = Callable[..., Strategy]
+
+#: Maps a strategy spec key → the constructor. The worker uses this to rebuild
+#: the strategy from a picklable spec (constructors themselves are picklable,
+#: but routing through a key keeps the spec a pure data object).
+_STRATEGY_REGISTRY: dict[str, _StrategyFactory] = {
+    "macrossover": MACrossover,
+    "donchian": DonchianBreakout,
+    "bollinger": BollingerReversion,
+    "rsi": RSIReversion,
+    "roc": ROCMomentum,
+    "session": SessionRangeBreakout,
+}
+
+
+def _default_param_grid() -> dict[str, list[dict[str, object]]]:
+    """Return the documented default param grid, keyed by strategy key.
+
+    Each value is a list of kwargs dicts; one strategy instance is built per
+    kwargs dict per (instrument, timeframe). ``instrument`` and ``timeframe``
+    are injected per-combo by the worker, so they are omitted here.
+    """
+    return {
+        "macrossover": [
+            {"fast_period": 10, "slow_period": 50},
+            {"fast_period": 20, "slow_period": 100},
+        ],
+        "donchian": [
+            {"channel_period": 20},
+            {"channel_period": 55},
+        ],
+        "bollinger": [
+            {"period": 20, "num_std": 2.0},
+        ],
+        "rsi": [
+            {"period": 14, "oversold": 30.0, "overbought": 70.0},
+        ],
+        "roc": [
+            # ROCMomentum requires instrument/timeframe positionally — the
+            # worker injects them; here we set only the tuning params.
+            {
+                "roc_period": 10,
+                "roc_threshold": 0.5,
+                "atr_filter_period": 14,
+            },
+        ],
+        "session": [
+            {"range_lookback": 20},
+        ],
+    }
+
+
+def _build_strategy(
+    key: str, params: dict[str, object], instrument: str, timeframe: str
+) -> Strategy:
+    """Instantiate a strategy from its registry key + params + combo context.
+
+    ``instrument``/``timeframe`` are passed to every strategy; ``ROCMomentum``
+    takes them positionally (its signature requires them), the rest as keyword
+    args with empty-string defaults.
+    """
+    factory = _STRATEGY_REGISTRY[key]
+    if key == "roc":
+        return factory(instrument=instrument, timeframe=timeframe, **params)
+    return factory(instrument=instrument, timeframe=timeframe, **params)
+
+
+# ---------------------------------------------------------------------------
+# Combo spec — the picklable unit of work sent to a worker
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComboSpec:
+    """One unit of work: a (strategy, instrument, timeframe) combination.
+
+    All fields are plain data so the spec pickles cleanly across the process
+    pool. The worker reconstructs the Store / engine / strategy from it.
+    """
+
+    strategy_key: str
+    strategy_params: tuple[tuple[str, object], ...]  # frozen kwargs
+    instrument: str
+    timeframe: str
+    # Cost-model inputs mapped from InstrumentMeta at build time (parent side):
+    spread_pips: float
+    slippage_pips: float
+    pip_value: float
+    swap_long_rate: float
+    swap_short_rate: float
+    commission_pips: float
+    # Run context:
+    db_path: str
+    start_iso: str
+    end_iso: str
+    train_months: int
+    test_months: int
+
+    def params_dict(self) -> dict[str, object]:
+        return dict(self.strategy_params)
+
+
+# ---------------------------------------------------------------------------
+# Worker — runs ONE combo and returns an ApprovedSetEntry or None
+# ---------------------------------------------------------------------------
+# Module-level (picklable) so ProcessPoolExecutor can dispatch it. Each worker
+# opens its OWN Store connection (SQLite connections are not shareable across
+# processes) and NEVER writes — it returns the result to the parent (INV-12).
+
+
+def _run_combo(spec: ComboSpec) -> Optional[ApprovedSetEntry]:
+    """Run walk-forward for one combo. Returns its ApprovedSetEntry or None.
+
+    Opens a private read connection to the candle store, builds the swap-aware
+    ``CostParams`` (mapping already done on the parent side), constructs the
+    strategy + engine, and runs the validator with this timeframe's window
+    sizing. Any per-combo failure is swallowed into ``None`` so one bad combo
+    cannot abort the whole universe run; the parent logs counts.
+
+    THE WORKER NEVER WRITES TO THE DB (INV-12).
+    """
+    # The walk-forward scan deliberately runs many short windows; the
+    # low-trade-count UserWarning from compute_metrics is expected per-combo
+    # noise here (the strict gate rejects those windows anyway). Silence it
+    # within the worker so the universe run's logs stay readable. This does NOT
+    # change which combos are approved.
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=r"compute_metrics:.*statistically meaningless",
+        category=UserWarning,
+    )
+
+    store = Store(spec.db_path)
+    try:
+        cost_params = CostParams(
+            spread_pips=spec.spread_pips,
+            slippage_pips=spec.slippage_pips,
+            pip_value=spec.pip_value,
+            swap_long_rate=spec.swap_long_rate,
+            swap_short_rate=spec.swap_short_rate,
+            commission_pips=spec.commission_pips,
+        )
+        engine = BacktestEngine(store=store, cost_params=cost_params)
+        strategy = _build_strategy(
+            spec.strategy_key,
+            spec.params_dict(),
+            spec.instrument,
+            spec.timeframe,
+        )
+        validator = WalkForwardValidator(engine=engine, strategy=strategy)
+        start = datetime.fromisoformat(spec.start_iso)
+        end = datetime.fromisoformat(spec.end_iso)
+        result = validator.run(
+            instrument=spec.instrument,
+            granularity=spec.timeframe,
+            start=start,
+            end=end,
+            train_months=spec.train_months,
+            test_months=spec.test_months,
+        )
+        return result.approved_set_entry
+    except Exception:  # noqa: BLE001 — one bad combo must not kill the run
+        return None
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Cost-model mapping: InstrumentMeta → CostParams inputs (the T-03 boundary)
+# ---------------------------------------------------------------------------
+# Documented defaults for spread/slippage (per-instrument typical spread could
+# be substituted later). pip_value is derived from pip_location: a pip is
+# 10**pip_location (e.g. -4 → 0.0001 for majors, -2 → 0.01 for JPY pairs).
+# long_rate/short_rate map straight onto swap_long_rate/swap_short_rate.
+
+_DEFAULT_SPREAD_PIPS = 1.5
+_DEFAULT_SLIPPAGE_PIPS = 0.5
+_DEFAULT_COMMISSION_PIPS = 0.0
+
+
+def _pip_value_from_location(pip_location: int) -> float:
+    """A pip is ``10 ** pip_location`` (−4 → 0.0001, −2 → 0.01)."""
+    return float(10.0**pip_location)
+
+
+@dataclass(frozen=True)
+class InstrumentCost:
+    """Cost-model inputs for one instrument (mapped from InstrumentMeta)."""
+
+    pip_value: float
+    swap_long_rate: float
+    swap_short_rate: float
+    spread_pips: float = _DEFAULT_SPREAD_PIPS
+    slippage_pips: float = _DEFAULT_SLIPPAGE_PIPS
+    commission_pips: float = _DEFAULT_COMMISSION_PIPS
+
+
+def _instrument_costs(store: Store) -> dict[str, InstrumentCost]:
+    """Build per-instrument cost inputs from cached InstrumentMeta rows.
+
+    Maps ``InstrumentMeta.long_rate → swap_long_rate``,
+    ``short_rate → swap_short_rate``, and derives ``pip_value`` from
+    ``pip_location`` (the T-03-deferred boundary mapping, owned here).
+    """
+    costs: dict[str, InstrumentCost] = {}
+    for meta in store.load_instruments():
+        costs[meta.name] = InstrumentCost(
+            pip_value=_pip_value_from_location(meta.pip_location),
+            swap_long_rate=meta.long_rate,
+            swap_short_rate=meta.short_rate,
+        )
+    return costs
+
+
+def _fallback_cost(instrument: str) -> InstrumentCost:
+    """Cost inputs when an instrument has no cached metadata.
+
+    pip_value falls back to the JPY-aware default: JPY pairs use 0.01, others
+    0.0001. Financing rates default to 0.0 (→ swap_modelled=False for that
+    combo) — honest: we did not model financing we have no data for.
+    """
+    pip_value = 0.01 if instrument.endswith("_JPY") else 0.0001
+    return InstrumentCost(
+        pip_value=pip_value, swap_long_rate=0.0, swap_short_rate=0.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Universe discovery
+# ---------------------------------------------------------------------------
+
+
+def _discover_universe(
+    instruments_arg: str,
+    db_path: str,
+    dry_run: bool,
+) -> list[str]:
+    """Return the list of instrument identifiers to run.
+
+    * An explicit comma-separated ``--instruments`` value is used verbatim.
+    * ``ALL`` (or ``all``) discovers the full FX universe. In ``--dry-run`` we
+      read the cached ``instruments`` table (no HTTP); otherwise we fetch via
+      ``OandaClient.list_instruments()`` and cache the result.
+
+    INV-08: the OANDA token / account ID are never logged here.
+    """
+    if instruments_arg.strip().upper() != "ALL":
+        return [s.strip() for s in instruments_arg.split(",") if s.strip()]
+
+    store = Store(db_path)
+    try:
+        cached = [m.name for m in store.load_instruments()]
+    finally:
+        store.close()
+
+    if dry_run:
+        _log.info(
+            "Universe (ALL, dry-run): %d instruments from cached metadata.",
+            len(cached),
+        )
+        return sorted(cached)
+
+    # Live discovery — import lazily so --dry-run never constructs Settings.
+    from config.settings import Settings
+    from data.oanda_client import OandaClient
+
+    settings = Settings()
+    # INV-08: log only non-secret config.
+    _log.info("Discovering universe via OANDA (env=%s).", settings.env)
+    client = OandaClient(settings)
+    metas = client.list_instruments()
+    store = Store(db_path)
+    try:
+        store.upsert_instruments(metas)
+    finally:
+        store.close()
+    names = sorted(m.name for m in metas)
+    _log.info("Universe (ALL): %d FX instruments discovered.", len(names))
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Combo list construction (parent side — deterministic order)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_strategy_keys(strategies_arg: str) -> list[str]:
+    if strategies_arg.strip().lower() == "all":
+        return list(_STRATEGY_REGISTRY.keys())
+    keys = [s.strip().lower() for s in strategies_arg.split(",") if s.strip()]
+    unknown = [k for k in keys if k not in _STRATEGY_REGISTRY]
+    if unknown:
+        raise ValueError(
+            f"Unknown strategy key(s): {unknown}. "
+            f"Valid: {sorted(_STRATEGY_REGISTRY)}"
+        )
+    return keys
+
+
+def _build_combos(
+    instruments: list[str],
+    timeframes: list[str],
+    strategy_keys: list[str],
+    instrument_costs: dict[str, InstrumentCost],
+    db_path: str,
+    start: datetime,
+    end: datetime,
+) -> list[ComboSpec]:
+    """Build the full, deterministically-ordered combo list.
+
+    Order is fixed (sorted instrument, timeframe, strategy key, param index) so
+    the run is reproducible regardless of worker count. Each timeframe pulls
+    its own train/test window sizing from ``WINDOW_CONFIG``.
+    """
+    grid = _default_param_grid()
+    start_iso = start.isoformat()
+    end_iso = end.isoformat()
+    combos: list[ComboSpec] = []
+
+    for instrument in sorted(instruments):
+        cost = instrument_costs.get(instrument) or _fallback_cost(instrument)
+        for timeframe in timeframes:
+            wc = WINDOW_CONFIG[timeframe]
+            for strategy_key in strategy_keys:
+                for params in grid[strategy_key]:
+                    combos.append(
+                        ComboSpec(
+                            strategy_key=strategy_key,
+                            strategy_params=tuple(sorted(params.items())),
+                            instrument=instrument,
+                            timeframe=timeframe,
+                            spread_pips=cost.spread_pips,
+                            slippage_pips=cost.slippage_pips,
+                            pip_value=cost.pip_value,
+                            swap_long_rate=cost.swap_long_rate,
+                            swap_short_rate=cost.swap_short_rate,
+                            commission_pips=cost.commission_pips,
+                            db_path=db_path,
+                            start_iso=start_iso,
+                            end_iso=end_iso,
+                            train_months=wc.train_months,
+                            test_months=wc.test_months,
+                        )
+                    )
+    return combos
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def _print_approved_table(entries: list[ApprovedSetEntry]) -> None:
+    """Print the approved-set table to stdout."""
+    if not entries:
+        print(
+            "No (strategy, pair, timeframe) combination passed walk-forward "
+            "validation. Approved set is empty (a valid result)."
+        )
+        return
+
+    header = (
+        f"{'Strategy':<40} {'Instrument':<10} {'Gran':<5} "
+        f"{'OOS Sharpe':>12} {'OOS Trades':>11} {'Swap':<6}"
+    )
+    separator = "-" * len(header)
+    print()
+    print("=== Approved-Set Table ===")
+    print(separator)
+    print(header)
+    print(separator)
+    for e in entries:
+        print(
+            f"{e.strategy_name:<40} {e.instrument:<10} {e.granularity:<5} "
+            f"{e.oos_sharpe_mean:>12.4f} {e.oos_trade_count_total:>11} "
+            f"{str(e.swap_modelled):<6}"
+        )
+    print(separator)
+    print(f"Total approved entries: {len(entries)}")
+    print()
+
+
+def _sort_key(e: ApprovedSetEntry) -> tuple[str, str, str]:
+    """Deterministic ordering for the approved set (worker-count independent)."""
+    return (e.strategy_name, e.instrument, e.granularity)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fathom",
+        description="Fathom CLI.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bt = sub.add_parser(
+        "backtest",
+        help="Run full-universe walk-forward validation; persist approved-set.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    bt.add_argument(
+        "--instruments",
+        default="ALL",
+        help="ALL to discover the full FX universe, or a comma-separated list.",
+    )
+    bt.add_argument(
+        "--timeframes",
+        default="H1,H4,D",
+        help="Comma-separated timeframes (each must have a window config).",
+    )
+    bt.add_argument(
+        "--strategies",
+        default="all",
+        help=(
+            "'all' or a comma-separated subset of: "
+            + ",".join(_STRATEGY_REGISTRY.keys())
+        ),
+    )
+    bt.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help="ProcessPoolExecutor worker count (results are worker-independent).",
+    )
+    bt.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite candle + approved_set store.",
+    )
+    bt.add_argument(
+        "--history-years",
+        type=int,
+        default=_DEFAULT_HISTORY_YEARS,
+        metavar="N",
+        help="Years of history to scan (must exceed the longest train+test span).",
+    )
+    bt.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Cache-only: never fetch from OANDA and never construct Settings; "
+            "run walk-forward against whatever candles are already cached."
+        ),
+    )
+    return parser
+
+
+def _build_date_range(history_years: int) -> tuple[datetime, datetime]:
+    end = datetime.now(tz=timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    start = end - timedelta(days=history_years * 365)
+    return start, end
+
+
+# ---------------------------------------------------------------------------
+# backtest command
+# ---------------------------------------------------------------------------
+
+
+def cmd_backtest(args: argparse.Namespace) -> int:
+    """Execute the ``fathom backtest`` command. Returns the process exit code."""
+    run_dt = datetime.now(tz=timezone.utc)
+    _log.info("fathom backtest started at %s", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    timeframes = [s.strip() for s in args.timeframes.split(",") if s.strip()]
+    for tf in timeframes:
+        if tf not in WINDOW_CONFIG:
+            _log.error(
+                "Timeframe %r has no window config. Known: %s",
+                tf,
+                sorted(WINDOW_CONFIG),
+            )
+            return 2
+
+    try:
+        strategy_keys = _resolve_strategy_keys(args.strategies)
+    except ValueError as exc:
+        _log.error("%s", exc)
+        return 2
+
+    db_path: str = args.db_path
+    dry_run: bool = args.dry_run
+
+    # Universe discovery (cache-only under --dry-run; no HTTP, no Settings).
+    try:
+        instruments = _discover_universe(args.instruments, db_path, dry_run)
+    except Exception as exc:  # noqa: BLE001
+        _log.error("Universe discovery failed: %s", exc)
+        return 1
+
+    if not instruments:
+        _log.warning(
+            "No instruments to run (empty universe). Approved set is empty."
+        )
+        _print_approved_table([])
+        return 0
+
+    # Per-instrument cost inputs from cached metadata (T-03 boundary mapping).
+    store = Store(db_path)
+    try:
+        instrument_costs = _instrument_costs(store)
+    finally:
+        store.close()
+
+    start, end = _build_date_range(args.history_years)
+    _log.info(
+        "Range %s → %s | instruments=%d timeframes=%s strategies=%s workers=%d",
+        start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        len(instruments),
+        timeframes,
+        strategy_keys,
+        args.workers,
+    )
+
+    combos = _build_combos(
+        instruments=instruments,
+        timeframes=timeframes,
+        strategy_keys=strategy_keys,
+        instrument_costs=instrument_costs,
+        db_path=db_path,
+        start=start,
+        end=end,
+    )
+    _log.info("Built %d (strategy, pair, timeframe) combos.", len(combos))
+
+    # ---- Fan out over the process pool. Workers return entries; the PARENT
+    # ---- collects ALL of them before any DB write (INV-12). --------------
+    results: list[Optional[ApprovedSetEntry]] = []
+    workers = max(1, args.workers)
+    if workers == 1:
+        # Serial path — identical results, simpler stack traces, and used by
+        # the determinism test as the reference.
+        results = [_run_combo(c) for c in combos]
+    else:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            # map preserves input order → deterministic collection.
+            results = list(pool.map(_run_combo, combos))
+
+    approved = [r for r in results if r is not None]
+    # Parent-side deterministic sort: the persisted table is byte-identical
+    # regardless of --workers.
+    approved.sort(key=_sort_key)
+    _log.info(
+        "Walk-forward complete: %d/%d combos approved.",
+        len(approved),
+        len(combos),
+    )
+
+    # ---- Single-writer, single-transaction persist (INV-10 + INV-12). -----
+    store = Store(db_path)
+    try:
+        written = store.write_approved_set(approved, run_timestamp=run_dt)
+    finally:
+        store.close()
+    _log.info(
+        "Persisted %d approved_set rows (run_timestamp=%s).",
+        written,
+        run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
+    _print_approved_table(approved)
+
+    _log.info(
+        "fathom backtest finished at %s. Approved entries: %d.",
+        _utc_now_rfc3339(),
+        len(approved),
+    )
+    # Empty approved set is a valid result — exit 0 (INV-10).
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    _configure_logging()
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "backtest":
+        return cmd_backtest(args)
+    parser.error(f"Unknown command: {args.command}")
+    return 2  # unreachable — parser.error exits
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/store.py
+++ b/data/store.py
@@ -31,11 +31,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from data.oanda_client import CandleRow, InstrumentMeta
+
+if TYPE_CHECKING:
+    # Import for typing only — importing at runtime would create a cycle
+    # (store → walkforward → engine → store).  ``write_approved_set`` uses
+    # only attribute access on the entries, so a TYPE_CHECKING import is safe.
+    from backtest.walkforward import ApprovedSetEntry
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +133,35 @@ class Store:
         )
     """
 
+    #: SQL to create the approved_set table if it does not already exist.
+    #: Mirrors the shipped ``ApprovedSetEntry`` model (strategy_name,
+    #: instrument, granularity, oos_sharpe_mean, oos_trade_count_total,
+    #: swap_modelled) plus a DB-table-only ``run_timestamp`` (UTC RFC 3339).
+    #: This is the INV-10 gate Phase 2's ranker reads.  The column is named
+    #: ``granularity`` (the shipped field name — not "timeframe").
+    _CREATE_APPROVED_SET_SQL: str = """
+        CREATE TABLE IF NOT EXISTS approved_set (
+            run_timestamp          TEXT    NOT NULL,
+            strategy_name          TEXT    NOT NULL,
+            instrument             TEXT    NOT NULL,
+            granularity            TEXT    NOT NULL,
+            oos_sharpe_mean        REAL    NOT NULL,
+            oos_trade_count_total  INTEGER NOT NULL,
+            swap_modelled          INTEGER NOT NULL,
+            PRIMARY KEY (run_timestamp, strategy_name, instrument, granularity)
+        )
+    """
+
+    #: SQL to insert one approved_set row.  ``INSERT OR REPLACE`` keeps a re-run
+    #: with the same ``run_timestamp`` idempotent.
+    _INSERT_APPROVED_SET_SQL: str = """
+        INSERT OR REPLACE INTO approved_set
+            (run_timestamp, strategy_name, instrument, granularity,
+             oos_sharpe_mean, oos_trade_count_total, swap_modelled)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?)
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
     _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
@@ -180,6 +217,7 @@ class Store:
         """Create the ``candles`` and ``instruments`` tables if needed."""
         self._conn.execute(self._CREATE_CANDLES_SQL)
         self._conn.execute(self._CREATE_INSTRUMENTS_SQL)
+        self._conn.execute(self._CREATE_APPROVED_SET_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -436,6 +474,112 @@ class Store:
                     short_rate=short_rate,
                     financing_days_of_week=json.loads(financing_days_json),
                 )
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Approved-set table (INV-10 gate; INV-12 single-writer)
+    # ------------------------------------------------------------------
+
+    def write_approved_set(
+        self,
+        entries: Iterable["ApprovedSetEntry"],
+        run_timestamp: datetime,
+    ) -> int:
+        """Persist a batch of approved-set entries in ONE transaction (INV-12).
+
+        This is the single-writer commit point for the ``approved_set`` table.
+        The full-universe backtest runner collects every ``ApprovedSetEntry``
+        from its worker processes into a list (no worker touches the DB) and
+        hands the complete batch here; this method performs all inserts inside
+        one ``executemany`` + ``commit`` so the table is written atomically —
+        either every approved combination lands or none does.  A partial write
+        (which INV-10 could not distinguish from a legitimately small set) is
+        therefore impossible.
+
+        The DB-only ``run_timestamp`` column is supplied here at the
+        persistence layer; the ``ApprovedSetEntry`` pydantic model is unchanged
+        (audit DRIFT-03).  The same ``run_timestamp`` is stamped on every row of
+        the batch.
+
+        Args:
+            entries: The complete batch of ``ApprovedSetEntry`` objects to
+                persist.  May be empty (an empty approved set is a valid result
+                — INV-10: empty means "no signals", not "all signals").
+            run_timestamp: UTC-aware timestamp for this run, stored as RFC 3339
+                TEXT on every row (INV-03).
+
+        Returns:
+            The number of rows written.
+        """
+        ts_str = _to_rfc3339(run_timestamp)
+        params = [
+            (
+                ts_str,
+                e.strategy_name,
+                e.instrument,
+                e.granularity,
+                float(e.oos_sharpe_mean),
+                int(e.oos_trade_count_total),
+                1 if e.swap_modelled else 0,
+            )
+            for e in entries
+        ]
+        # Single transaction: executemany + one commit. Even an empty batch is
+        # committed (a no-op) so the call site has uniform semantics.
+        self._conn.executemany(self._INSERT_APPROVED_SET_SQL, params)
+        self._conn.commit()
+        return len(params)
+
+    def load_approved_set(
+        self,
+        run_timestamp: datetime | None = None,
+    ) -> list[dict[str, object]]:
+        """Load approved-set rows (the INV-10 gate Phase 2 reads).
+
+        Args:
+            run_timestamp: If given, return only rows for that run (matched on
+                the RFC 3339 string); otherwise return all rows.
+
+        Returns:
+            A list of dicts, one per row, with keys ``run_timestamp``,
+            ``strategy_name``, ``instrument``, ``granularity``,
+            ``oos_sharpe_mean``, ``oos_trade_count_total``, ``swap_modelled``
+            (``swap_modelled`` coerced back to ``bool``).  Empty list when the
+            table has no matching rows.
+        """
+        if run_timestamp is not None:
+            cursor = self._conn.execute(
+                """
+                SELECT run_timestamp, strategy_name, instrument, granularity,
+                       oos_sharpe_mean, oos_trade_count_total, swap_modelled
+                FROM   approved_set
+                WHERE  run_timestamp = ?
+                ORDER  BY strategy_name, instrument, granularity
+                """,
+                (_to_rfc3339(run_timestamp),),
+            )
+        else:
+            cursor = self._conn.execute(
+                """
+                SELECT run_timestamp, strategy_name, instrument, granularity,
+                       oos_sharpe_mean, oos_trade_count_total, swap_modelled
+                FROM   approved_set
+                ORDER  BY run_timestamp, strategy_name, instrument, granularity
+                """
+            )
+        result: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            result.append(
+                {
+                    "run_timestamp": row[0],
+                    "strategy_name": row[1],
+                    "instrument": row[2],
+                    "granularity": row[3],
+                    "oos_sharpe_mean": row[4],
+                    "oos_trade_count_total": row[5],
+                    "swap_modelled": bool(row[6]),
+                }
             )
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,13 @@ dev = [
     "hypothesis>=6.0",
 ]
 
+[project.scripts]
+fathom = "cli:main"
+
+[tool.setuptools]
+# Top-level single-file modules (not packages) that must be installed.
+py-modules = ["cli"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["config*", "data*", "strategies*", "backtest*", "scripts*"]

--- a/tests/integration/test_backtest_runner.py
+++ b/tests/integration/test_backtest_runner.py
@@ -1,0 +1,466 @@
+"""Integration tests for the ``fathom backtest`` runner (P1A-T-08).
+
+Design (NO live HTTP)
+---------------------
+* Candle data lives in a real SQLite file in ``tmp_path`` (cached fixtures).
+* The OANDA universe is provided via cached ``instruments`` rows (the
+  ``--dry-run`` path reads cached metadata and never constructs ``Settings`` or
+  ``OandaClient``) — so no network and no ``.env`` is required.
+* In-process tests drive ``cli.cmd_backtest`` / ``cli.main`` directly so they
+  can assert on the persisted ``approved_set`` table, on per-timeframe window
+  config, and on the single-writer (INV-12) contract via a write spy.
+* A subprocess ``--dry-run`` smoke confirms the console entry point exits 0.
+
+What is asserted
+----------------
+1. Combos are built across H1/H4/D (one row per strategy × pair × timeframe).
+2. Per-timeframe window sizing is consulted (WINDOW_CONFIG, D-P1-2 ruling).
+3. The approved set is persisted with a ``granularity`` column (not
+   "timeframe") and a DB-only ``run_timestamp`` (UTC RFC 3339).
+4. INV-12: workers return entries; the PARENT performs all inserts in ONE
+   ``write_approved_set`` call — workers never write. Proven with a spy that
+   asserts ``write_approved_set`` is called exactly once, after every combo
+   has been collected.
+5. Empty approved set → exit 0.
+6. Determinism: ``--workers 1`` and ``--workers 4`` persist byte-identical
+   tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, cast
+
+import pytest
+
+import cli
+from backtest.walkforward import ApprovedSetEntry
+from data.oanda_client import CandleRow, InstrumentMeta
+from data.store import Store
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: cached candles + cached instrument metadata (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candle(
+    instrument: str, granularity: str, t: datetime, price: float
+) -> CandleRow:
+    return CandleRow(
+        instrument=instrument,
+        granularity=granularity,
+        time=t,
+        open_bid=price,
+        high_bid=price + 0.0030,
+        low_bid=price - 0.0030,
+        close_bid=price + 0.0001,
+        open_ask=price + 0.0002,
+        high_ask=price + 0.0032,
+        low_ask=price - 0.0028,
+        close_ask=price + 0.0003,
+        open_mid=price + 0.0001,
+        high_mid=price + 0.0031,
+        low_mid=price - 0.0029,
+        close_mid=price + 0.0002,
+        volume=100,
+        complete=True,
+    )
+
+
+def _populate_daily(store: Store, instrument: str, n_days: int = 1100) -> None:
+    """~3 years of daily candles with a sinusoidal walk (creates crossovers)."""
+    base = _utc(2023, 1, 1)
+    rows = []
+    for i in range(n_days):
+        t = base + timedelta(days=i)
+        delta = 0.0080 * math.sin(2 * math.pi * i / 180)
+        rows.append(_make_candle(instrument, "D", t, 1.1000 + delta))
+    store.upsert(rows)
+
+
+def _instruments() -> list[InstrumentMeta]:
+    return [
+        InstrumentMeta(
+            name="EUR_USD",
+            pip_location=-4,
+            min_trade_size=1.0,
+            margin_rate=0.02,
+            display_precision=5,
+            long_rate=-0.0001,  # financing data present → swap_modelled True
+            short_rate=0.00005,
+            financing_days_of_week=[2],
+        ),
+        InstrumentMeta(
+            name="USD_JPY",
+            pip_location=-2,
+            min_trade_size=1.0,
+            margin_rate=0.04,
+            display_precision=3,
+            long_rate=0.0002,
+            short_rate=-0.0003,
+            financing_days_of_week=[2],
+        ),
+    ]
+
+
+@pytest.fixture()
+def populated_db(tmp_path: Path) -> str:
+    """SQLite file with daily candles for two pairs + cached instrument meta."""
+    db_path = str(tmp_path / "fathom_test.db")
+    store = Store(db_path)
+    for inst in ("EUR_USD", "USD_JPY"):
+        _populate_daily(store, inst)
+    store.upsert_instruments(_instruments())
+    store.close()
+    return db_path
+
+
+@pytest.fixture()
+def empty_db(tmp_path: Path) -> str:
+    """An empty store (schema only, no candles, no instruments)."""
+    db_path = str(tmp_path / "empty.db")
+    Store(db_path).close()
+    return db_path
+
+
+def _ns(**overrides: object) -> argparse.Namespace:
+    """Build a backtest args Namespace with sensible test defaults."""
+    base: dict[str, object] = dict(
+        instruments="EUR_USD,USD_JPY",
+        timeframes="H1,H4,D",
+        strategies="all",
+        workers=1,
+        db_path="",
+        history_years=3,
+        dry_run=True,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# Combo building + per-timeframe windows
+# ---------------------------------------------------------------------------
+
+
+class TestComboBuilding:
+    def test_combos_span_all_timeframes(self) -> None:
+        cost = {
+            "EUR_USD": cli.InstrumentCost(
+                pip_value=0.0001, swap_long_rate=0.0, swap_short_rate=0.0
+            )
+        }
+        start = _utc(2023, 1, 1)
+        end = _utc(2026, 1, 1)
+        combos = cli._build_combos(
+            instruments=["EUR_USD"],
+            timeframes=["H1", "H4", "D"],
+            strategy_keys=list(cli._STRATEGY_REGISTRY.keys()),
+            instrument_costs=cost,
+            db_path="x.db",
+            start=start,
+            end=end,
+        )
+        tfs = {c.timeframe for c in combos}
+        assert tfs == {"H1", "H4", "D"}
+
+    def test_per_timeframe_window_sizing_applied(self) -> None:
+        """Each combo carries the WINDOW_CONFIG sizing for its timeframe."""
+        cost = {
+            "EUR_USD": cli.InstrumentCost(
+                pip_value=0.0001, swap_long_rate=0.0, swap_short_rate=0.0
+            )
+        }
+        combos = cli._build_combos(
+            instruments=["EUR_USD"],
+            timeframes=["H1", "H4", "D"],
+            strategy_keys=["macrossover"],
+            instrument_costs=cost,
+            db_path="x.db",
+            start=_utc(2023, 1, 1),
+            end=_utc(2026, 1, 1),
+        )
+        by_tf = {c.timeframe: (c.train_months, c.test_months) for c in combos}
+        assert by_tf["H1"] == (12, 3)
+        assert by_tf["H4"] == (18, 6)
+        assert by_tf["D"] == (24, 6)
+
+    def test_instrument_meta_maps_to_cost_params(self) -> None:
+        """long_rate→swap_long_rate, short_rate→swap_short_rate, pip from loc."""
+        store_path = ":memory:"
+        store = Store(store_path)
+        store.upsert_instruments(_instruments())
+        costs = cli._instrument_costs(store)
+        store.close()
+        eur = costs["EUR_USD"]
+        assert eur.pip_value == pytest.approx(0.0001)  # 10**-4
+        assert eur.swap_long_rate == pytest.approx(-0.0001)
+        assert eur.swap_short_rate == pytest.approx(0.00005)
+        jpy = costs["USD_JPY"]
+        assert jpy.pip_value == pytest.approx(0.01)  # 10**-2 (JPY)
+
+
+# ---------------------------------------------------------------------------
+# Persistence schema: granularity + run_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceSchema:
+    def test_approved_set_table_has_granularity_column(self, empty_db: str) -> None:
+        store = Store(empty_db)
+        cols = [
+            row[1]
+            for row in store._conn.execute(
+                "PRAGMA table_info(approved_set)"
+            ).fetchall()
+        ]
+        store.close()
+        assert "granularity" in cols
+        assert "timeframe" not in cols  # the shipped field name, not "timeframe"
+        assert "run_timestamp" in cols
+
+    def test_write_approved_set_stamps_run_timestamp(self, empty_db: str) -> None:
+        store = Store(empty_db)
+        entry = ApprovedSetEntry(
+            instrument="EUR_USD",
+            granularity="H1",
+            strategy_name="MACrossover(10,50)",
+            oos_sharpe_mean=1.23,
+            oos_trade_count_total=42,
+            swap_modelled=True,
+        )
+        run_dt = datetime(2026, 5, 29, 8, 0, 0, tzinfo=timezone.utc)
+        n = store.write_approved_set([entry], run_timestamp=run_dt)
+        rows = store.load_approved_set()
+        store.close()
+        assert n == 1
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["run_timestamp"] == "2026-05-29T08:00:00Z"  # UTC RFC 3339
+        assert r["granularity"] == "H1"
+        assert r["strategy_name"] == "MACrossover(10,50)"
+        assert r["oos_sharpe_mean"] == pytest.approx(1.23)
+        assert r["oos_trade_count_total"] == 42
+        assert r["swap_modelled"] is True
+
+
+# ---------------------------------------------------------------------------
+# INV-12: single-writer, parent-serialized, one transaction
+# ---------------------------------------------------------------------------
+
+
+def _fake_entry(spec: "cli.ComboSpec") -> ApprovedSetEntry:
+    """Deterministic synthetic approver keyed off the combo identity."""
+    return ApprovedSetEntry(
+        instrument=spec.instrument,
+        granularity=spec.timeframe,
+        strategy_name=f"{spec.strategy_key}::{dict(spec.strategy_params)}",
+        oos_sharpe_mean=1.0,
+        oos_trade_count_total=10,
+        swap_modelled=spec.swap_long_rate != 0.0 or spec.swap_short_rate != 0.0,
+    )
+
+
+class TestSingleWriterInv12:
+    def test_parent_writes_exactly_once_after_all_combos(
+        self, populated_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """INV-12: a single write_approved_set call performs ALL inserts.
+
+        We monkeypatch the worker to a pure function (no DB write) and spy on
+        the Store write method. The spy must be called exactly once, with the
+        FULL batch — proving no worker writes and the parent serializes the
+        write into one transaction.
+        """
+        # Worker returns an entry and never touches the DB for writing.
+        monkeypatch.setattr(cli, "_run_combo", _fake_entry)
+
+        write_calls: list[tuple[int, str]] = []
+        real_write = Store.write_approved_set
+
+        def spy_write(
+            self: Store,
+            entries: Iterable[ApprovedSetEntry],
+            run_timestamp: datetime,
+        ) -> int:
+            batch = list(entries)
+            write_calls.append((len(batch), run_timestamp.isoformat()))
+            return real_write(self, batch, run_timestamp)
+
+        monkeypatch.setattr(Store, "write_approved_set", spy_write)
+
+        rc = cli.cmd_backtest(_ns(db_path=populated_db, workers=1))
+        assert rc == 0
+        # Exactly ONE write — the parent's single-transaction insert.
+        assert len(write_calls) == 1, (
+            f"INV-12 violated: expected exactly one write_approved_set call, "
+            f"got {len(write_calls)}."
+        )
+        batch_size = write_calls[0][0]
+        # The single batch holds every combo's entry (all 'approved' here).
+        store = Store(populated_db)
+        persisted = store.load_approved_set()
+        store.close()
+        assert len(persisted) == batch_size
+        assert batch_size > 0
+
+    def test_no_partial_write_all_or_nothing(
+        self, populated_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The persisted count equals the number of approved entries collected."""
+        monkeypatch.setattr(cli, "_run_combo", _fake_entry)
+        rc = cli.cmd_backtest(_ns(db_path=populated_db, workers=1))
+        assert rc == 0
+        store = Store(populated_db)
+        rows = store.load_approved_set()
+        store.close()
+        # 2 instruments × 3 timeframes × (sum of param-grid sizes per strategy)
+        expected = 0
+        grid = cli._default_param_grid()
+        per_combo = sum(len(grid[k]) for k in cli._STRATEGY_REGISTRY)
+        expected = 2 * 3 * per_combo
+        assert len(rows) == expected
+
+
+# ---------------------------------------------------------------------------
+# Empty approved set → exit 0
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyApprovedSet:
+    def test_empty_store_exits_zero(self, empty_db: str) -> None:
+        rc = cli.cmd_backtest(_ns(db_path=empty_db, instruments="EUR_USD"))
+        assert rc == 0
+        store = Store(empty_db)
+        assert store.load_approved_set() == []
+        store.close()
+
+    def test_real_walkforward_on_cached_data_exits_zero(
+        self, populated_db: str
+    ) -> None:
+        """End-to-end with the REAL worker over cached daily candles: exit 0.
+
+        Daily candles only, so H1/H4 windows simply find no data (empty
+        DataFrame → no windows → not approved) and D windows run for real.
+        Whatever the edge, the run must complete and persist a table (possibly
+        empty) and exit 0.
+        """
+        rc = cli.cmd_backtest(
+            _ns(db_path=populated_db, timeframes="D", strategies="macrossover")
+        )
+        assert rc == 0
+        store = Store(populated_db)
+        rows = store.load_approved_set()
+        store.close()
+        # Table exists and is queryable; every persisted row is granularity 'D'.
+        for r in rows:
+            assert r["granularity"] == "D"
+
+
+# ---------------------------------------------------------------------------
+# Determinism across worker counts
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_workers_1_vs_4_identical_table(self, tmp_path: Path) -> None:
+        """--workers 1 and --workers 4 persist identical approved sets.
+
+        Uses the REAL worker over real cached daily candles (the monkeypatched
+        fake worker cannot be used here: a ProcessPoolExecutor child re-imports
+        ``cli`` fresh and would not see a parent-side monkeypatch). The two runs
+        must agree regardless of which combinations are approved — determinism
+        is the property under test, not the contents of the approved set.
+        """
+
+        def _setup(name: str) -> str:
+            db = str(tmp_path / name)
+            store = Store(db)
+            for inst in ("EUR_USD", "USD_JPY"):
+                _populate_daily(store, inst, n_days=900)
+            store.upsert_instruments(_instruments())
+            store.close()
+            return db
+
+        db1 = _setup("w1.db")
+        db4 = _setup("w4.db")
+
+        # Run a small but non-trivial grid on the daily timeframe (the cached
+        # data is daily). Both worker counts traverse the same combo list; a
+        # trimmed strategy set keeps the parallel path exercised but fast.
+        common: dict[str, object] = dict(
+            timeframes="D", strategies="macrossover,donchian,bollinger"
+        )
+        assert cli.cmd_backtest(_ns(db_path=db1, workers=1, **common)) == 0
+        assert cli.cmd_backtest(_ns(db_path=db4, workers=4, **common)) == 0
+
+        def _normalised(db: str) -> list[tuple[object, ...]]:
+            store = Store(db)
+            rows = store.load_approved_set()
+            store.close()
+            # Drop run_timestamp (wall-clock, differs between runs); compare the
+            # content that must be deterministic.
+            return [
+                (
+                    r["strategy_name"],
+                    r["instrument"],
+                    r["granularity"],
+                    round(float(cast(float, r["oos_sharpe_mean"])), 10),
+                    r["oos_trade_count_total"],
+                    r["swap_modelled"],
+                )
+                for r in rows
+            ]
+
+        rows1 = _normalised(db1)
+        rows4 = _normalised(db4)
+        assert rows1 == rows4
+
+
+# ---------------------------------------------------------------------------
+# Subprocess --dry-run smoke (console entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunSmoke:
+    def test_dry_run_subprocess_exits_zero(self, tmp_path: Path) -> None:
+        db = str(tmp_path / "smoke.db")
+        Store(db).close()  # empty store, schema only
+        project_root = str(Path(__file__).parent.parent.parent)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "cli",
+                "backtest",
+                "--dry-run",
+                "--db-path",
+                db,
+                "--instruments",
+                "EUR_USD",
+                "--timeframes",
+                "H1,H4,D",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+        assert result.returncode == 0, (
+            f"dry-run smoke expected exit 0, got {result.returncode}.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "Approved set is empty" in result.stdout
+        # INV-08: no token/account-id strings leaked.
+        combined = (result.stdout + result.stderr).upper()
+        assert "OANDA_API_TOKEN" not in combined
+        assert "OANDA_ACCOUNT_ID" not in combined


### PR DESCRIPTION
Closes #28.

The Phase 1A capstone/join: a `fathom backtest` CLI that walk-forward-validates every (strategy × pair × timeframe) combination across the full FX universe and persists the approved-set table — the **INV-10 gate** Phase 2's ranker reads.

## What's here
- **`cli.py`** — `fathom backtest` (argparse, no new dep), registered as console entry point `fathom = cli:main`.
  - `--instruments ALL|...` (universe via `list_instruments()`, cached under `--dry-run` — no HTTP), `--timeframes H1,H4,D`, `--strategies all|<keys>`, `--workers N`, `--db-path`, `--history-years`, `--dry-run`.
  - All six strategies with a documented default param grid.
- **Per-timeframe windows (D-P1-2 ruling):** H1 = 12/3, H4 = 18/6, D = 24/6. Strict per-window gate (Sharpe > 0 AND ≥ 5 trades) unchanged — it lives in `WalkForwardValidator`.
- **InstrumentMeta→CostParams mapping** (the boundary T-03 deferred here): `long_rate → swap_long_rate`, `short_rate → swap_short_rate`, `pip_value = 10**pip_location`; documented default spread/slippage. Engine computes `holding_days` → swap modelled (INV-06 full, `swap_modelled=True` where financing data is present).
- **`approved_set` SQLite table** (in `data/store.py`): mirrors `ApprovedSetEntry` + a DB-only `run_timestamp` (UTC RFC 3339). Column is **`granularity`** (not "timeframe"). `ApprovedSetEntry` pydantic model is **unchanged** — `run_timestamp` is supplied at the persistence layer (DRIFT-03).
- **Engine docstring fix** at `engine.py:181` (stale "including swap_modelled=False").

## INV-12 — single-writer, parent-serialized
`ProcessPoolExecutor` workers each open their **own** `Store`, run the validator, and return `ApprovedSetEntry` objects — **no worker writes the DB**. The parent collects every future first, sorts deterministically, then writes the full batch in **one** `executemany` + `commit` (`Store.write_approved_set`). A partial write that INV-10 could not distinguish from a legitimately small set is therefore impossible.

## Determinism, INV-03, INV-08
Fixed sorted combo order + `map` order + a parent-side sort → `--workers 1` and `--workers 4` persist identical tables. All log timestamps UTC RFC 3339; the token/account-id are never logged (cache-only `--dry-run` never even constructs `Settings`). Empty approved set → exit 0 with a clear message.

## Tests (cached SQLite + cached instrument meta — NO live HTTP)
`tests/integration/test_backtest_runner.py` (11 tests): combos span H1/H4/D; per-tf window sizing applied; `granularity` + `run_timestamp` persisted; **INV-12 single-write proven via a spy** (exactly one `write_approved_set`, full batch); empty-set exits 0; `--workers 1` vs `4` identical; `--dry-run` subprocess smoke exits 0.

## Verification (raw)
- `pytest tests/integration/test_backtest_runner.py -q` → **11 passed, exit 0**
- `pytest -q` (full) → **360 passed, exit 0**
- `mypy cli.py data/store.py backtest/engine.py tests/integration/test_backtest_runner.py` → **Success, exit 0**
- `mypy .` → 53 errors, **all pre-existing** in `tests/test_momentum.py` + `tests/test_breakout.py` (identical on a pristine `origin/main`; surfaced by env mypy 2.1.0 vs the 1.8 the merged context used; `pyproject.toml` pins only `mypy>=1.8`). Not introduced here.
- `fathom backtest --dry-run --db-path /tmp/x.db --instruments EUR_USD,GBP_USD,USD_JPY --timeframes H1,H4,D` → empty-set message, **exit 0**.

No new dependencies (argparse + concurrent.futures are stdlib). `pyproject.toml` adds only the console-script + `py-modules` packaging entries.