### PR TITLE
test: fix mypy 2.1 arg-type errors in strategy test files

### DIFF
--- a/tests/test_breakout.py
+++ b/tests/test_breakout.py
@@ -27,7 +27,7 @@ from strategies.breakout import SessionRangeBreakout
 
 def _utc(*args: int) -> datetime:
     """Convenience constructor: _utc(Y, M, D, H=0, Min=0)."""
-    return datetime(*args, tzinfo=timezone.utc)
+    return datetime(*args, tzinfo=timezone.utc)  # type: ignore[misc, arg-type]
 
 
 def _make_h1_candles(

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -14,12 +14,21 @@ AC coverage (P1A-T-06):
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import TypedDict
 
 import pandas as pd
 import pytest
 
 from strategies.base import Direction, Signal
 from strategies.momentum import ROCMomentum
+
+
+class _ROCMomentumParams(TypedDict):
+    instrument: str
+    timeframe: str
+    roc_period: int
+    roc_threshold: float
+    atr_filter_period: int
 
 
 # ---------------------------------------------------------------------------
@@ -94,13 +103,13 @@ def _flat_then_surge(
     return _make_candles(closes, highs=highs, lows=lows)
 
 
-_DEFAULT_PARAMS = dict(
-    instrument="EUR_USD",
-    timeframe="H1",
-    roc_period=10,
-    roc_threshold=0.005,
-    atr_filter_period=20,
-)
+_DEFAULT_PARAMS: _ROCMomentumParams = {
+    "instrument": "EUR_USD",
+    "timeframe": "H1",
+    "roc_period": 10,
+    "roc_threshold": 0.005,
+    "atr_filter_period": 20,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -122,23 +131,23 @@ class TestROCMomentumConstruction:
 
     def test_invalid_roc_period_zero(self) -> None:
         with pytest.raises(ValueError, match="roc_period"):
-            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_period": 0})
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_period": 0})  # type: ignore[arg-type]
 
     def test_invalid_roc_threshold_zero(self) -> None:
         with pytest.raises(ValueError, match="roc_threshold"):
-            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": 0.0})
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": 0.0})  # type: ignore[arg-type]
 
     def test_invalid_roc_threshold_negative(self) -> None:
         with pytest.raises(ValueError, match="roc_threshold"):
-            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": -0.01})
+            ROCMomentum(**{**_DEFAULT_PARAMS, "roc_threshold": -0.01})  # type: ignore[arg-type]
 
     def test_invalid_atr_filter_period_zero(self) -> None:
         with pytest.raises(ValueError, match="atr_filter_period"):
-            ROCMomentum(**{**_DEFAULT_PARAMS, "atr_filter_period": 0})
+            ROCMomentum(**{**_DEFAULT_PARAMS, "atr_filter_period": 0})  # type: ignore[arg-type]
 
     def test_invalid_rr_ratio_zero(self) -> None:
         with pytest.raises(ValueError, match="rr_ratio"):
-            ROCMomentum(**{**_DEFAULT_PARAMS, "rr_ratio": 0.0})
+            ROCMomentum(**{**_DEFAULT_PARAMS, "rr_ratio": 0.0})  # type: ignore[arg-type]
 
     def test_default_rr_ratio_is_1_5(self) -> None:
         strat = ROCMomentum(**_DEFAULT_PARAMS)


### PR DESCRIPTION
## Summary

- Resolves all 53 pre-existing mypy errors in `tests/test_momentum.py` and `tests/test_breakout.py` introduced by mypy 2.1's stricter unpacking checks.
- No test logic, assertions, fixtures, or values changed — type annotations only.
- All shipped modules remain untouched; this is test-only type hygiene.

## Approach per file

**`tests/test_momentum.py`** (51 errors → 0):
- Introduced a precise `_ROCMomentumParams` `TypedDict` (5 required keys matching `_DEFAULT_PARAMS`) so that `ROCMomentum(**_DEFAULT_PARAMS)` type-checks cleanly without any ignore.
- For the 5 call sites that merge `_DEFAULT_PARAMS` with a single override key (`{**_DEFAULT_PARAMS, "roc_period": 0}` etc.), a targeted `# type: ignore[arg-type]` was added per line. These are genuinely heterogeneous dict-merge expressions (testing invalid constructor args) that cannot be narrowed further without rewriting the tests.

**`tests/test_breakout.py`** (2 errors → 0):
- The `[misc]` + `[arg-type]` pair on line 30 came from `_utc(*args: int)` calling `datetime(*args, tzinfo=timezone.utc)`. mypy 2.1 rejects unpacking `tuple[int, ...]` into `datetime`'s precise positional signature and flags a potential duplicate `tzinfo` keyword. Added a single targeted `# type: ignore[misc, arg-type]` on that line; runtime behaviour is correct and the function already constrains callers to int-only args.

## Verification

```
$ python -m mypy .
Success: no issues found in 37 source files
Exit code: 0

$ python -m pytest -q
362 passed, 85 warnings in 97.44s
Exit code: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)