### PR TITLE
docs: Phase 1A results (10/72 approved + engine perf fix)

### DIFF
--- a/docs/phases/phase-1a-results.md
+++ b/docs/phases/phase-1a-results.md
@@ -1,0 +1,52 @@
+# Fathom Phase 1A — Results
+
+**Run date:** 2026-05-29 (live OANDA demo data, cached; backtest via `fathom backtest`)
+**Verdict:** ✅ **10 of 72 combos approved** — genuine out-of-sample edge found across the broader strategy set.
+**Engine:** O(n) precompute engine (PR #40) — the run that previously hung at 30+ min now completes in **22 seconds**.
+
+---
+
+## What was tested
+
+- **Pairs:** EUR_USD, GBP_USD, USD_JPY (the 3 majors — representative acceptance; full ~70-pair universe now feasible, see Performance below)
+- **Timeframes:** H1, H4, D — with per-timeframe walk-forward windows (H1 12m/3m, H4 18m/6m, D 24m/6m)
+- **Strategies (6):** MA crossover, Donchian breakout, Bollinger/z-score, RSI, ROC momentum, session/range breakout
+- **Combos:** 72 (strategy × pair × timeframe × default params)
+- **Costs:** spread + slippage + swap (INV-06 fully modelled)
+- **Gate:** strict per-window — every OOS window Sharpe > 0 AND ≥ 5 trades
+
+## Approved set (10 combos)
+
+| Strategy | Pair | TF | OOS Sharpe (mean) | OOS trades (total) |
+|---|---|---|---|---|
+| BollingerReversion(20,2.0) | EUR_USD | D | 2.00 | 7 |
+| BollingerReversion(20,2.0) | USD_JPY | D | 1.03 | 9 |
+| BollingerReversion(20,2.0) | GBP_USD | D | 0.63 | 7 |
+| DonchianBreakout(20) | GBP_USD | D | 0.56 | 6 |
+| SessionRangeBreakout(20) | GBP_USD | D | 0.56 | 6 |
+| SessionRangeBreakout(20) | GBP_USD | H4 | 0.29 | 95 |
+| DonchianBreakout(20) | GBP_USD | H4 | 0.25 | 114 |
+| MACrossover(10,50) | USD_JPY | H4 | 0.21 | 38 |
+| RSIReversion(14,30,70) | EUR_USD | H4 | 0.19 | 39 |
+| DonchianBreakout(55) | USD_JPY | H4 | 0.10 | 61 |
+
+## Honest reading
+
+- **Mean-reversion (Bollinger) on the daily timeframe is the standout** — Sharpe 0.6–2.0 across all three majors. But these rest on only **6–9 trades** over the full out-of-sample period — **below the ~20-trade statistical-meaningfulness threshold** (the metrics emit a warning under 20). Treat the daily results as **suggestive, not proven** — a handful of good trades can produce a high Sharpe by luck.
+- **The H4 breakout/Donchian/MA/RSI combos are more trustworthy** — modest Sharpe (0.1–0.3) but on **38–114 trades**, which is enough to take more seriously.
+- **MACrossover alone is weak** (consistent with the PoC) — it only clears the gate on USD_JPY H4, and barely.
+- This is a backtest, not proof of profitability. Per INV-07, these are candidates for the **demo track record** to validate, not a green light to trade.
+
+## Key engineering finding (the real Phase 1A story)
+
+The original event-driven engine was **O(n²)**: it called each strategy's `generate_signals` on an expanding `df.iloc[:i+1]` slice every bar, recomputing the full indicator history per bar (~200 bars/sec). This made the 3-major H1 run take 30+ minutes and the full universe impractical (days). The PoC's small single-strategy data masked it; reviewers checked correctness, not complexity; **the acceptance gate caught it.**
+
+Fixed in PR #40 (precompute `generate_signals(df)` once → O(n)), proven **byte-identical** to the old engine for all six strategies via an equivalence regression test (this also surfaced and fixed an inconsistent warm-up guard in MACrossover/RSIReversion). Result: **~1080× faster** (175s → 0.16s for a 4,663-bar backtest).
+
+## Performance — full universe now feasible
+
+3 pairs × 3 timeframes (72 combos) = **22 seconds**. The full ~70-pair universe (~1,300 combos) extrapolates to **~7 minutes** — practical, where before it was days. No vectorised pre-screen needed (D-P1-1 stays "skip").
+
+## Status
+
+Phase 1A acceptance gate (T-09 / #29): **PASSED** on the 3-major representative run. The full-universe production run is now a quick follow-up. Next: epic 1B (live-streaming ready; economic-calendar needs a provider) or Phase 2 (watchlist → Discord), which consumes this approved-set.


### PR DESCRIPTION
Records the Phase 1A acceptance result: 10/72 combos approved (genuine OOS edge), the O(n^2)→O(n) engine fix the gate caught, and the honest low-trade-count caveats. Closes #29.