### PR TITLE
docs: Phase 1B plan (live-data groundwork)

### DIFF
--- a/docs/features/economic-calendar.md
+++ b/docs/features/economic-calendar.md
@@ -1,6 +1,6 @@
 # Feature: economic-calendar
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 1
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -38,17 +38,19 @@ Backend module. `EconomicCalendar(...)` exposing `upcoming_events(currencies, wi
 
 - `config/settings.py` (for any provider key), `data/store.py` (operational persistence) — exist on `main`.
 
-External:
-- An economic-calendar/news data source (provider TBD — see Open questions). Could be a free calendar API or a scraped feed.
+External (provider decided 2026-05-29):
+- **FairEconomy / ForexFactory weekly calendar XML feed** — `https://nfs.faireconomy.media/ff_calendar_thisweek.xml` (and the `nextweek` variant). Free, **no auth/key**. Each `<event>` carries `<title>`, `<country>` (currency code: USD/EUR/GBP/JPY/…), `<date>`, `<time>`, `<impact>` (High/Medium/Low/Holiday), `<forecast>`, `<previous>`. Fits demo-first / self-hosted / no-paid-services. Built behind the `EconomicCalendar` interface so it can be swapped for a paid/official provider later without rippling.
 
 ## Approach
 
-Define `CalendarEvent` + an `EconomicCalendar` interface with a concrete provider implementation behind it. Pull on a schedule (invoked by the Phase 2 Hermes job later; for Phase 1 a manual/CLI refresh suffices), normalise impact + currency, store to SQLite. Keep the provider behind the interface so the (uncertain) data source can change without touching consumers.
+Define `CalendarEvent` + an `EconomicCalendar` ABC, with a concrete `FairEconomyCalendar` provider behind it (fetch the weekly XML via `httpx`, parse with the stdlib XML parser). Normalise `<impact>` → the high/medium/low enum (map `Holiday`→low or skip), tag `<country>` → currency. Pull on demand (Phase 2's Hermes job schedules it later; a manual/CLI refresh suffices for Phase 1). Store to SQLite operational state, idempotent upsert keyed on (currency, event_name, time). Keep the provider behind the interface.
+
+**INV-03 is the sharp edge here:** the FF feed publishes times in a fixed display timezone (historically US Eastern / a feed-configured TZ), **not** UTC. The provider MUST convert each event's date+time from the feed's timezone to UTC before constructing `CalendarEvent.time`. Parse defensively (missing/`All Day`/tentative times) and document the source-TZ assumption; a wrong TZ conversion silently shifts every event.
 
 ## Open questions
 
-- **Provider choice** — this is the main unknown. Options: a free economic-calendar API (rate-limited), a paid feed, or scraping (fragile). OANDA's v20 API does *not* provide an economic calendar (it has a separate, deprecated labs calendar endpoint). Decide the provider before drafting the Plan; it determines auth, rate limits, and the impact-level mapping. **Blocking for this spec's implementation, not for the rest of Phase 1.**
-- Headline/news feed: bundle with the calendar provider, or separate source? (Lean: calendar first; headlines are a softer Phase 2 input.)
+- Feed timezone: confirm the exact TZ the FF XML emits (it has historically been US Eastern; verify against a known event at fetch time). The provider must convert to UTC regardless (INV-03).
+- Headline/news feed: deferred — calendar only for Phase 1; headlines are a softer Phase 2 input.
 
 ## Out of scope
 

--- a/docs/phases/phase-1b-taskgraph.md
+++ b/docs/phases/phase-1b-taskgraph.md
@@ -1,0 +1,83 @@
+# Fathom Phase 1B — Task Graph (Live-Data Groundwork)
+
+> ✅ **APPROVED — proceeding** (user greenlit "finish Phase 1"; calendar provider decided 2026-05-29).
+
+Completes Phase 1: the live-data groundwork 1A deferred (off the approved-set critical path; groundwork for Phase 2's live signals + news-risk). Both 1B specs are `ready`.
+
+## Decision applied
+
+- **Calendar provider:** free FairEconomy/ForexFactory weekly XML feed (no auth), behind the pluggable `EconomicCalendar` interface. (See economic-calendar.md.)
+
+## Summary
+
+| Item | Value |
+|---|---|
+| Tasks | 3 (2 code + 1 manual acceptance) |
+| Model split | 2 sonnet, 1 manual |
+| Parallel | 1B-T-01 ∥ 1B-T-02 at t=0 (distinct new files: `data/stream.py` vs `data/calendar.py`) |
+| Critical path | 2 hops: {T-01, T-02} → T-03 |
+| New deps | none for stream (oandapyV20 present); `httpx` for calendar IF not already present — coordinator-branch edit if so |
+| Invariants | INV-03 (UTC — sharp for both), INV-08 (no token/key logged), INV-09 (env-scoped) |
+
+## Dependency graph
+
+```mermaid
+flowchart TD
+    T01["1B-T-01 live-streaming\ndata/stream.py · 🔧 sonnet"]
+    T02["1B-T-02 economic-calendar\ndata/calendar.py · 🔧 sonnet"]
+    T03["1B-T-03 acceptance\n🔵 manual · human-admin"]
+    T01 --> T03
+    T02 --> T03
+    style T03 fill:#dbeafe,stroke:#3b82f6
+```
+
+Both code tasks depend only on the existing data layer / config / store (all on `main`) — fully parallel, distinct files. No `strategies/__init__.py`-style shared-file contention this time.
+
+## Tasks
+
+### 1B-T-01 — live-streaming
+| Field | Value |
+|---|---|
+| area | data · surface backend · **model** sonnet (read-only price stream; a bug means missed ticks, not bad trades — INV-01 unaffected) |
+| feature_spec | `docs/features/live-streaming.md` |
+| depends_on | _(none — existing data layer on main)_ |
+| worktree | `../fathom-p1b-T-01-stream` |
+| verification | auto — mocked `PricingStream`: yields UTC-aware `PriceTick`s; heartbeat resets liveness timer; heartbeat-timeout → reconnect; reconnect uses capped exp backoff + jitter; `gap_detected` raised on reconnect; clean shutdown (no orphaned thread); typed errors not raw |
+
+`data/stream.py`: `PriceStream(settings, instruments)` over `oandapyV20.endpoints.pricing.PricingStream`, background thread + thread-safe queue (spec lean). INV-03 (UTC ticks), INV-08 (no token logged), INV-09 (env from settings). **No live HTTP in tests** — mock the stream generator.
+
+### 1B-T-02 — economic-calendar
+| Field | Value |
+|---|---|
+| area | data · surface backend · **model** sonnet |
+| feature_spec | `docs/features/economic-calendar.md` |
+| depends_on | _(none — existing config/store on main)_ |
+| worktree | `../fathom-p1b-T-02-calendar` |
+| verification | auto — parse a **fixture FF XML** (no live HTTP): `CalendarEvent`s with UTC-aware times (feed-TZ→UTC conversion correct), impact normalised, currency tagged; idempotent upsert; provider behind the `EconomicCalendar` ABC |
+
+`data/calendar.py`: `EconomicCalendar` ABC + `FairEconomyCalendar` provider (fetch weekly XML via `httpx`, parse stdlib XML). **INV-03 sharp edge:** convert the feed's display-TZ times to UTC — a fixture test must assert a known event lands at the right UTC instant. INV-08: no key needed (free feed); if a configurable URL/key is ever added it lives in `.env`.
+**library_defaults:** `httpx` — confirm whether it's already a dep (oandapyV20 may pull `requests`, not httpx); if NEW, the coordinator adds it to `pyproject.toml` + CLAUDE.md Stack. `httpx` defaults: 5s timeout is None by default — set an explicit timeout; raises on `.raise_for_status()` only when called.
+
+### 1B-T-03 — acceptance (manual)
+| Field | Value |
+|---|---|
+| area | data · **model** n/a — human/lead-run · **human_admin** true (live demo token for the stream) |
+| depends_on | 1B-T-01, 1B-T-02 |
+| verification | manual |
+
+Checklist: `PriceStream` connects to the live **practice** endpoint and yields real ticks (UTC-aware) for a few seconds, reconnects cleanly on a forced drop; `FairEconomyCalendar` fetches the live weekly XML, stores events with correct UTC times + impact + currency. No token/key in logs. Save a short note to `docs/phases/phase-1-results.md` (or append to 1a-results) confirming both work; then Phase 1 (1A+1B) is complete.
+
+## Sanity checks
+
+| Check | Result |
+|---|---|
+| DAG acyclic | ✓ {T-01,T-02} → T-03 |
+| Parallel slot | ✓ T-01 ∥ T-02 (distinct new files, no shared edits) |
+| Invariants mapped | ✓ INV-03/08/09 on both; INV-01 explicitly unaffected (read-only stream) |
+| Shared-file contention | ✓ none (new files; only `pyproject.toml`/CLAUDE.md if httpx is new → coordinator) |
+| No-live-HTTP in tests | ✓ both verified with mocks/fixtures |
+| Acceptance task present | ✓ T-03 (live demo) |
+
+## Post-approval handoff
+
+Open 3 issues (`area:data`/`phase:p1b`/`role:sonnet`; T-03 `blocked-on-human`, no role). Dispatch T-01 ∥ T-02; fresh read-only reviewer per PR → `gh pr merge --squash --delete-branch`; if `httpx` is new, coordinator applies the dep edit first. T-03 is lead/human-run against the live demo. On pass, Phase 1 is complete → Phase 2 (watchlist → Discord) consumes the 1A approved-set.


### PR DESCRIPTION
Taskgraph for the rest of Phase 1: live-streaming + economic-calendar (free FF/FairEconomy XML feed). Both specs ready. Proceeding to orchestrate.