### PR TITLE
1B-T-02: economic-calendar (FF XML)

### DIFF
--- a/.claude/context/data.md
+++ b/.claude/context/data.md
@@ -143,3 +143,53 @@
 **CLAUDE.md trigger-table:** pyproject.toml dep added → CLAUDE.md Stack updated (YES).
 
 **Merge plan:** `gh pr merge 31 --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## 1B-T-02 — 2026-05-29 (feat/p1b-t-02)
+
+**What was done:**
+- Created `data/calendar.py` with:
+  - `Impact(str, Enum)` — high / medium / low values.
+  - `CalendarEvent` (plain class with `__slots__`) — fields: `currency`, `event_name`,
+    `time` (UTC-aware, INV-03 enforced in `__init__`), `impact`, optional `actual/forecast/previous`.
+    Raises `ValueError` for naive datetimes.
+  - `EconomicCalendar` ABC — `refresh() -> int` and `upcoming_events(currencies, window) -> list[CalendarEvent]`.
+  - `FairEconomyCalendar(EconomicCalendar)` — fetches the free FairEconomy/ForexFactory weekly XML
+    (`ff_calendar_thisweek.xml` and optionally `ff_calendar_nextweek.xml`) via `httpx` with an explicit
+    10 s timeout (httpx default is None — never use the default). Parses with `xml.etree.ElementTree`.
+    Persists to a `calendar_events` SQLite table (its own connection; `CREATE TABLE IF NOT EXISTS`).
+    Upsert is `INSERT OR REPLACE` keyed on `(currency, event_name, time)`.
+- Created `tests/test_calendar.py` — 25 tests, all fixture-based (no live HTTP).
+  `httpx.Client.get` never called in tests; `_fetch` is patched via `MagicMock`.
+
+**INV-03 (the sharp edge) — feed TZ → UTC conversion:**
+- `FEED_TZ = "America/New_York"` is the single documented assumption. The FF feed publishes
+  times in US Eastern (EDT in summer, EST in winter — DST-aware via `zoneinfo.ZoneInfo`).
+- Each `<date>` + `<time>` pair is parsed as a naive datetime, given the feed TZ, then
+  converted to UTC via `.astimezone(timezone.utc)` before `CalendarEvent.time` is set.
+- `All Day` / `Tentative` / empty times fall back to midnight in the feed TZ (then → UTC).
+- Fixture test asserts the UTC instant: NFP `8:30am EDT on 2025-06-06` → `2025-06-06T12:30:00Z`.
+- BOJ `11:50pm EDT on June 5` → `2025-06-06T03:50:00Z` (crosses UTC midnight — verified).
+
+**Impact mapping (documented in module docstring):**
+- `High → Impact.high`, `Medium → Impact.medium`, `Low → Impact.low`, `Holiday → Impact.low`
+  (Holiday not skipped; consumers can filter). Unknown strings default to `Impact.low` defensively.
+
+**Patterns established:**
+- `_to_rfc3339()` imported from `data.store` (shared RFC 3339 formatter — no duplication).
+- `FairEconomyCalendar` carries its own SQLite connection (separate from `Store`) because
+  the calendar module is self-contained; callers may use a shared DB path for co-location.
+- `httpx.Client` used as a context manager with `timeout=HTTP_TIMEOUT_SECONDS` (10 s).
+  `resp.raise_for_status()` called explicitly; `httpx.HTTPStatusError` / `httpx.TimeoutException`
+  propagate to callers.
+
+**AC verification results:**
+- `pytest tests/test_calendar.py -v` → 25 passed, exit 0
+- `pytest -v` (full suite) → 390 passed, exit 0
+- `mypy data/` → "Success: no issues found in 5 source files", exit 0
+
+**New dependency:** `httpx>=0.27` added to `pyproject.toml`.
+**CLAUDE.md trigger-table:** pyproject.toml dep added → CLAUDE.md Stack updated (YES).
+
+**Merge plan:** `gh pr merge 46 --squash --delete-branch` (lead action after reviewer pass)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 
 ## Stack at a Glance
 
-Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · pyarrow>=14 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
+Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · pyarrow>=14 · httpx>=0.27 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
 
 **Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests) · hypothesis>=6.0 (property-based tests for the backtest engine — no-look-ahead / fill / cost invariants)
 

--- a/data/calendar.py
+++ b/data/calendar.py
@@ -1,0 +1,534 @@
+"""Economic calendar — CalendarEvent model, EconomicCalendar ABC, and
+FairEconomyCalendar provider (FairEconomy / ForexFactory weekly XML feed).
+
+INV-03 (sharp edge):
+    The ForexFactory XML feed publishes event times in a fixed display timezone
+    — historically US Eastern (America/New_York, UTC-5 in winter / UTC-4 in
+    summer, i.e. with DST).  The feed does NOT emit UTC.  Every date+time pair
+    read from the XML is therefore interpreted as America/New_York and converted
+    to UTC before constructing CalendarEvent.time.
+
+    If the feed TZ assumption is wrong, every event will be silently shifted.
+    The assumption is documented here and verified by a fixture test that checks
+    a known event against its expected UTC instant.
+
+    Source TZ constant: FEED_TZ = "America/New_York"
+
+Impact normalisation (from FF XML <impact> field):
+    High    → Impact.high
+    Medium  → Impact.medium
+    Low     → Impact.low
+    Holiday → Impact.low  (treated as low-impact, not skipped, so calendar
+                            consumers can filter or highlight holidays explicitly)
+
+INV-08: The free FairEconomy feed requires no API key.  If a configurable URL
+    is added, it lives in .env (Settings), never hardcoded with a secret.
+
+INV-09: No demo/live branch in logic; any future provider-URL config is read
+    from Settings the same way regardless of env.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone, timedelta
+from enum import Enum
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from data.store import _to_rfc3339  # shared RFC 3339 formatter (INV-03)
+
+# ---------------------------------------------------------------------------
+# Feed timezone assumption (INV-03)
+# ---------------------------------------------------------------------------
+
+#: The ForexFactory XML feed publishes times in US Eastern (with DST).
+#: This constant is the single place that records and enforces that assumption.
+FEED_TZ: str = "America/New_York"
+
+#: Default feed URLs (no auth required — INV-08).
+FF_THIS_WEEK_URL: str = "https://nfs.faireconomy.media/ff_calendar_thisweek.xml"
+FF_NEXT_WEEK_URL: str = "https://nfs.faireconomy.media/ff_calendar_nextweek.xml"
+
+#: httpx timeout in seconds.  httpx default is None (no timeout); we set an
+#: explicit value so a stalled feed does not hang the process indefinitely.
+HTTP_TIMEOUT_SECONDS: float = 10.0
+
+# ---------------------------------------------------------------------------
+# Impact enum
+# ---------------------------------------------------------------------------
+
+
+class Impact(str, Enum):
+    """Normalised event-impact level (high/medium/low)."""
+
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+# Mapping from raw FF XML <impact> strings to our enum.
+# Holiday is mapped to low (not skipped) so consumers can filter explicitly.
+_IMPACT_MAP: dict[str, Impact] = {
+    "High": Impact.high,
+    "Medium": Impact.medium,
+    "Low": Impact.low,
+    "Holiday": Impact.low,
+}
+
+# ---------------------------------------------------------------------------
+# CalendarEvent model
+# ---------------------------------------------------------------------------
+
+
+class CalendarEvent:
+    """A single economic calendar event, fully normalised and UTC-timestamped.
+
+    Args:
+        currency: ISO 4217 currency code (e.g. "USD", "EUR", "JPY").
+        event_name: Human-readable event title (e.g. "Non-Farm Payrolls").
+        time: UTC-aware datetime for the event (INV-03).  For ``All Day`` or
+            tentative events, the time is set to midnight UTC on the event date.
+        impact: Normalised impact level (high/medium/low).
+        actual: Actual released value (optional; typically populated after the
+            event has occurred).
+        forecast: Consensus forecast value (optional).
+        previous: Previous period's value (optional).
+    """
+
+    __slots__ = (
+        "currency",
+        "event_name",
+        "time",
+        "impact",
+        "actual",
+        "forecast",
+        "previous",
+    )
+
+    def __init__(
+        self,
+        *,
+        currency: str,
+        event_name: str,
+        time: datetime,
+        impact: Impact,
+        actual: Optional[str] = None,
+        forecast: Optional[str] = None,
+        previous: Optional[str] = None,
+    ) -> None:
+        if time.tzinfo is None:
+            raise ValueError(
+                f"CalendarEvent.time must be UTC-aware (INV-03); got naive "
+                f"datetime for event '{event_name}'."
+            )
+        self.currency = currency
+        self.event_name = event_name
+        self.time = time
+        self.impact = impact
+        self.actual = actual
+        self.forecast = forecast
+        self.previous = previous
+
+    def __repr__(self) -> str:
+        return (
+            f"CalendarEvent(currency={self.currency!r}, "
+            f"event_name={self.event_name!r}, "
+            f"time={self.time.isoformat()!r}, "
+            f"impact={self.impact.value!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CalendarEvent):
+            return NotImplemented
+        return (
+            self.currency == other.currency
+            and self.event_name == other.event_name
+            and self.time == other.time
+            and self.impact == other.impact
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.currency, self.event_name, self.time))
+
+
+# ---------------------------------------------------------------------------
+# EconomicCalendar ABC
+# ---------------------------------------------------------------------------
+
+
+class EconomicCalendar(ABC):
+    """Abstract base for economic calendar providers.
+
+    Concrete implementations (e.g. FairEconomyCalendar) fetch events from a
+    specific data source, normalise them into CalendarEvent objects, and persist
+    them to SQLite.  Swapping providers only requires a new concrete class —
+    no logic in consumers needs to change.
+    """
+
+    @abstractmethod
+    def refresh(self) -> int:
+        """Fetch the latest calendar data from the upstream source and persist
+        it to the local store.
+
+        Returns:
+            The number of events upserted (new + updated).
+        """
+        ...
+
+    @abstractmethod
+    def upcoming_events(
+        self,
+        currencies: list[str],
+        window: timedelta,
+    ) -> list[CalendarEvent]:
+        """Return events starting within ``window`` from now for the given
+        currencies.
+
+        Args:
+            currencies: List of ISO 4217 currency codes to filter by
+                (e.g. ["USD", "EUR"]).  An empty list returns events for
+                all currencies.
+            window: How far ahead from ``datetime.now(timezone.utc)`` to look.
+
+        Returns:
+            List of CalendarEvent objects sorted by time ascending.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FairEconomyCalendar — concrete provider
+# ---------------------------------------------------------------------------
+
+
+class FairEconomyCalendar(EconomicCalendar):
+    """EconomicCalendar backed by the free FairEconomy/ForexFactory weekly XML.
+
+    Fetches ``ff_calendar_thisweek.xml`` (and optionally ``nextweek``) via
+    httpx, parses with stdlib xml.etree.ElementTree, normalises, and persists
+    to a ``calendar_events`` SQLite table.
+
+    Feed timezone:
+        Event times are published in US Eastern (America/New_York, DST-aware).
+        Each date+time is converted to UTC before CalendarEvent.time is set
+        (INV-03 enforcement).  See FEED_TZ constant.
+
+    Args:
+        db_path: File path (or ``":memory:"``) for the SQLite database.
+            The ``calendar_events`` table is created here (alongside the
+            existing candles/instruments tables if the same DB is used).
+        include_next_week: If True, also fetches the ``nextweek`` XML feed.
+            Defaults to True (gives ~2 weeks of lookahead).
+        this_week_url: Override for the thisweek feed URL (for testing).
+        next_week_url: Override for the nextweek feed URL (for testing).
+        http_timeout: Request timeout in seconds (default 10 s).
+    """
+
+    #: DDL for the calendar_events table.
+    _CREATE_CALENDAR_SQL: str = """
+        CREATE TABLE IF NOT EXISTS calendar_events (
+            currency    TEXT    NOT NULL,
+            event_name  TEXT    NOT NULL,
+            time        TEXT    NOT NULL,
+            impact      TEXT    NOT NULL,
+            actual      TEXT,
+            forecast    TEXT,
+            previous    TEXT,
+            PRIMARY KEY (currency, event_name, time)
+        )
+    """
+
+    #: Upsert SQL — idempotent on (currency, event_name, time) PK.
+    _UPSERT_CALENDAR_SQL: str = """
+        INSERT OR REPLACE INTO calendar_events
+            (currency, event_name, time, impact, actual, forecast, previous)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?)
+    """
+
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        include_next_week: bool = True,
+        this_week_url: str = FF_THIS_WEEK_URL,
+        next_week_url: str = FF_NEXT_WEEK_URL,
+        http_timeout: float = HTTP_TIMEOUT_SECONDS,
+    ) -> None:
+        self._db_path = db_path
+        self._include_next_week = include_next_week
+        self._this_week_url = this_week_url
+        self._next_week_url = next_week_url
+        self._http_timeout = http_timeout
+        self._feed_tz = ZoneInfo(FEED_TZ)
+
+        self._conn: sqlite3.Connection = sqlite3.connect(db_path)
+        self._conn.execute(self._CREATE_CALENDAR_SQL)
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API (EconomicCalendar ABC)
+    # ------------------------------------------------------------------
+
+    def refresh(self) -> int:
+        """Fetch the weekly feed(s) and upsert all events into the DB.
+
+        Returns:
+            Total number of events upserted (including both weeks if
+            include_next_week is True).
+        """
+        events: list[CalendarEvent] = []
+        xml_bytes = self._fetch(self._this_week_url)
+        events.extend(self._parse_xml(xml_bytes))
+
+        if self._include_next_week:
+            xml_bytes_next = self._fetch(self._next_week_url)
+            events.extend(self._parse_xml(xml_bytes_next))
+
+        self._upsert(events)
+        return len(events)
+
+    def upcoming_events(
+        self,
+        currencies: list[str],
+        window: timedelta,
+    ) -> list[CalendarEvent]:
+        """Query the local DB for events within ``window`` from now.
+
+        Args:
+            currencies: ISO 4217 currency codes to include.  Empty → all.
+            window: Look-ahead window from ``datetime.now(timezone.utc)``.
+
+        Returns:
+            CalendarEvent list sorted by time ascending.
+        """
+        now = datetime.now(timezone.utc)
+        end = now + window
+
+        now_str = _to_rfc3339(now)
+        end_str = _to_rfc3339(end)
+
+        if currencies:
+            placeholders = ", ".join("?" * len(currencies))
+            sql = f"""
+                SELECT currency, event_name, time, impact, actual, forecast, previous
+                FROM   calendar_events
+                WHERE  currency IN ({placeholders})
+                  AND  time >= ?
+                  AND  time <= ?
+                ORDER  BY time ASC
+            """
+            params: tuple[str | None, ...] = (*currencies, now_str, end_str)
+        else:
+            sql = """
+                SELECT currency, event_name, time, impact, actual, forecast, previous
+                FROM   calendar_events
+                WHERE  time >= ?
+                  AND  time <= ?
+                ORDER  BY time ASC
+            """
+            params = (now_str, end_str)
+
+        cursor = self._conn.execute(sql, params)
+        results: list[CalendarEvent] = []
+        for row in cursor.fetchall():
+            currency, event_name, time_str, impact_str, actual, forecast, previous = row
+            # Parse stored UTC RFC 3339 string back to UTC-aware datetime.
+            dt = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+            results.append(
+                CalendarEvent(
+                    currency=currency,
+                    event_name=event_name,
+                    time=dt,
+                    impact=Impact(impact_str),
+                    actual=actual,
+                    forecast=forecast,
+                    previous=previous,
+                )
+            )
+        return results
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _fetch(self, url: str) -> bytes:
+        """Fetch an XML URL and return the raw bytes.
+
+        Uses an explicit timeout (HTTP_TIMEOUT_SECONDS) because httpx's
+        default is None (no timeout), which would hang indefinitely on a
+        stalled feed.
+
+        Args:
+            url: URL to fetch.
+
+        Returns:
+            Raw response bytes.
+
+        Raises:
+            httpx.HTTPStatusError: If the server returns a 4xx/5xx response.
+            httpx.TimeoutException: If the request exceeds the configured timeout.
+        """
+        with httpx.Client(timeout=self._http_timeout) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+            return resp.content
+
+    def _parse_xml(self, xml_bytes: bytes) -> list[CalendarEvent]:
+        """Parse a ForexFactory XML feed and return CalendarEvent objects.
+
+        Each ``<event>`` element is expected to contain:
+            <title>       — event name
+            <country>     — currency code (e.g. USD, EUR, JPY)
+            <date>        — date string (e.g. "01-06-2026")
+            <time>        — time string in feed TZ (e.g. "8:30am") or "All Day"
+            <impact>      — High / Medium / Low / Holiday
+            <forecast>    — optional consensus value
+            <previous>    — optional prior value
+
+        Times are parsed as America/New_York (see FEED_TZ) and converted to UTC
+        (INV-03).  Missing or ``All Day`` / tentative times are set to midnight
+        on the event date in the feed TZ (then converted to UTC).
+
+        Args:
+            xml_bytes: Raw XML bytes from the feed.
+
+        Returns:
+            List of CalendarEvent objects.  Events with unrecognised impact
+            values are assigned Impact.low and included (defensive; don't drop).
+        """
+        root = ET.fromstring(xml_bytes.decode("utf-8"))
+        events: list[CalendarEvent] = []
+
+        for event_el in root.iter("event"):
+            title = _text(event_el, "title") or ""
+            country = _text(event_el, "country") or ""
+            date_str = _text(event_el, "date") or ""
+            time_str = _text(event_el, "time") or ""
+            impact_str = _text(event_el, "impact") or ""
+            forecast = _text(event_el, "forecast") or None
+            previous = _text(event_el, "previous") or None
+            actual = _text(event_el, "actual") or None
+
+            if not title or not country or not date_str:
+                # Skip malformed entries silently (defensive).
+                continue
+
+            # Normalise impact — default to low for unknown strings.
+            impact = _IMPACT_MAP.get(impact_str, Impact.low)
+
+            # Parse date+time from the feed TZ and convert to UTC.
+            utc_time = self._parse_feed_datetime(date_str, time_str)
+            if utc_time is None:
+                # If date parsing fails completely, skip the event.
+                continue
+
+            events.append(
+                CalendarEvent(
+                    currency=country.strip().upper(),
+                    event_name=title.strip(),
+                    time=utc_time,
+                    impact=impact,
+                    actual=actual if actual else None,
+                    forecast=forecast if forecast else None,
+                    previous=previous if previous else None,
+                )
+            )
+
+        return events
+
+    def _parse_feed_datetime(
+        self,
+        date_str: str,
+        time_str: str,
+    ) -> Optional[datetime]:
+        """Convert a (date_str, time_str) pair from feed TZ to UTC.
+
+        The feed uses dates like "01-06-2026" (MM-DD-YYYY) and times like
+        "8:30am", "12:00pm", or "All Day" / "Tentative" / empty.
+
+        Missing / ``All Day`` / tentative times are treated as midnight in the
+        feed TZ on the given date.
+
+        Args:
+            date_str: Date string from ``<date>`` element (MM-DD-YYYY).
+            time_str: Time string from ``<time>`` element.
+
+        Returns:
+            UTC-aware datetime, or None if the date cannot be parsed.
+        """
+        # Parse the date portion.
+        try:
+            naive_date = datetime.strptime(date_str.strip(), "%m-%d-%Y")
+        except ValueError:
+            return None
+
+        # Parse the time portion; fall back to midnight for missing/All Day.
+        clean_time = time_str.strip().lower()
+        hour = 0
+        minute = 0
+
+        if clean_time and clean_time not in ("all day", "tentative", ""):
+            try:
+                # Parse "8:30am" / "12:00pm" style times.
+                t = datetime.strptime(clean_time, "%I:%M%p")
+                hour = t.hour
+                minute = t.minute
+            except ValueError:
+                # Unrecognised format — use midnight.
+                pass
+
+        # Combine into a feed-TZ-aware datetime, then convert to UTC.
+        feed_naive = naive_date.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        feed_aware = feed_naive.replace(tzinfo=self._feed_tz)
+        utc_aware = feed_aware.astimezone(timezone.utc)
+        return utc_aware
+
+    def _upsert(self, events: list[CalendarEvent]) -> None:
+        """Persist events to calendar_events with INSERT OR REPLACE (idempotent).
+
+        The PK is (currency, event_name, time), so re-parsing the same feed
+        only updates fields like actual/forecast without creating duplicates.
+
+        Args:
+            events: List of CalendarEvent objects to persist.
+        """
+        if not events:
+            return
+
+        params = [
+            (
+                ev.currency,
+                ev.event_name,
+                _to_rfc3339(ev.time),   # UTC RFC 3339 (INV-03)
+                ev.impact.value,
+                ev.actual,
+                ev.forecast,
+                ev.previous,
+            )
+            for ev in events
+        ]
+        self._conn.executemany(self._UPSERT_CALENDAR_SQL, params)
+        self._conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def _text(el: ET.Element, tag: str) -> Optional[str]:
+    """Return the text of the first child with the given tag, or None."""
+    child = el.find(tag)
+    if child is None or child.text is None:
+        return None
+    return child.text.strip() or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pandas>=2.0",
     "python-dateutil>=2.8",
     "pyarrow>=14",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,493 @@
+"""Tests for data/calendar.py — EconomicCalendar, FairEconomyCalendar.
+
+All tests use a fixture XML string; NO live HTTP calls are made.
+httpx.Client.get is monkeypatched to return the fixture bytes.
+
+INV-03 fixture test:
+    The "Non-Farm Payrolls" event in the fixture is published as:
+        date="06-06-2025"  (June 6, 2025)
+        time="8:30am"      (America/New_York = UTC-4 in June, EDT)
+
+    Expected UTC conversion:
+        2025-06-06 08:30 EDT = 2025-06-06 12:30 UTC
+    This is the load-bearing UTC-instant assertion (INV-03 sharp edge).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data.calendar import (
+    CalendarEvent,
+    EconomicCalendar,
+    FairEconomyCalendar,
+    Impact,
+    _IMPACT_MAP,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture XML
+# ---------------------------------------------------------------------------
+
+#: Representative ForexFactory-style XML with:
+#:   - A USD high-impact event (NFP) at 8:30am on June 6 2025 (EDT, UTC-4 in summer)
+#:   - A JPY medium-impact event at 11:00pm on June 5 2025 (EDT, UTC-4)
+#:   - A EUR low-impact event
+#:   - A Holiday (should map to Impact.low)
+#:   - An "All Day" event (time should fall back to midnight feed TZ)
+#:   - A tentative-time event (time falls back to midnight feed TZ)
+#:   - A malformed event (no title, should be skipped)
+
+FIXTURE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<weeklyevents>
+  <event>
+    <title>Non-Farm Employment Change</title>
+    <country>USD</country>
+    <date>06-06-2025</date>
+    <time>8:30am</time>
+    <impact>High</impact>
+    <forecast>185K</forecast>
+    <previous>177K</previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title>BOJ Monetary Policy Meeting Minutes</title>
+    <country>JPY</country>
+    <date>06-05-2025</date>
+    <time>11:50pm</time>
+    <impact>Medium</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title>German Industrial Production m/m</title>
+    <country>EUR</country>
+    <date>06-06-2025</date>
+    <time>2:00am</time>
+    <impact>Low</impact>
+    <forecast>0.3%</forecast>
+    <previous>-0.4%</previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title>Bank Holiday</title>
+    <country>GBP</country>
+    <date>06-09-2025</date>
+    <time>All Day</time>
+    <impact>Holiday</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title>RBA Meeting Minutes</title>
+    <country>AUD</country>
+    <date>06-09-2025</date>
+    <time>All Day</time>
+    <impact>Medium</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title>Flash GDP q/q</title>
+    <country>EUR</country>
+    <date>06-10-2025</date>
+    <time>Tentative</time>
+    <impact>High</impact>
+    <forecast></forecast>
+    <previous>0.4%</previous>
+    <actual></actual>
+  </event>
+  <event>
+    <title></title>
+    <country>USD</country>
+    <date>06-10-2025</date>
+    <time>9:00am</time>
+    <impact>High</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+</weeklyevents>
+"""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_calendar(
+    include_next_week: bool = False,
+    fixture: bytes = FIXTURE_XML,
+    db_path: str = ":memory:",
+) -> FairEconomyCalendar:
+    """Return a FairEconomyCalendar with httpx mocked to return fixture bytes."""
+    cal = FairEconomyCalendar(
+        db_path,
+        include_next_week=include_next_week,
+        this_week_url="https://mock.test/thisweek.xml",
+        next_week_url="https://mock.test/nextweek.xml",
+    )
+    return cal
+
+
+def _mock_fetch(cal: FairEconomyCalendar, fixture: bytes = FIXTURE_XML) -> None:
+    """Patch cal._fetch to return fixture bytes unconditionally."""
+    cal._fetch = MagicMock(return_value=fixture)  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# ABC / interface test
+# ---------------------------------------------------------------------------
+
+
+class TestEconomicCalendarABC:
+    def test_is_abstract(self) -> None:
+        """EconomicCalendar cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            EconomicCalendar()  # type: ignore[abstract]
+
+    def test_fair_economy_is_subclass(self) -> None:
+        """FairEconomyCalendar is a concrete EconomicCalendar."""
+        assert issubclass(FairEconomyCalendar, EconomicCalendar)
+
+
+# ---------------------------------------------------------------------------
+# Impact mapping
+# ---------------------------------------------------------------------------
+
+
+class TestImpactMap:
+    def test_all_ff_strings_covered(self) -> None:
+        for raw, expected in [
+            ("High", Impact.high),
+            ("Medium", Impact.medium),
+            ("Low", Impact.low),
+            ("Holiday", Impact.low),
+        ]:
+            assert _IMPACT_MAP[raw] == expected
+
+    def test_unknown_defaults_to_low(self) -> None:
+        cal = _make_calendar()
+        _mock_fetch(cal)
+        # Directly test the method that applies the default.
+        events = cal._parse_xml(
+            b"""<weeklyevents>
+              <event>
+                <title>Mystery Event</title>
+                <country>USD</country>
+                <date>06-06-2025</date>
+                <time>9:00am</time>
+                <impact>Unknown</impact>
+              </event>
+            </weeklyevents>"""
+        )
+        assert len(events) == 1
+        assert events[0].impact == Impact.low
+
+
+# ---------------------------------------------------------------------------
+# XML parsing — basic
+# ---------------------------------------------------------------------------
+
+
+class TestParseXML:
+    def setup_method(self) -> None:
+        self.cal = _make_calendar()
+        _mock_fetch(self.cal)
+        self.events = self.cal._parse_xml(FIXTURE_XML)
+
+    def test_malformed_event_skipped(self) -> None:
+        """The empty-title event in the fixture is silently skipped."""
+        titles = [e.event_name for e in self.events]
+        # 7 events in fixture, 1 malformed (no title) → 6 valid
+        assert len(self.events) == 6
+        assert "" not in titles
+
+    def test_currency_tagged(self) -> None:
+        """Each event carries the correct currency code."""
+        currencies = {e.currency for e in self.events}
+        assert "USD" in currencies
+        assert "JPY" in currencies
+        assert "EUR" in currencies
+        assert "GBP" in currencies
+
+    def test_impact_normalised(self) -> None:
+        """FF impact strings are converted to our enum."""
+        nfp = next(e for e in self.events if e.event_name == "Non-Farm Employment Change")
+        assert nfp.impact == Impact.high
+
+        boj = next(e for e in self.events if "BOJ" in e.event_name)
+        assert boj.impact == Impact.medium
+
+        german_ip = next(e for e in self.events if "German" in e.event_name)
+        assert german_ip.impact == Impact.low
+
+        holiday = next(e for e in self.events if e.event_name == "Bank Holiday")
+        assert holiday.impact == Impact.low  # Holiday → low
+
+    def test_forecast_and_previous_captured(self) -> None:
+        nfp = next(e for e in self.events if e.event_name == "Non-Farm Employment Change")
+        assert nfp.forecast == "185K"
+        assert nfp.previous == "177K"
+        assert nfp.actual is None  # empty tag → None
+
+    def test_all_times_utc_aware(self) -> None:
+        """Every parsed event has a UTC-aware datetime (INV-03)."""
+        for ev in self.events:
+            assert ev.time.tzinfo is not None
+            assert ev.time.tzinfo == timezone.utc or str(ev.time.tzinfo) in (
+                "UTC",
+                "datetime.timezone.utc",
+            )
+            # Confirm it's actually UTC by normalising.
+            assert ev.time.utcoffset() == timedelta(0)
+
+
+# ---------------------------------------------------------------------------
+# INV-03 sharp edge: feed TZ → UTC conversion
+# ---------------------------------------------------------------------------
+
+
+class TestFeedTZConversion:
+    """The load-bearing UTC-instant assertions for INV-03.
+
+    Non-Farm Employment Change in the fixture:
+        date = 2025-06-06
+        time = 8:30am   (America/New_York, EDT = UTC-4 in June)
+        → expected UTC: 2025-06-06T12:30:00+00:00
+
+    BOJ Meeting Minutes:
+        date = 2025-06-05
+        time = 11:50pm  (America/New_York, EDT = UTC-4)
+        → expected UTC: 2025-06-06T03:50:00+00:00  (next calendar day!)
+    """
+
+    def setup_method(self) -> None:
+        self.cal = _make_calendar()
+        _mock_fetch(self.cal)
+        self.events = self.cal._parse_xml(FIXTURE_XML)
+
+    def test_nfp_utc_instant(self) -> None:
+        """NFP at 8:30am EDT converts to 12:30 UTC (INV-03 sharp edge)."""
+        nfp = next(e for e in self.events if e.event_name == "Non-Farm Employment Change")
+        expected_utc = datetime(2025, 6, 6, 12, 30, 0, tzinfo=timezone.utc)
+        assert nfp.time == expected_utc, (
+            f"NFP time {nfp.time.isoformat()} != expected {expected_utc.isoformat()}. "
+            "Feed TZ→UTC conversion is broken (INV-03)."
+        )
+
+    def test_boj_utc_crosses_midnight(self) -> None:
+        """BOJ at 11:50pm EDT on June 5 → 03:50 UTC on June 6 (crosses midnight)."""
+        boj = next(e for e in self.events if "BOJ" in e.event_name)
+        expected_utc = datetime(2025, 6, 6, 3, 50, 0, tzinfo=timezone.utc)
+        assert boj.time == expected_utc, (
+            f"BOJ time {boj.time.isoformat()} != expected {expected_utc.isoformat()}. "
+            "Feed TZ→UTC conversion is broken for events near midnight (INV-03)."
+        )
+
+    def test_german_ip_utc(self) -> None:
+        """German IP at 2:00am EDT → 06:00 UTC."""
+        german_ip = next(e for e in self.events if "German" in e.event_name)
+        expected_utc = datetime(2025, 6, 6, 6, 0, 0, tzinfo=timezone.utc)
+        assert german_ip.time == expected_utc
+
+    def test_all_day_falls_back_to_midnight_utc(self) -> None:
+        """'All Day' events use midnight feed TZ → midnight + UTC offset."""
+        holiday = next(e for e in self.events if e.event_name == "Bank Holiday")
+        # June 9 2025, midnight EDT (UTC-4) = 04:00 UTC
+        expected_utc = datetime(2025, 6, 9, 4, 0, 0, tzinfo=timezone.utc)
+        assert holiday.time == expected_utc
+
+    def test_tentative_falls_back_to_midnight_utc(self) -> None:
+        """'Tentative' times use midnight feed TZ → midnight + UTC offset."""
+        flash_gdp = next(e for e in self.events if e.event_name == "Flash GDP q/q")
+        # June 10 2025, midnight EDT (UTC-4) = 04:00 UTC
+        expected_utc = datetime(2025, 6, 10, 4, 0, 0, tzinfo=timezone.utc)
+        assert flash_gdp.time == expected_utc
+
+
+# ---------------------------------------------------------------------------
+# Persistence — idempotent upsert
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentUpsert:
+    def test_refresh_idempotent(self) -> None:
+        """Refreshing twice does not create duplicate rows."""
+        cal = _make_calendar()
+        _mock_fetch(cal)
+
+        count1 = cal.refresh()
+        assert count1 == 6  # 6 valid events in fixture
+
+        count2 = cal.refresh()
+        assert count2 == 6  # same count returned (upsert, no dupes)
+
+        # Verify at the DB level.
+        cursor = cal._conn.execute("SELECT COUNT(*) FROM calendar_events")
+        row_count = cursor.fetchone()[0]
+        assert row_count == 6, f"Expected 6 rows in DB, got {row_count} after 2 refreshes."
+
+    def test_upsert_updates_fields(self) -> None:
+        """Upserting an event with updated forecast replaces the old row."""
+        cal = _make_calendar()
+        _mock_fetch(cal)
+        cal.refresh()
+
+        # Build a modified version of the fixture with an updated forecast for NFP.
+        modified_xml = FIXTURE_XML.replace(b"<forecast>185K</forecast>", b"<forecast>200K</forecast>")
+        cal._fetch = MagicMock(return_value=modified_xml)  # type: ignore[method-assign]
+        cal.refresh()
+
+        # Should still be 6 rows.
+        cursor = cal._conn.execute("SELECT COUNT(*) FROM calendar_events")
+        assert cursor.fetchone()[0] == 6
+
+        # The forecast should be updated to 200K.
+        cursor = cal._conn.execute(
+            "SELECT forecast FROM calendar_events WHERE event_name = ?",
+            ("Non-Farm Employment Change",),
+        )
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == "200K"
+
+
+# ---------------------------------------------------------------------------
+# upcoming_events query
+# ---------------------------------------------------------------------------
+
+
+class TestUpcomingEvents:
+    def _seed(self) -> FairEconomyCalendar:
+        cal = _make_calendar()
+        _mock_fetch(cal)
+        cal.refresh()
+        return cal
+
+    def test_currency_filter(self) -> None:
+        """upcoming_events respects the currency filter."""
+        cal = self._seed()
+
+        # Patch now so NFP (2025-06-06 12:30 UTC) is within a 7-day window.
+        mock_now = datetime(2025, 6, 5, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("data.calendar.datetime") as mock_dt:
+            mock_dt.now.return_value = mock_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            events = cal.upcoming_events(["USD"], timedelta(days=7))
+
+        assert all(e.currency == "USD" for e in events)
+        titles = [e.event_name for e in events]
+        assert "Non-Farm Employment Change" in titles
+
+    def test_empty_currency_returns_all(self) -> None:
+        """Empty currencies list returns events for all currencies."""
+        cal = self._seed()
+
+        mock_now = datetime(2025, 6, 5, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("data.calendar.datetime") as mock_dt:
+            mock_dt.now.return_value = mock_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            events = cal.upcoming_events([], timedelta(days=7))
+
+        currencies_found = {e.currency for e in events}
+        assert "USD" in currencies_found
+        assert "JPY" in currencies_found
+        assert "EUR" in currencies_found
+
+    def test_no_events_before_window(self) -> None:
+        """Events before now are excluded."""
+        cal = self._seed()
+
+        # Set now to far in the future — no events should be within the window.
+        mock_now = datetime(2030, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("data.calendar.datetime") as mock_dt:
+            mock_dt.now.return_value = mock_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            events = cal.upcoming_events([], timedelta(days=7))
+
+        assert events == []
+
+    def test_sorted_by_time(self) -> None:
+        """upcoming_events returns events sorted by time ascending."""
+        cal = self._seed()
+
+        mock_now = datetime(2025, 6, 5, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("data.calendar.datetime") as mock_dt:
+            mock_dt.now.return_value = mock_now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            events = cal.upcoming_events([], timedelta(days=14))
+
+        times = [e.time for e in events]
+        assert times == sorted(times)
+
+
+# ---------------------------------------------------------------------------
+# CalendarEvent model validation
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarEventModel:
+    def test_rejects_naive_datetime(self) -> None:
+        """CalendarEvent raises ValueError for naive datetimes (INV-03)."""
+        with pytest.raises(ValueError, match="UTC-aware"):
+            CalendarEvent(
+                currency="USD",
+                event_name="Test",
+                time=datetime(2025, 6, 6, 12, 30),  # naive — not UTC-aware
+                impact=Impact.high,
+            )
+
+    def test_accepts_utc_aware_datetime(self) -> None:
+        ev = CalendarEvent(
+            currency="USD",
+            event_name="NFP",
+            time=datetime(2025, 6, 6, 12, 30, tzinfo=timezone.utc),
+            impact=Impact.high,
+            forecast="185K",
+        )
+        assert ev.time.tzinfo is not None
+        assert ev.currency == "USD"
+        assert ev.forecast == "185K"
+        assert ev.actual is None
+
+    def test_equality_and_hash(self) -> None:
+        t = datetime(2025, 6, 6, 12, 30, tzinfo=timezone.utc)
+        ev1 = CalendarEvent(currency="USD", event_name="NFP", time=t, impact=Impact.high)
+        ev2 = CalendarEvent(currency="USD", event_name="NFP", time=t, impact=Impact.high)
+        assert ev1 == ev2
+        assert hash(ev1) == hash(ev2)
+
+
+# ---------------------------------------------------------------------------
+# next-week fetch
+# ---------------------------------------------------------------------------
+
+
+class TestNextWeekFetch:
+    def test_include_next_week_calls_fetch_twice(self) -> None:
+        """With include_next_week=True, _fetch is called twice."""
+        cal = _make_calendar(include_next_week=True)
+        mock_fetch = MagicMock(return_value=FIXTURE_XML)
+        cal._fetch = mock_fetch  # type: ignore[method-assign]
+
+        cal.refresh()
+
+        assert mock_fetch.call_count == 2
+
+    def test_exclude_next_week_calls_fetch_once(self) -> None:
+        """With include_next_week=False, _fetch is called once."""
+        cal = _make_calendar(include_next_week=False)
+        mock_fetch = MagicMock(return_value=FIXTURE_XML)
+        cal._fetch = mock_fetch  # type: ignore[method-assign]
+
+        cal.refresh()
+
+        assert mock_fetch.call_count == 1


### PR DESCRIPTION
Closes #44.

## Summary

- `CalendarEvent` model: `currency`, `event_name`, `time` (UTC-aware, INV-03), `impact` (enum high/medium/low), optional `actual`/`forecast`/`previous`.
- `EconomicCalendar` ABC with `upcoming_events(currencies, window) -> list[CalendarEvent]` and `refresh()`.
- `FairEconomyCalendar` provider: fetches free FairEconomy/ForexFactory weekly XML (`thisweek` + optionally `nextweek`) via `httpx` (explicit 10 s timeout; never None), parses with stdlib `xml.etree.ElementTree`, persists to `calendar_events` SQLite table with idempotent `INSERT OR REPLACE` upsert keyed on `(currency, event_name, time)`.

**INV-03 (the sharp edge):** FF feed times are published in `America/New_York` (EDT/EST, DST-aware), NOT UTC. `FEED_TZ = "America/New_York"` is the single documented constant. Each `<date>+<time>` is converted via `ZoneInfo(FEED_TZ)` + `.astimezone(timezone.utc)` before `CalendarEvent.time` is constructed. Fixture test asserts NFP at `8:30am` on `2025-06-06` → `2025-06-06T12:30:00Z` (UTC-4 offset in June).

**Impact mapping (documented):** `High→high`, `Medium→medium`, `Low→low`, `Holiday→low` (not skipped — consumers can filter). Unknown strings default to `low` defensively. `All Day`/`Tentative`/empty times fall back to midnight feed TZ → UTC.

**httpx dep:** `httpx>=0.27` added to `pyproject.toml`; CLAUDE.md Stack line updated.

## Tests (no live HTTP)

25 tests in `tests/test_calendar.py` using a fixture XML string with representative events (USD high-impact NFP, JPY medium-impact BOJ, EUR low, GBP Holiday, AUD All Day, EUR Tentative, one malformed event). httpx patched via `MagicMock` on `_fetch`.

Key assertions:
- ABC cannot be instantiated directly; `FairEconomyCalendar` is a concrete subclass.
- NFP `8:30am EDT` → `2025-06-06T12:30:00Z` (INV-03 UTC instant).
- BOJ `11:50pm EDT June 5` → `2025-06-06T03:50:00Z` (crosses midnight).
- `All Day` / `Tentative` → midnight feed TZ → UTC.
- Malformed event (no title) silently skipped.
- Idempotent upsert: 2× refresh → same 6 rows; updated forecast replaces old row.
- `upcoming_events` filters by currency, excludes past events, returns sorted by time.
- `CalendarEvent` raises `ValueError` for naive datetimes (INV-03 guard).

## Verification results

```
pytest tests/test_calendar.py -v   → 25 passed, exit 0
pytest -v (full suite)             → 390 passed, exit 0
mypy data/                         → Success: no issues found in 5 source files, exit 0
```