### PR TITLE
fix: calendar next-week best-effort (live 404 from acceptance gate)

### DIFF
--- a/data/calendar.py
+++ b/data/calendar.py
@@ -30,6 +30,7 @@ INV-09: No demo/live branch in logic; any future provider-URL config is read
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
@@ -41,6 +42,8 @@ from zoneinfo import ZoneInfo
 import httpx
 
 from data.store import _to_rfc3339  # shared RFC 3339 formatter (INV-03)
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Feed timezone assumption (INV-03)
@@ -255,7 +258,7 @@ class FairEconomyCalendar(EconomicCalendar):
         self,
         db_path: str,
         *,
-        include_next_week: bool = True,
+        include_next_week: bool = False,
         this_week_url: str = FF_THIS_WEEK_URL,
         next_week_url: str = FF_NEXT_WEEK_URL,
         http_timeout: float = HTTP_TIMEOUT_SECONDS,
@@ -287,8 +290,19 @@ class FairEconomyCalendar(EconomicCalendar):
         events.extend(self._parse_xml(xml_bytes))
 
         if self._include_next_week:
-            xml_bytes_next = self._fetch(self._next_week_url)
-            events.extend(self._parse_xml(xml_bytes_next))
+            # Best-effort: the next-week feed is an optional extension and its
+            # URL is not always available (e.g. returns 404). A failure here
+            # must NOT lose the this-week events we already have — log and
+            # continue rather than propagating.
+            try:
+                xml_bytes_next = self._fetch(self._next_week_url)
+                events.extend(self._parse_xml(xml_bytes_next))
+            except httpx.HTTPError as exc:
+                _log.warning(
+                    "next-week calendar feed unavailable (%s) — "
+                    "continuing with this-week events only.",
+                    exc,
+                )
 
         self._upsert(events)
         return len(events)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -19,6 +19,7 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from data.calendar import (
@@ -491,3 +492,29 @@ class TestNextWeekFetch:
         cal.refresh()
 
         assert mock_fetch.call_count == 1
+
+    def test_next_week_404_is_best_effort_not_fatal(self) -> None:
+        """A failing next-week fetch must NOT lose this-week events (live 404).
+
+        The real ff_calendar_nextweek.xml URL returns 404; refresh() must
+        swallow the httpx error, log, and still persist this-week events.
+        """
+        cal = _make_calendar(include_next_week=True)
+        # this-week fetch succeeds, next-week fetch raises (as the live 404 does)
+        mock_fetch = MagicMock(
+            side_effect=[FIXTURE_XML, httpx.HTTPError("simulated 404 Not Found")]
+        )
+        cal._fetch = mock_fetch  # type: ignore[method-assign]
+
+        # Must not raise despite the next-week failure.
+        n = cal.refresh()
+
+        # Both feeds were attempted (best-effort, not short-circuited)...
+        assert mock_fetch.call_count == 2
+        # ...and the this-week events were still parsed and stored despite the
+        # next-week 404 (the events that were lost in the live acceptance bug).
+        assert n > 0
+        row_count = cal._conn.execute(
+            "SELECT COUNT(*) FROM calendar_events"
+        ).fetchone()[0]
+        assert row_count == n


### PR DESCRIPTION
1B acceptance caught a live 404 on the next-week FF URL; refresh() hard-failed. Now best-effort (log+continue), default include_next_week=False. this-week feed verified live (97 events). Non-vacuous test added. Ref #44.