### PR TITLE
docs: Phase 2 spec layer + cross-spec audit

### DIFF
--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -12,10 +12,12 @@ Single Python repo (not a monorepo) — "areas" are package directories.
 | `data` | `data/oanda_client.py`, `data/candles.py`, `data/store.py`, `data/stream.py`, `data/calendar.py` | OANDA access, candle fetch/cache, storage, live stream, calendar | partial (PoC: client+candles+store) |
 | `strategies` | `strategies/base.py`, `strategies/_indicators.py`, `strategies/trend.py`, `strategies/mean_reversion.py`, `strategies/momentum.py`, `strategies/breakout.py` | strategy interface + shared indicators (`atr()`) + implementations | partial (PoC: base + trend/MACrossover) |
 | `backtest` | `backtest/engine.py`, `backtest/costs.py`, `backtest/walkforward.py`, `backtest/metrics.py` | event-driven engine, cost model, walk-forward, metrics | shipped (PoC); `costs.py` extended in Phase 1 |
+| `signals` | `signals/ranker.py`, `signals/portfolio.py`, `signals/charts.py` | ranker (score/filter/dedup/conflict), portfolio correlation+exposure caps, chart PNG rendering | Phase 2 (not started) |
+| `hermes_integration` | `hermes_integration/news_risk.py`, `hermes_integration/narration.py`, `hermes_integration/prompts/`, `hermes_integration/jobs/` | Claude response models+validators (INV-02), prompt templates, plain-English Hermes job (configured, not coded) | Phase 2 (not started) |
 | `cli` | `cli.py` | `fathom backtest` (Phase 1), `scan\|watchlist\|chart` (Phase 2) | new in Phase 1 |
 | `scripts` | `scripts/poc_run.py` | one-off runners | shipped (PoC) |
 | `tests` | `tests/`, `tests/integration/` | test suites (per-area files) | shipped (PoC) |
-| _future_ | `signals/`, `risk/`, `execution/`, `monitoring/`, `hermes_integration/`, `panel/` | Phase 2+ | not started |
+| _future_ | `risk/`, `execution/`, `monitoring/`, `panel/` | Phase 3+ | not started |
 
 ## Shared / coordinator-owned files
 
@@ -47,3 +49,16 @@ Edits to these go through the **coordinator branch** or are **serialized** — n
 | shared ATR helper | all 5 strategy specs import `strategies/_indicators.py::atr()` (INV-11) | `_indicators.py` is a **shared prerequisite** — it must be created (extract the existing `trend.py` ATR, `ewm(com=period-1, adjust=False)`) before the strategy tasks can import it. Sequence it first (a small dedicated task, or fold into the donchian/trend task and have the others depend on it). |
 
 **Safe-parallel set for Phase 1 (after `data-layer-expansion` AND `_indicators.py` land):** `{donchian (trend.py)}`, `{bollinger→rsi (mean_reversion.py, serialized)}`, `{roc (momentum.py)}`, `{breakout (breakout.py)}`, `{live-streaming (stream.py)}`, `{economic-calendar (calendar.py)}` can all run concurrently — distinct files, all importing the shared `_indicators.atr()`. `swap-cost-model (costs.py)` is independent of the strategies. The runner (`cli.py`) is the join point and runs last.
+
+## Phase 2 dispatch implications (pre-resolved collisions)
+
+| Collision | Files | Resolution |
+|---|---|---|
+| `signal-ranker` defines the `Candidate` contract | `signals/ranker.py` | **load-bearing prerequisite** — `Candidate` shape is consumed by portfolio, cli, narration, charts. Ship/lock it first; downstream tasks depend on it. |
+| `portfolio-limits` | `signals/portfolio.py` (distinct file from ranker) | parallel-safe with other `signals/` files once `Candidate` is locked; logically sequenced after `signal-ranker`. |
+| `chart-generation` | `signals/charts.py` | distinct file → parallel-safe. New dep `matplotlib` → **coordinator** edits `pyproject.toml` + CLAUDE.md. |
+| `cli-commands` | `cli.py` (shared with Phase 1 `backtest`) | **ONLY Phase 2 task that edits `cli.py`** — no other Phase 2 worker touches it; it's the join point. Depends on ranker+portfolio+charts. |
+| `news-risk-assessment` + `watchlist-narration` | both under `hermes_integration/` but **different files** (`news_risk.py`+`prompts/news_risk.md` vs `narration.py`+`prompts/narration.md`) | parallel-safe (distinct files); `prompts/` dir is shared but the two files within it don't collide. No `anthropic` dep added (D-P2-3). |
+| `hermes-job-definitions` | `hermes_integration/jobs/daily.md` (config, not code) | capstone — depends on cli + both Claude specs; runs last. Its live Discord acceptance is a **manual/human-admin** task (D-P2-5). |
+
+**Safe-parallel set for Phase 2 (after `signal-ranker` locks the `Candidate` shape):** `{portfolio-limits (portfolio.py)}`, `{chart-generation (charts.py)}`, `{news-risk-assessment (hermes_integration/news_risk.py)}`, `{watchlist-narration (hermes_integration/narration.py)}` run concurrently — distinct files. `cli-commands (cli.py)` is the join (after ranker+portfolio+charts); `hermes-job-definitions` is the capstone (config + manual acceptance). `matplotlib` dep via coordinator.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -38,16 +38,17 @@ One row per feature. Scannable in a single read — the cross-feature-consistenc
 | live-streaming | OANDA pricing stream, reconnect/backoff/gap | [live-streaming.md](live-streaming.md) | ready |
 | economic-calendar | calendar/news pull, currency+impact tags | [economic-calendar.md](economic-calendar.md) | draft — blocked on provider choice |
 
-## Phase 2 — watchlist → Discord (not yet specced)
+## Phase 2 — watchlist → Discord (specs ready; cross-spec audit passed 2026-05-29)
 
-| Feature | Summary | Status |
-|---|---|---|
-| signal-ranker | score, filter (spread/liquidity/news), dedupe, conflict policy, portfolio correlation | planned |
-| cli-commands | `fathom scan \| watchlist \| chart` (Hermes tools) | planned |
-| chart-generation | candle chart + signal/entry/stop/target overlays for Discord | planned |
-| hermes-job-definitions | plain-English Hermes cron jobs (daily + intraday) | planned |
-| news-risk-assessment | Claude structured event-risk scoring (INV-02) | planned |
-| watchlist-narration | Claude one-line rationale per candidate | planned |
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| signal-ranker | gate (INV-10) → filter → news → conflict → rank (by oos_sharpe_mean); emits the pinned `Candidate` (INV-13) | [signal-ranker.md](signal-ranker.md) | ready |
+| portfolio-limits | correlation-aware exposure, per-currency + max-concurrent caps | [portfolio-limits.md](portfolio-limits.md) | ready |
+| chart-generation | candle chart + entry/stop/target overlays → PNG (matplotlib) | [chart-generation.md](chart-generation.md) | ready |
+| news-risk-assessment | Claude `{event_risk,reason,suggest_action}` model + validator (INV-02, malformed→skip) | [news-risk-assessment.md](news-risk-assessment.md) | ready |
+| watchlist-narration | Claude one-line rationale + deterministic fallback (cosmetic, NOT INV-02) | [watchlist-narration.md](watchlist-narration.md) | ready |
+| cli-commands | `fathom scan \| watchlist \| chart` (Hermes tools; the Hermes boundary) | [cli-commands.md](cli-commands.md) | ready |
+| hermes-job-definitions | plain-English daily Hermes job → Discord (configured not coded; capstone, INV-01) | [hermes-job-definitions.md](hermes-job-definitions.md) | ready |
 
 ## Later — execution, monitoring, panel (Phase 3+)
 

--- a/docs/features/chart-generation.md
+++ b/docs/features/chart-generation.md
@@ -1,0 +1,64 @@
+# Feature: chart-generation
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Render a candle chart for a watchlist candidate — recent candles plus overlays for the proposed entry, stop-loss, and take-profit levels and the signal marker — and save it as a PNG for Discord delivery. Uses `matplotlib` (D-P2-2): simple dependency, native PNG export, no headless-browser/kaleido requirement. This is the visual that accompanies each ranked candidate in the daily watchlist.
+
+## User-facing behaviour
+
+Backend module `signals/charts.py`. `render_candidate_chart(candidate: Candidate, candles: pd.DataFrame, out_dir: str) -> str`:
+- Plots the recent candle window (OHLC) for the candidate's instrument/timeframe.
+- Overlays: a marker at the signal bar, a horizontal line at `candidate.entry_ref`, a stop line at `entry_ref ∓ candidate.stop_distance`, a target line at `entry_ref ± candidate.target_distance` (sign per `candidate.direction`).
+- Title carries `candidate.instrument`, `timeframe`, `strategy_name`, `direction`, `oos_sharpe_mean`, and `rank` (the flat `Candidate` fields per INV-13 — not `Signal.quality_score`).
+- Saves a PNG to `out_dir`, returns the path. X-axis labelled in UTC (INV-03).
+
+## Acceptance criteria
+
+- [ ] Produces a PNG file on disk for a given candidate + candle window; returns its path.
+- [ ] The chart shows candles plus three correctly-placed horizontal levels (entry, stop, target) — stop below/target above for LONG, inverted for SHORT.
+- [ ] A signal marker sits at the candidate's `generated_at` bar.
+- [ ] X-axis time labels are UTC (INV-03); no naive/local times.
+- [ ] Deterministic output path (e.g. `{instrument}_{timeframe}_{run_ts}.png`); re-render overwrites cleanly.
+- [ ] Renders headless (Agg backend) — no display server required (it runs under Hermes/cron).
+- [ ] A candidate with insufficient candles degrades gracefully (renders what it has or raises a clear error — no crash mid-batch).
+
+## Component design
+
+`signals/charts.py` using `matplotlib` with the `Agg` (non-interactive) backend forced at import (so it works under cron/Hermes with no display). Candles from `Store.load_candles`. Levels read from the **flat `Candidate` fields** (`candidate.entry_ref`, `candidate.stop_distance`, `candidate.target_distance`, `candidate.direction`) per the INV-13 contract — `Candidate` flattens `Signal`'s fields, so there is no `candidate.signal.*` nesting. Keep it a pure function (candidate + df → path) for testability — assert the file exists and is non-empty rather than pixel-diffing.
+
+## Non-goals
+
+- No interactive/JS charts — that's TradingView Lightweight Charts in the Phase 5 admin panel. Phase 2 produces static PNGs for Discord.
+- No indicator panels beyond the candidate's own levels (keep it readable for a Discord attachment).
+- No delivery — Hermes posts the PNG to Discord (INV-01 boundary; this feature only renders).
+
+## Touches
+
+- [INV-03] — UTC time axis.
+- [INV-01] — produces an image artefact only; no orders.
+
+## Depends on
+
+- [[signal-ranker]] — the `Candidate` (and its `Signal` levels) being charted.
+- `Store.load_candles` (shipped) — the candle window.
+
+External:
+- `matplotlib` — NEW dependency (coordinator adds to `pyproject.toml` + CLAUDE.md Stack).
+
+## Approach
+
+Force `matplotlib.use("Agg")` before `pyplot` import. Draw OHLC bars/candlesticks over the recent N candles, then `axhline` for entry/stop/target with distinct styles, a scatter marker at the signal bar, a descriptive title. Save with `fig.savefig(path, dpi=…)` and close the figure (no leak across a batch). Tests assert the PNG is produced and non-trivial in size for a representative candidate.
+
+## Open questions
+
+- Candle window length to show (e.g. last 100 bars) — confirm a readable default.
+- Candlestick rendering: hand-drawn with `matplotlib` primitives vs a tiny helper — lean hand-drawn to avoid another dependency (`mplfinance`).
+
+## Out of scope
+
+- Discord posting ([[hermes-job-definitions]]), the CLI `chart` command surface ([[cli-commands]]), the Phase 5 interactive panel.

--- a/docs/features/cli-commands.md
+++ b/docs/features/cli-commands.md
@@ -1,0 +1,65 @@
+# Feature: cli-commands
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Expose the Phase 2 pipeline as CLI subcommands that Hermes invokes as tools: `fathom scan`, `fathom watchlist`, `fathom chart`. These extend the existing `fathom backtest` (Phase 1) in `cli.py`. `scan` runs the deterministic pipeline (refresh data → ranker → portfolio) and persists the resulting watchlist; `watchlist` emits the latest watchlist as structured JSON (the contract Hermes consumes); `chart` renders a candidate's PNG. This is the tool surface at the **Hermes boundary** — these commands produce watchlists and images, never orders (INV-01).
+
+## User-facing behaviour
+
+`cli.py` gains three subcommands (argparse, no new dep):
+- `fathom scan [--instruments …] [--timeframes …] [--db-path …]` — refreshes candles (+ calendar), runs [[signal-ranker]] → [[portfolio-limits]], persists the ranked `Candidate` list (a `watchlist` table or run-stamped JSON), prints a summary. Empty approved-set ⇒ empty watchlist, exit 0 (INV-10).
+- `fathom watchlist [--db-path …] [--format json]` — the persisted-read accessor: emits the **latest persisted** watchlist (from the `watchlist` table) as **structured JSON** — a list of the pinned `Candidate` wire shape (INV-13): `instrument, timeframe, strategy_name, direction, entry_ref, stop_distance, target_distance, oos_sharpe_mean, quality_score, rank, spread_ok, session_ok, news_flag, generated_at`. (Hermes typically reads `fathom scan`'s stdout JSON directly; `watchlist` is for re-reading without re-running, and for the Phase 5 panel.)
+- `fathom chart <instrument> [--timeframe …] [--out-dir …]` — renders the candidate's chart via [[chart-generation]] and prints the PNG path.
+
+## Acceptance criteria
+
+- [ ] `fathom scan` runs end-to-end against cached/refreshed data, produces a ranked watchlist, persists it; exit 0. Empty approved-set ⇒ empty watchlist, clear message, exit 0 (INV-10).
+- [ ] `fathom watchlist` emits valid JSON matching the pinned `Candidate` wire shape (snake_case, UTC RFC-3339 times); parseable by a consumer with no Fathom imports.
+- [ ] `fathom chart <instrument>` writes a PNG and prints its path.
+- [ ] All three are registered alongside the existing `backtest` subcommand without breaking it.
+- [ ] No live OANDA/HTTP in tests — mock the client; use cached fixtures (mirrors the Phase 1 runner test pattern).
+- [ ] No token/secret in any command's output or logs (INV-08); all timestamps UTC (INV-03).
+- [ ] None of these commands can place or size an order (INV-01) — they have no import path to a (non-existent in Phase 2) execution module.
+
+## Component design
+
+Extend `cli.py`'s argparse with three `add_parser` entries + `cmd_scan` / `cmd_watchlist` / `cmd_chart` handlers, reusing the Phase 1 patterns (`_build_date_range`, the data-refresh helpers, structured logging, UTC formatter). `scan` composes `Ranker` + `PortfolioLimiter`; persistence is a `watchlist` table in `Store` (or a run-stamped JSON artefact) — pin the choice in Plan. `watchlist` serialises the stored `Candidate`s to JSON. `chart` calls `render_candidate_chart`.
+
+**Wire-format contract (the Hermes-facing surface):** both `fathom scan`'s stdout JSON and `fathom watchlist`'s output must match the `Candidate` field table pinned in [[signal-ranker]] / **INV-13** exactly (same field names, snake_case, RFC-3339 UTC) — do not re-list or rename fields here. Any drift breaks the Hermes job.
+
+**Persistence (AMBIGUOUS-03 resolution):** `fathom scan` writes the ranked `Candidate` list to a **`watchlist` SQLite table** (run-timestamped, mirroring how `approved_set` is stored) and prints the same JSON to stdout. `fathom watchlist` reads the latest run from that table. The `Candidate`↔table mapping lives at the persistence layer; the `Candidate` pydantic model is unchanged.
+
+## Non-goals
+
+- No Hermes job logic (that's [[hermes-job-definitions]] — these are just the tools it calls).
+- No Discord delivery, no Claude calls (those are Hermes-side).
+- No `fathom execute` / order command — does not exist in Phase 2 (INV-01).
+
+## Touches
+
+- [INV-01] — the tool surface stops at watchlist + chart; no order path.
+- [INV-10] — `scan` returns an empty watchlist on an empty approved-set.
+- [INV-03] — UTC timestamps in output. [INV-08] — no secrets logged.
+
+## Depends on
+
+- [[signal-ranker]] (`Ranker`, `Candidate`), [[portfolio-limits]] (`PortfolioLimiter`), [[chart-generation]] (`render_candidate_chart`).
+- Phase 1 `cli.py` (the `backtest` subcommand + helpers), `Store` (shipped).
+
+## Approach
+
+Additive to `cli.py` — **the only Phase 2 task that edits `cli.py`** (serialize per code-map; no other Phase 2 worker touches it). Reuse the runner's data-refresh + logging scaffolding. Integration tests run `scan`/`watchlist`/`chart` against cached fixtures with a mocked client, asserting JSON shape, PNG creation, and empty-approved-set behaviour.
+
+## Open questions
+
+- ~~Watchlist persistence~~ **RESOLVED:** `watchlist` SQLite table, run-timestamped (consistent with `approved_set`); `scan` persists + prints, `watchlist` reads it.
+- Does `scan` always refresh live data, or honor a `--dry-run` (cache-only) like `backtest`? Lean: yes, mirror `backtest`'s `--dry-run`.
+
+## Out of scope
+
+- Hermes job / Discord ([[hermes-job-definitions]]), Claude assessment/narration ([[news-risk-assessment]], [[watchlist-narration]]).

--- a/docs/features/hermes-job-definitions.md
+++ b/docs/features/hermes-job-definitions.md
@@ -1,0 +1,106 @@
+# Feature: hermes-job-definitions
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The Phase 2 capstone: the plain-English **Hermes daily job** that wires the whole watchlist pipeline together and delivers it to Discord. On schedule, Hermes calls `fathom scan`, runs Claude per candidate for news-risk ([[news-risk-assessment]]) and narration ([[watchlist-narration]]), calls `fathom chart` for survivors, and posts the ranked watchlist + charts to the Discord channel via its own gateway. **Hermes is configured, not coded** — this feature's deliverable is the job definition + the prompt wiring + an operator runbook, *not* a built service. The job ends at Discord delivery: **Hermes never places orders (INV-01).**
+
+## User-facing behaviour
+
+The trader receives, on schedule (weekday, after a major session close, in their timezone), a Discord message with: a ranked list of candidate pairs, a one-line Claude rationale per candidate (with a news-risk flag where `event_risk != low`), and a chart PNG per surviving candidate showing entry/stop/target. Candidates the news-risk verdict marks `skip` are vetoed; `reduce_size` are flagged.
+
+Deliverable artefacts (in `hermes_integration/jobs/`):
+- `daily.md` — the plain-English Hermes job: trigger, the ordered tool calls, the Claude prompt steps, the delivery target, and the failure/safe-default behaviour.
+- An operator runbook section: how to register the job in Hermes, point it at the `fathom` CLI as a tool, and connect the Discord gateway.
+
+## Sequence diagram
+
+> Included: 4 actors (Hermes, fathom CLI, Claude, Discord) + scheduled/async coordination + per-candidate fan-out — well past the threshold.
+
+```mermaid
+sequenceDiagram
+    participant Cron as Hermes scheduler
+    participant H as Hermes session
+    participant F as fathom CLI
+    participant Cl as Claude
+    participant D as Discord
+
+    Cron->>H: trigger (weekday, post-session-close)
+    H->>F: fathom scan
+    F-->>H: ranked watchlist — JSON Candidate[] on stdout (INV-13 shape;<br/>high-impact-news candidates already dropped, medium flagged)
+    loop per candidate
+        H->>Cl: news_risk prompt (currencies + calendar events)
+        Cl-->>H: {event_risk, reason, suggest_action}  (validated; malformed→skip, INV-02)
+        alt suggest_action == skip
+            H->>H: veto candidate
+        else proceed / reduce_size
+            H->>F: fathom chart <instrument>
+            F-->>H: chart PNG path
+            H->>Cl: narration prompt (candidate facts)
+            Cl-->>H: one-line rationale (fallback to template on failure)
+        end
+    end
+    H->>D: deliver ranked watchlist + charts
+    Note over H,D: job ends at delivery — Hermes places NO orders (INV-01)
+```
+
+### Failure modes considered
+
+- `fathom scan` returns an empty watchlist (empty approved-set, INV-10) → Hermes posts "no candidates today" rather than failing.
+- Claude news-risk malformed/unavailable → `parse_news_risk` defaults to `skip` (INV-02) → that candidate is vetoed (fails safe, never "proceed").
+- Claude narration unavailable → deterministic `fallback_narration` (cosmetic; candidate stays).
+- A prompt-injected calendar headline can only ever produce a bad *suggestion* that gets vetoed/down-ranked — never a trade (INV-01, the whole point of the boundary).
+- Discord delivery fails → retry per Hermes' gateway; the watchlist is still persisted by `fathom scan` for the panel (Phase 5).
+
+## Acceptance criteria
+
+- [ ] `daily.md` defines the trigger, the exact ordered tool calls (`scan` → per-candidate news-risk → `chart` → narration → deliver), and the delivery target.
+- [ ] The job applies the news-risk verdict: `skip` ⇒ veto, `reduce_size` ⇒ flag, `proceed` ⇒ keep (consuming the [[news-risk-assessment]] contract).
+- [ ] **Hermes is given access ONLY to `fathom scan|watchlist|chart`** — never an execute/order/risk entrypoint (INV-01). The runbook states this explicitly.
+- [ ] Empty watchlist and malformed-Claude paths are specified to fail safe (INV-10, INV-02).
+- [ ] The operator runbook is sufficient to register the job, wire the CLI as a tool, and connect Discord — without code changes to Fathom.
+- [ ] **Acceptance is operational (D-P2-5):** a configured Hermes instance delivers a coherent, actionable watchlist to Discord on ≥5 consecutive daily runs (human-reviewed).
+
+## Component design
+
+Not a coded component — a **configuration artefact**. `daily.md` is the Hermes job (plain English / its `/cron` form). The only Fathom code it leans on is the CLI ([[cli-commands]]) and the two prompt+helper modules ([[news-risk-assessment]], [[watchlist-narration]]). No Discord library, no `anthropic` SDK in Fathom (Hermes owns both — D-P2-3, D-P2-4).
+
+**Watchlist source (AMBIGUOUS-03 resolution):** the job consumes `fathom scan`'s **stdout JSON** directly (the `Candidate[]` array, INV-13 shape) — it does *not* call `fathom watchlist` (that's the persisted-read accessor for re-reads / the Phase 5 panel). **News relationship (AMBIGUOUS-01 resolution):** `fathom scan` has *already* dropped high-impact-news candidates (deterministic gate) and flagged medium ones (`news_flag`); the per-candidate Claude news-risk step is the *finer qualitative veto* on the survivors (it can still `skip`/`reduce_size` a candidate the deterministic gate passed). The two layers are pre-filter (hard, deterministic) then LLM-veto (soft, qualitative) — not a contradictory double-filter.
+
+## Non-goals
+
+- No order placement, sizing, or risk logic — the job ends at Discord (INV-01; Phases 3–4).
+- No intraday job (Phase 2 is daily/swing only — Decision #6; the intraday variant is the same structure on a faster schedule, added later).
+- No Fathom-side Discord client or Claude client.
+
+## Touches
+
+- [INV-01] — **the canonical INV-01 feature**: Hermes's authority ends at the watchlist; it has no order path.
+- [INV-02] — consumes the validated news-risk verdict; malformed → skip.
+- [INV-10] — empty approved-set ⇒ empty watchlist ⇒ "no candidates" message.
+- [INV-08] — Discord/Anthropic credentials live in Hermes' config / `.env`, never committed.
+
+## Depends on
+
+- [[cli-commands]] — the tools Hermes calls.
+- [[news-risk-assessment]] — the verdict contract + parser.
+- [[watchlist-narration]] — the narration prompt + fallback.
+- Hermes Agent (external, configured) + a Discord channel + the Anthropic key (operator-provided).
+
+## Approach
+
+Author `daily.md` as the job definition with the ordered steps from the sequence diagram, explicitly bounding Hermes' tool access to the read-only/watchlist CLI (INV-01). Write the operator runbook for registering the job, wiring the CLI tool, and connecting Discord. The Fathom code it depends on (CLI, prompts, parsers) is delivered by the other Phase 2 specs; this spec is the integration + configuration layer and the human-operational acceptance.
+
+## Open questions
+
+- **D-P2-4 — RESOLVED (recommended, overridable):** delivery via Hermes' Discord gateway; Fathom emits JSON + PNGs, builds no delivery code.
+- **D-P2-5:** the live ≥5-run Discord acceptance requires a running Hermes + Discord channel — an operator/human gate, not an automatable test. Flag in the taskgraph as a manual, human-admin task.
+- Schedule specifics (which session close, which timezone) — operator preference; `daily.md` carries a sensible default (weekday, post-NY-close, user TZ).
+
+## Out of scope
+
+- Execution, risk, monitoring, the admin panel (Phases 3–5). Anything that acts on the watchlist beyond delivering it.

--- a/docs/features/news-risk-assessment.md
+++ b/docs/features/news-risk-assessment.md
@@ -1,0 +1,62 @@
+# Feature: news-risk-assessment
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The Claude layer that assesses per-pair news/event risk for a watchlist candidate and returns a **structured, validated verdict** that can down-rank or veto the candidate. This is the first Claude output in the production decision path, so it is governed by **INV-02**: the response is a pydantic-validated `{event_risk, reason, suggest_action}` object, and any malformed / low-confidence / unparseable response defaults to the safe action (`skip`) — never "trade anyway." The Claude call itself runs inside the Hermes daily session (Hermes is configured, not coded — D-P2-3); **this feature owns the Fathom-side contract**: the prompt template, the pydantic response model, and the parse-and-default validator — all unit-testable without a live Claude call.
+
+## User-facing behaviour
+
+Two Fathom artefacts + one contract:
+- `hermes_integration/prompts/news_risk.md` — the prompt template Hermes fills per candidate (given the pair's two currencies, the upcoming `CalendarEvent`s, and recent headlines).
+- `NewsRiskVerdict` (pydantic): `event_risk: Literal["high","medium","low"]`, `reason: str`, `suggest_action: Literal["proceed","reduce_size","skip"]`.
+- `parse_news_risk(raw: str) -> NewsRiskVerdict` — parses Claude's JSON; **on any failure (malformed JSON, missing field, invalid enum, empty) returns the safe default `NewsRiskVerdict(event_risk="high", reason="unparseable response — defaulting to skip", suggest_action="skip")`** and logs (INV-02).
+
+## Acceptance criteria
+
+- [ ] `NewsRiskVerdict` validates the three fields with strict enums; rejects out-of-enum values.
+- [ ] `parse_news_risk` returns a valid verdict for well-formed Claude JSON.
+- [ ] **Malformed input → safe default (`suggest_action="skip"`), never an exception that aborts the run, never "proceed"** (INV-02). Tested with: invalid JSON, missing field, wrong enum value, empty string, and a low-confidence/ambiguous response.
+- [ ] The prompt template instructs Claude to emit *only* the JSON object matching the schema (no prose), and to default to higher risk when uncertain.
+- [ ] No secret/token in the template or logs (INV-08).
+- [ ] The verdict maps to a ranking effect: `skip` ⇒ veto the candidate; `reduce_size` ⇒ flag (Phase 3 sizing consumes it); `proceed` ⇒ no change. (The application of this mapping lives in the Hermes job [[hermes-job-definitions]]; this spec defines the contract + helper.)
+
+## Component design
+
+`hermes_integration/` new package. `NewsRiskVerdict` + `parse_news_risk` in e.g. `hermes_integration/news_risk.py`; the prompt in `prompts/news_risk.md`. The parser is the INV-02 enforcement point — a single function with a try/except-everything fallback to the skip default. **No `anthropic` SDK dependency is added in Phase 2** (D-P2-3): the live model call is Hermes-side; Fathom supplies the prompt + validates whatever string comes back. This keeps C1 fully unit-testable offline.
+
+**Wire-format contract:** `{event_risk: "high"|"medium"|"low", reason: string, suggest_action: "proceed"|"reduce_size"|"skip"}` — snake_case, exact enum spellings. Pin here so the prompt, the model, and the Hermes job agree.
+
+## Non-goals
+
+- No live Claude/Anthropic API client in Fathom (Hermes invokes Claude; D-P2-3).
+- No calendar fetching (consumes [[economic-calendar]] output, which Hermes passes into the prompt).
+- No narration (that is [[watchlist-narration]] — cosmetic, not INV-02-governed).
+
+## Touches
+
+- [INV-02] — **this is the canonical INV-02 feature**: structured JSON, validated, malformed → safe default (`skip`).
+- [INV-01] — the verdict can only down-rank/veto a *suggestion*; it never reaches the (non-existent in Phase 2) execution path.
+- [INV-08] — no secrets in prompt/logs.
+
+## Depends on
+
+- `data/calendar.py` (`CalendarEvent`, `Impact`) — the events the prompt reasons over (shipped).
+- Hermes (configured, not coded) invokes the prompt and feeds the raw response to `parse_news_risk`.
+
+## Approach
+
+Define the schema first (it's the contract). Write the parser as a defensive boundary: attempt `json.loads` → pydantic validate; on *any* exception or validation error, log and return the skip default. Author the prompt to demand schema-only output and to bias toward `skip`/`reduce_size` under uncertainty (a false skip costs an opportunity; a false proceed costs money — INV-02's asymmetry). Unit-test the parser exhaustively with malformed inputs.
+
+## Open questions
+
+- **D-P2-3 — RESOLVED (recommended, overridable):** Claude call runs Hermes-side; Fathom owns model+validator+prompt, no `anthropic` dep. (If a deterministic pre-trade check is later wanted in-pipeline — Phase 3 — that's when the SDK enters.)
+- Headlines source: the prompt references "recent headlines" — Phase 2's calendar feed has no headlines (deferred). For now the prompt reasons over calendar events only; headlines are a later enrichment.
+
+## Out of scope
+
+- The daily job wiring ([[hermes-job-definitions]]), narration ([[watchlist-narration]]), the deterministic calendar news-gate (that's in [[signal-ranker]]).

--- a/docs/features/portfolio-limits.md
+++ b/docs/features/portfolio-limits.md
@@ -1,0 +1,63 @@
+# Feature: portfolio-limits
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Apply portfolio-level filters to the ranker's output so the watchlist isn't five correlated bets that are really one big bet. Consumes the ranked `Candidate` list from [[signal-ranker]] and enforces correlation-aware exposure: highly correlated pairs count as shared exposure, a per-currency cap limits how many candidates lean on the same currency, and a max-concurrent cap bounds the list length. Returns the final, portfolio-filtered ranked list that the CLI emits.
+
+## User-facing behaviour
+
+Backend module `signals/portfolio.py`. `PortfolioLimiter(store, config)` with `apply(candidates: list[Candidate]) -> list[Candidate]`:
+- Walk candidates highest-score-first; admit each unless it would breach a limit, else drop it.
+- **Correlation:** if a candidate's instrument is highly correlated (above a threshold) with an already-admitted instrument, count them as shared exposure — drop the lower-scored one.
+- **Per-currency cap:** at most `max_per_currency` admitted candidates may share a base or quote currency.
+- **Max concurrent:** at most `max_concurrent` candidates admitted total.
+- Order preserved (still score-ranked); dropped candidates logged with the limit they hit.
+
+## Acceptance criteria
+
+- [ ] Given a ranked list, returns a subset preserving score order, with every admitted candidate respecting all caps.
+- [ ] Two highly-correlated instruments (e.g. EUR_USD & GBP_USD above the correlation threshold) are not both admitted — the higher-scored one wins, the other is dropped with a logged reason.
+- [ ] `max_per_currency` is enforced (e.g. ≤ N candidates sharing USD).
+- [ ] `max_concurrent` bounds the output length.
+- [ ] Greedy admission is deterministic (highest score first; stable tie-break).
+- [ ] Empty input → empty output (no error).
+- [ ] Produces only a filtered watchlist — no sizing/orders (INV-01).
+
+## Component design
+
+`PortfolioLimiter.apply` is a deterministic greedy pass over the score-ranked list. The correlation source is a pairwise correlation computed from recent candle returns via `Store.load_candles` (rolling window), or a static FX correlation grouping as a fallback — see Open questions. `config` carries `correlation_threshold`, `max_per_currency`, `max_concurrent`. Currency extraction splits the OANDA `INSTRUMENT` (`EUR_USD` → base `EUR`, quote `USD`).
+
+## Non-goals
+
+- No position sizing or risk budget (Phase 3 / INV-05 — that's `risk/`).
+- No order placement (INV-01).
+- No re-scoring — consumes the ranker's scores as-is; only admits/drops.
+
+## Touches
+
+- [INV-01] — output is a filtered watchlist of candidates only; never orders.
+- [INV-03] — correlation computed from UTC-stamped candles.
+
+## Depends on
+
+- [[signal-ranker]] — consumes its `Candidate` output (and the pinned `Candidate` wire shape).
+- `Store.load_candles` (shipped) — for correlation from returns.
+
+## Approach
+
+New `signals/portfolio.py` beside `ranker.py` (distinct file → parallel-safe with ranker once the `Candidate` shape is fixed, but logically sequenced after it). Greedy admission keeps it simple and deterministic. Correlation from recent daily returns over a rolling window is the honest approach; a static major-pairs correlation grouping is an acceptable Phase-2 fallback if the rolling computation proves noisy.
+
+## Open questions
+
+- Correlation source: rolling return-correlation (data-driven, can be noisy on short windows) vs a static FX correlation grouping (simple, stable, but coarse). Lean: rolling daily-return correlation with a sane min-window; document the threshold (e.g. |ρ| > 0.7).
+- Default caps: `max_concurrent` (e.g. 5), `max_per_currency` (e.g. 2) — confirm in Plan.
+
+## Out of scope
+
+- Risk sizing / exposure-in-currency-terms beyond candidate counting (Phase 3).
+- The CLI surface ([[cli-commands]]).

--- a/docs/features/signal-ranker.md
+++ b/docs/features/signal-ranker.md
@@ -1,0 +1,94 @@
+# Feature: signal-ranker
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Turn "all approved strategies evaluated against current data" into a short, ranked, filtered list of trade **candidates**. This is the deterministic core of Phase 2: it loads the approved-set (the INV-10 gate), evaluates only approved (strategy, pair, timeframe) combos against current candles, scores each by backtested expectancy × current signal quality, filters out poor conditions (wide spread, illiquid session, imminent high-impact news), resolves conflicts, and emits a ranked `Candidate` list. The `Candidate` shape is the contract every downstream Phase 2 feature consumes (CLI, narration, charts, the Hermes job).
+
+## User-facing behaviour
+
+Backend module `signals/ranker.py`. `Ranker(store, calendar)` with `rank(now: datetime) -> list[Candidate]`:
+
+1. **Gate (INV-10):** `store.load_approved_set()` → the approved (strategy, pair, timeframe) rows. **If empty, return `[]`** (no signals — not all signals) and log it.
+2. **Evaluate:** for each approved combo, run that strategy's `generate_signals` on the latest cached candles; take the most recent bar's `Signal` (if any).
+3. **Filter:** exclude candidates where current spread exceeds an instrument threshold (`spread_ok=False` → dropped) or the instrument is in an illiquid session (`session_ok=False` → dropped).
+4. **News gate (deterministic, calendar-based):** for either leg-currency, query `calendar.upcoming_events` within the news window. A **high-impact** event in-window ⇒ the candidate is **dropped** (hard pre-filter). A **medium-impact** event in-window ⇒ the candidate is **kept with `news_flag=True`** (so Claude/narration can mention it; the Claude news-risk layer in the Hermes job is the finer veto on survivors). Low/none ⇒ `news_flag=False`.
+5. **Conflict policy (D-P2-1, lead ruling):** if two approved combos produce **opposite** directions on the **same (instrument, timeframe)**, suppress both. Different timeframes are ranked independently (no conflict).
+6. **Rank (D-P2-4 / AMBIGUOUS-04 ruling):** sort survivors by **`oos_sharpe_mean` descending (primary)**, then **`quality_score` descending (tie-break)**. `quality_score` is *not* multiplied into a cross-strategy composite — `oos_sharpe_mean` is the INV-11-comparable validated number; `quality_score` (per-strategy [0,1]) only orders ties. Assign 1-based `rank`. Return the ranked list.
+
+`Candidate` is a flat pydantic model — the frozen Hermes-facing wire contract (**INV-13**). Its exact fields are pinned in Component design below.
+
+## Acceptance criteria
+
+- [ ] Loads the approved-set via `store.load_approved_set()`; an empty approved-set → `rank()` returns `[]` and logs (INV-10 — no signals, not all signals).
+- [ ] Only emits candidates for (strategy, pair, timeframe) combos present in the approved-set.
+- [ ] Ranking is by `oos_sharpe_mean` descending (primary), `quality_score` descending (tie-break) — deterministic, with a final stable tie-break (instrument then strategy_name). No multiplicative cross-strategy composite.
+- [ ] A candidate whose current spread exceeds the instrument's threshold is excluded (`spread_ok=False` → dropped); illiquid session → `session_ok=False` → dropped.
+- [ ] A **high-impact** calendar event for either leg-currency within the news window ⇒ candidate **dropped**; a **medium-impact** event ⇒ candidate kept with `news_flag=True`; low/none ⇒ `news_flag=False`.
+- [ ] The `Candidate` output matches the pinned field table exactly (INV-13); a serialisation round-trip test pins the JSON shape.
+- [ ] The approved-set gate join uses `signal.timeframe == row['granularity']` (DRIFT-01).
+- [ ] Same-(instrument, timeframe) opposite-direction conflict → both suppressed (D-P2-1).
+- [ ] All timestamps UTC (INV-03); candidates carry their `Signal.generated_at`.
+- [ ] Produces only candidates — never places or sizes orders (INV-01 boundary).
+
+## Component design
+
+`Ranker` composes existing pieces: `Store.load_approved_set` + `Store.load_candles` (data), the strategy registry (map `strategy_name` → `Strategy` instance, mirroring the runner's `_build_strategy`), and `EconomicCalendar.upcoming_events` (news gate). Pipeline stages are pure functions (gate → evaluate → filter → news → conflict → rank) so each is unit-testable in isolation.
+
+**The `Candidate` wire contract (pinned — INV-13).** Flat, snake_case, the single authoritative field list every downstream spec ([[cli-commands]], [[chart-generation]], [[watchlist-narration]], [[hermes-job-definitions]]) builds against:
+
+| Field | Type | Source / meaning |
+|---|---|---|
+| `instrument` | str | e.g. `EUR_USD` |
+| `timeframe` | str | from `Signal.timeframe`; **same dimension the approved-set/DB calls `granularity`** |
+| `strategy_name` | str | from `Signal` / approved-set row |
+| `direction` | str | `"LONG"` \| `"SHORT"` |
+| `entry_ref` | float | from `Signal` |
+| `stop_distance` | float | from `Signal` (ATR-derived, INV-11) |
+| `target_distance` | float | from `Signal` (RR multiple, INV-11) |
+| `oos_sharpe_mean` | float | from the approved-set row — the validated expectancy + **primary rank key** |
+| `quality_score` | float | from `Signal`, [0,1] — current signal strength; **tie-break only** |
+| `rank` | int | 1-based position after sorting |
+| `spread_ok` | bool | passed the spread filter |
+| `session_ok` | bool | passed the session-liquidity filter |
+| `news_flag` | bool | medium-impact event nearby (high-impact ⇒ dropped, never flagged) |
+| `generated_at` | str | UTC RFC-3339 (the signal bar's close time, INV-03) |
+
+`Candidate` flattens the relevant `Signal` fields (no nested object) so the `fathom watchlist` JSON is flat for Hermes/Discord. Do not leak raw dicts.
+
+**INV-10 gate join (DRIFT-01 resolution):** `load_approved_set()` rows key the dimension as `row['granularity']`; `Signal` calls it `timeframe`. They are the **same dimension** — the gate match is `signal.instrument == row['instrument'] AND signal.strategy_name == row['strategy_name'] AND signal.timeframe == row['granularity']`. The `Candidate` exposes it as `timeframe` (human-facing, matching `Signal`).
+
+## Non-goals
+
+- No position sizing, no order placement, no risk limits (Phase 3 / INV-01).
+- No LLM reasoning — the deterministic news gate here uses the calendar directly; the *Claude* news-risk assessment ([[news-risk-assessment]]) is a separate, Hermes-side layer applied in the daily job.
+- No portfolio correlation/exposure caps — that is the next stage ([[portfolio-limits]]).
+
+## Touches
+
+- [INV-10] — the ranker is the enforcement point: empty approved-set ⇒ no candidates.
+- [INV-11] — consumes `Signal`s whose ATR-derived stops make cross-strategy scores comparable.
+- [INV-03] — UTC timestamps throughout.
+- [INV-01] — output is a watchlist of candidates only; never orders.
+
+## Depends on
+
+- `Store.load_approved_set` / `load_candles` (shipped), `strategies/*` (`Signal`, `generate_signals`), `data/calendar.py` (`upcoming_events`, `CalendarEvent`, `Impact`) — all on `main`.
+
+## Approach
+
+A new `signals/` package. `Ranker.rank()` runs the pipeline; the strategy-name→instance mapping reuses the runner's construction logic (factor a shared `_build_strategy` if helpful). The deterministic news gate queries `calendar.upcoming_events([base_ccy, quote_ccy], news_window)` and flags high-impact hits. Conflict suppression operates on the `(instrument, timeframe)` group after scoring.
+
+## Open questions
+
+- **D-P2-1 conflict policy — RESOLVED (lead ruling, overridable):** suppress both on same-(instrument, timeframe) opposite-direction conflict; cross-timeframe ranked independently. Conservative / bounded-downside; revisit once a demo track record exists.
+- News window length: how many hours before a high-impact event to veto? Propose **4h** for high-impact, 1h for medium. Confirm in Plan.
+- Spread threshold source: per-instrument `typical_spread` from `InstrumentMeta` × a multiplier, vs a flat pip cap. Lean: `InstrumentMeta`-derived.
+
+## Out of scope
+
+- Portfolio limits ([[portfolio-limits]]), charts ([[chart-generation]]), the CLI surface ([[cli-commands]]), Claude assessment ([[news-risk-assessment]]).

--- a/docs/features/watchlist-narration.md
+++ b/docs/features/watchlist-narration.md
@@ -1,0 +1,56 @@
+# Feature: watchlist-narration
+
+**Status.** ready
+**Phase.** Phase 2
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+Turn each ranked candidate into a one-line, human-readable rationale so the trader understands *why* a pair is on the list (e.g. "Donchian 20-bar breakout long on GBP/USD H4, OOS Sharpe 0.25, no high-impact news for 6h"). Claude writes the narration inside the Hermes daily session. Unlike [[news-risk-assessment]], narration is **cosmetic — it does not feed any automated decision**, so it is **not** governed by INV-02; a missing/malformed narration falls back to a deterministic template string rather than the safe-skip default.
+
+## User-facing behaviour
+
+Two Fathom artefacts:
+- `hermes_integration/prompts/narration.md` — the prompt template Hermes fills with a candidate's facts (the flat `Candidate` fields per INV-13: `instrument, timeframe, strategy_name, direction, oos_sharpe_mean, news_flag` — *not* "expectancy") and asks for one concise plain-English line.
+- `fallback_narration(candidate: Candidate) -> str` — a deterministic one-liner built from the candidate's own fields, used when Claude is unavailable or returns something unusable. Always produces a sensible line (never empty, never an exception).
+
+## Acceptance criteria
+
+- [ ] The prompt template instructs Claude to return exactly one line (no JSON, no markdown), grounded only in the supplied facts (no invented numbers).
+- [ ] `fallback_narration` produces a clear one-line summary from the candidate's fields for any candidate (tested across LONG/SHORT, each strategy).
+- [ ] An empty/whitespace/over-long Claude response → caller uses `fallback_narration` (graceful, cosmetic — NOT a safety veto; the candidate stays on the list).
+- [ ] Narration never alters ranking or filtering — it is presentation only.
+- [ ] No secret/token in the template or logs (INV-08).
+
+## Component design
+
+`hermes_integration/narration.py` for `fallback_narration` + the prompt in `prompts/narration.md`. Deliberately mirrors [[news-risk-assessment]]'s prompt+helper shape so the two are consistent — **but the failure semantics differ on purpose**: news-risk fails *safe* (skip, INV-02); narration fails *cosmetic* (template fallback, candidate unaffected). This distinction must be explicit so a future reader doesn't apply INV-02's veto-on-failure to narration.
+
+## Non-goals
+
+- No INV-02 safe-default veto — narration failure must NOT drop a candidate (that would let a cosmetic-layer hiccup silently shrink the watchlist).
+- No ranking/scoring influence.
+- No live Claude client in Fathom (Hermes invokes Claude; D-P2-3).
+
+## Touches
+
+- [INV-08] — no secrets in prompt/logs.
+- *(Explicitly NOT INV-02)* — narration is cosmetic; documented here to prevent mis-application of the safe-default rule.
+
+## Depends on
+
+- [[signal-ranker]] — the `Candidate` being narrated.
+- Hermes (configured) invokes the prompt; falls back to `fallback_narration` on failure.
+
+## Approach
+
+Write `fallback_narration` first (it's the guaranteed path) from the candidate's fields. Author the prompt to be tightly grounded (one line, only supplied facts) to avoid hallucinated levels. The Hermes job ([[hermes-job-definitions]]) calls Claude with the prompt and substitutes `fallback_narration` on any unusable result.
+
+## Open questions
+
+- Should narration mention the news-risk verdict ([[news-risk-assessment]]) inline (e.g. "⚠ high-impact USD news in 3h")? Lean: yes — fold the verdict's `reason` into the line when `event_risk != low`, since they're presented together. Decide in Plan.
+
+## Out of scope
+
+- News-risk *assessment*/veto ([[news-risk-assessment]]), the daily job wiring ([[hermes-job-definitions]]).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -122,3 +122,13 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 **Reason:** SQLite without explicit WAL + retry is not safe for concurrent writers. A partially-failed concurrent write produces an incomplete approved-set that INV-10 cannot distinguish from a legitimately small one — silently undermining the gate (some combinations approved but missing, while the runner exits 0).
 
 **Enforcement:** `fathom backtest` collects all `ProcessPoolExecutor` futures into a list before any DB write, then writes the full batch in one `BEGIN…COMMIT`. Reviewed at the runner task.
+
+---
+
+## INV-13 · The `Candidate` Model Is the Frozen Hermes-Facing Wire Contract
+
+**Rule:** `signals/ranker.py`'s `Candidate` pydantic model is the stable output contract of the Phase 2 watchlist pipeline. Its field **names** (snake_case), **types**, and **flat (non-nested) shape** are frozen once the ranker ships. A `fathom watchlist` JSON response is always a JSON array of `Candidate` objects serialised by this model; the Hermes job, charts, narration, and portfolio layer all build against this exact shape. The pinned fields are: `instrument, timeframe, strategy_name, direction, entry_ref, stop_distance, target_distance, oos_sharpe_mean, quality_score, rank, spread_ok, session_ok, news_flag, generated_at` (UTC RFC-3339). Changes to field names/types/shape are **breaking changes to the Hermes integration** and must be treated as an amendment to this invariant.
+
+**Reason:** `Candidate` is consumed by `portfolio.py`, `charts.py`, `cli.py`, `narration.py`, and the Hermes daily job. Once shipped, a silent field rename ripples across all of them and breaks the Discord watchlist. Freezing the contract (as INV-11 freezes the `Signal` stop/target derivation) makes the dependency explicit and reviewable. Note: `timeframe` is the same dimension the approved-set/DB calls `granularity`; the INV-10 gate join is `signal.timeframe == approved_set.granularity`.
+
+**Enforcement:** The field table lives in `docs/features/signal-ranker.md`; `cli-commands`, `chart-generation`, and `watchlist-narration` reference it rather than re-listing fields. A serialisation round-trip test pins the JSON shape. Reviewer checks any `Candidate` field change against this invariant.

--- a/docs/phases/phase-2-spec-audit-2026-05-29.md
+++ b/docs/phases/phase-2-spec-audit-2026-05-29.md
@@ -1,0 +1,34 @@
+# Fathom Phase 2 — Cross-Spec Audit (2026-05-29)
+
+Run per `runbook-cross-spec-audit` by a fresh, independent auditor (read-only). Fixes applied by the lead afterward — each finding annotated with its resolution.
+
+## Scope
+
+7 Phase 2 specs: signal-ranker, portfolio-limits, chart-generation, news-risk-assessment, watchlist-narration, cli-commands, hermes-job-definitions. Cross-checked against `invariants.md`, `code-map.md`, `INDEX.md`, `phase-2.md`, and shipped contracts (`Signal`, `load_approved_set`, `ApprovedSetEntry`, `CalendarEvent`/`upcoming_events`, `cli.py`).
+
+## Summary
+
+14 shared concepts · 7 consistent · 3 blocking (drift/ambiguous) · 4 non-blocking · 2 invariant-promotion candidates.
+
+## Findings & resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| DRIFT-02 | blocking | `Candidate` wire shape never pinned (prose only); `rank` field inconsistent across specs; Signal nest-vs-flatten unresolved | **Fixed** — signal-ranker now pins an explicit **flat** `Candidate` field table; cli/chart/narration aligned to it; promoted to **INV-13** (frozen Hermes-facing contract) |
+| DRIFT-01 | blocking | `granularity` (approved-set/DB) vs `timeframe` (Signal) join-key equivalence undocumented — INV-10 gate footgun | **Fixed** — signal-ranker documents the join `signal.timeframe == row['granularity']` |
+| AMBIGUOUS-01 | blocking | news-flagged candidates: dropped by `rank()` or passed through? deterministic gate vs Claude veto relationship undefined | **Fixed (lead ruling)** — high-impact event in-window ⇒ **dropped** (hard pre-filter); medium-impact ⇒ kept with `news_flag=True`; Claude news-risk is the finer veto on survivors. signal-ranker AC + hermes-job sequence aligned |
+| DRIFT-03 | non-blocking | `expectancy` = `oos_sharpe_mean` (misleading; "expectancy" usually means EV) | **Fixed** — field renamed `oos_sharpe_mean` throughout; the misleading `expectancy`/composite `score` names removed |
+| AMBIGUOUS-02 | non-blocking | chart title `score` vs `Signal.quality_score` ambiguity | **Fixed** — chart references `Candidate` fields (`oos_sharpe_mean`, `rank`) explicitly |
+| AMBIGUOUS-03 | non-blocking | watchlist persistence undecided; `fathom watchlist` absent from Hermes sequence | **Fixed** — persistence = `watchlist` SQLite table; `fathom scan` persists + prints JSON; `fathom watchlist` is the persisted-read accessor; hermes-job sequence notes it uses `scan`'s JSON directly |
+| AMBIGUOUS-04 | non-blocking | `quality_score` not cross-strategy comparable, yet multiplied into the ranking score | **Fixed (lead ruling)** — rank by `oos_sharpe_mean` primary (INV-11-comparable), `quality_score` **tie-break only**; no multiplicative cross-strategy composite. Closes CANDIDATE-INV-B by removing the comparability dependency |
+
+## Invariant-promotion candidates
+
+- **CANDIDATE-INV-A → promoted as INV-13:** the `Candidate` model is the frozen Hermes-facing wire contract.
+- **CANDIDATE-INV-B → resolved in-spec** (quality_score demoted to tie-break) — no new invariant needed; the incommensurability dependency is removed rather than enforced.
+
+## Consistent (no action)
+
+INV-02 (news-risk fails safe / narration fails cosmetic — distinction explicit), INV-01 (cli + hermes-job both bound to no-order-path), INV-10 (empty approved-set → empty watchlist, consistent across ranker/cli/hermes-job), `NewsRiskVerdict` schema (identical across specs), conflict policy D-P2-1 (ranker-internal), dependency graph (acyclic, matches code-map), no `anthropic` dep (D-P2-3), INV-03/INV-08, INDEX matches the 7 files, matplotlib via coordinator, cli.py single-writer.
+
+*Verdict after fixes: spec corpus coherent; ready for taskgraph generation.*


### PR DESCRIPTION
Layer-4 spec layer for Phase 2 (watchlist → Discord), planning only — no code.

**Adds:** 7 feature specs under docs/features/, code-map Phase 2 update, cross-spec audit report.
**Promotes:** INV-13 (Candidate = frozen Hermes-facing wire contract).
**Audit:** 3 blocking (Candidate shape never pinned, granularity/timeframe join, news drop-vs-flag) + 4 non-blocking — all resolved. Lead rulings applied: conflict=suppress-both, news=drop-high-impact/flag-medium, rank by oos_sharpe_mean with quality_score tie-break, Discord via Hermes gateway, Claude Hermes-side (no anthropic dep).

All 7 specs ready. Next: taskgraph generation (Plan Mode). No code in this PR.