### PR TITLE
P2-T-04: news-risk-assessment

### DIFF
--- a/.claude/context/hermes_integration.md
+++ b/.claude/context/hermes_integration.md
@@ -1,0 +1,58 @@
+# Hermes integration context
+
+## P2-T-04 — 2026-05-29 (feat/p2-t-04)
+
+**What was done:**
+- Created `hermes_integration/__init__.py` (package marker with module-level docstring).
+- Created `hermes_integration/news_risk.py` with:
+  - `NewsRiskVerdict` pydantic v2 model:
+    - `event_risk: Literal["high","medium","low"]`
+    - `reason: str`
+    - `suggest_action: Literal["proceed","reduce_size","skip"]`
+    - `model_config = {"extra": "forbid"}` — rejects unknown fields at validation time.
+  - `_safe_default()` — private factory returning the INV-02 safe default
+    `NewsRiskVerdict(event_risk="high", reason="unparseable response — defaulting to skip", suggest_action="skip")`.
+  - `parse_news_risk(raw: str) -> NewsRiskVerdict` — INV-02 enforcement boundary:
+    empty-string guard → `json.loads` → `isinstance(dict)` check → `NewsRiskVerdict.model_validate`.
+    Any failure at any stage: `_log.warning(...)` + return `_safe_default()`. Never raises. Never returns `proceed` on failure.
+- Created `hermes_integration/prompts/news_risk.md` — prompt template with `{{instrument}}`,
+  `{{base_currency}}`, `{{quote_currency}}`, `{{direction}}`, `{{entry_window_utc}}`,
+  `{{calendar_events}}` placeholders. Instructs Claude to output ONLY the JSON object
+  matching the schema; no prose, no markdown fences. Bias table: high-impact ≤ 4h → skip;
+  medium ≤ 1h or high 4–12h → reduce_size; ambiguous/uncertain → skip. No secrets (INV-08).
+- Created `tests/test_news_risk.py` — 50 tests, zero live Claude/Anthropic calls:
+  - `TestNewsRiskVerdictModel` (14 tests): valid construction, all enum values, rejects
+    out-of-enum event_risk, out-of-enum suggest_action, missing fields, extra fields.
+  - `TestParseNewsRiskWellFormed` (6 tests): proceed/skip/reduce_size verdicts, type check,
+    all enum round-trips.
+  - `TestParseNewsRiskMalformedInputs` (26 tests): invalid JSON, partial JSON, prose response,
+    markdown-fenced JSON, empty string, whitespace, missing each required field, missing all
+    fields, bad event_risk enum ("catastrophic", "extreme"), bad suggest_action enum
+    ("trade", "allow", "go"), JSON array, null, bare string, number, boolean, null field
+    values, extra field, ambiguous text. Plus `test_never_returns_proceed_on_failure` and
+    `test_never_raises_on_any_input` (INV-02 invariant sweeps over 8+ inputs each).
+  - `TestParseNewsRiskLogging` (4 tests): warning logged on bad JSON/empty/bad-enum;
+    no secret token leaks in logs (INV-08).
+
+**INV-02 design decision:**
+- `parse_news_risk` has three layers of defence: (1) empty-string guard, (2) JSON parse
+  try/except, (3) pydantic validate try/except + bare `except Exception` catch-all.
+  Each layer independently returns the skip default and logs — no failure can propagate.
+- `model_config = {"extra": "forbid"}` means a Claude response with extra fields
+  (e.g. `"confidence": 0.9`) triggers a `ValidationError` → skip default. This is intentional:
+  the wire contract is exactly `{event_risk, reason, suggest_action}`.
+
+**No anthropic SDK dep** (D-P2-3 enforced — Hermes calls Claude; Fathom owns validation).
+**pyproject.toml untouched** — no new dependencies. `hermes_integration` is importable via
+the editable install path (worktree root on sys.path); setuptools `packages.find.include`
+does not need updating for offline unit tests.
+
+**AC verification results:**
+- `pytest tests/test_news_risk.py -v` → 50 passed, exit 0
+- `pytest -q` (full suite) → 473 passed, exit 0
+- `mypy hermes_integration/` → "Success: no issues found in 2 source files", exit 0
+
+**New dependency added to pyproject.toml?** NO (no new deps; pydantic already present).
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/hermes_integration/__init__.py
+++ b/hermes_integration/__init__.py
@@ -1,0 +1,10 @@
+"""Hermes integration — prompt templates, response models, and parse helpers.
+
+This package owns the Fathom-side contract for Claude-powered daily watchlist
+generation.  No ``anthropic`` SDK dependency (D-P2-3): Claude is invoked
+Hermes-side; Fathom supplies the prompt templates, validates the JSON strings
+that come back, and exposes typed pydantic models to downstream pipeline steps.
+
+Modules:
+    news_risk: NewsRiskVerdict model + parse_news_risk() — INV-02 enforcement.
+"""

--- a/hermes_integration/news_risk.py
+++ b/hermes_integration/news_risk.py
@@ -1,0 +1,155 @@
+"""News-risk assessment — INV-02 enforcement boundary.
+
+Owns the Fathom-side contract for Claude's per-pair news/event risk verdict:
+
+  * ``NewsRiskVerdict`` (pydantic v2) — typed, enum-validated response model.
+  * ``parse_news_risk(raw)`` — the INV-02 safe-default boundary.  Any failure
+    (invalid JSON, missing field, out-of-enum value, empty string, wrong type)
+    returns the skip default and logs.  It **never raises**, and it **never
+    returns** ``suggest_action="proceed"`` on a parse/validation failure.
+
+The asymmetry (INV-02):
+    A false ``skip`` costs an opportunity; a false ``proceed`` costs money.
+    The parser is therefore the safe boundary — wrap everything in
+    try/except → skip default, not raise.
+
+No ``anthropic`` SDK dependency (D-P2-3): Claude is invoked Hermes-side.
+This module is fully unit-testable offline.
+
+INV-08: No secrets, tokens, or API keys are referenced here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel, ValidationError
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Safe default (INV-02) — returned whenever parse_news_risk fails for ANY reason
+# ---------------------------------------------------------------------------
+
+_SAFE_DEFAULT_EVENT_RISK: Literal["high"] = "high"
+_SAFE_DEFAULT_REASON: str = "unparseable response — defaulting to skip"
+_SAFE_DEFAULT_ACTION: Literal["skip"] = "skip"
+
+
+# ---------------------------------------------------------------------------
+# NewsRiskVerdict pydantic model
+# ---------------------------------------------------------------------------
+
+
+class NewsRiskVerdict(BaseModel):
+    """Structured news/event-risk verdict returned by Claude (via Hermes).
+
+    Wire format (snake_case, exact enum spellings):
+        ``{"event_risk": "high"|"medium"|"low", "reason": "...",
+           "suggest_action": "proceed"|"reduce_size"|"skip"}``
+
+    Pydantic v2 strict enum validation rejects any value outside the declared
+    literals at construction time, satisfying the INV-02 strict-enum requirement.
+
+    Attributes:
+        event_risk: Assessed risk level for the upcoming event window.
+        reason: Human-readable explanation from Claude.
+        suggest_action: Recommended pipeline action:
+            - ``"proceed"`` — no change to candidacy.
+            - ``"reduce_size"`` — flag for Phase 3 sizing; candidate kept.
+            - ``"skip"`` — veto the candidate entirely.
+    """
+
+    event_risk: Literal["high", "medium", "low"]
+    reason: str
+    suggest_action: Literal["proceed", "reduce_size", "skip"]
+
+    model_config = {"extra": "forbid"}
+
+
+# ---------------------------------------------------------------------------
+# Safe-default factory
+# ---------------------------------------------------------------------------
+
+
+def _safe_default() -> NewsRiskVerdict:
+    """Return the INV-02 safe default verdict (skip, high-risk)."""
+    return NewsRiskVerdict(
+        event_risk=_SAFE_DEFAULT_EVENT_RISK,
+        reason=_SAFE_DEFAULT_REASON,
+        suggest_action=_SAFE_DEFAULT_ACTION,
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_news_risk — INV-02 enforcement boundary
+# ---------------------------------------------------------------------------
+
+
+def parse_news_risk(raw: str) -> NewsRiskVerdict:
+    """Parse Claude's JSON response into a ``NewsRiskVerdict``.
+
+    This is the INV-02 enforcement boundary.  **On ANY failure** — invalid
+    JSON, missing required field, out-of-enum value, empty string, wrong
+    JSON type — returns the safe default
+    ``NewsRiskVerdict(event_risk="high", reason="unparseable response — defaulting to skip",
+    suggest_action="skip")`` and logs at WARNING level.  It **never raises**
+    and **never returns** ``suggest_action="proceed"`` on a failure path.
+
+    Args:
+        raw: The raw string returned by Claude (expected to be a JSON object).
+
+    Returns:
+        A validated ``NewsRiskVerdict``.  On any failure, the safe-default
+        ``skip`` verdict is returned instead.
+
+    Examples:
+        >>> parse_news_risk('{"event_risk":"low","reason":"quiet week","suggest_action":"proceed"}')
+        NewsRiskVerdict(event_risk='low', reason='quiet week', suggest_action='proceed')
+
+        >>> parse_news_risk("this is not json")
+        NewsRiskVerdict(event_risk='high', reason='unparseable response — defaulting to skip', suggest_action='skip')
+    """
+    # Guard: reject empty / whitespace-only input immediately.
+    if not raw or not raw.strip():
+        _log.warning(
+            "parse_news_risk: empty response — returning safe default (INV-02)"
+        )
+        return _safe_default()
+
+    try:
+        data: Any = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        _log.warning(
+            "parse_news_risk: JSON decode failed (%s) — returning safe default (INV-02)",
+            exc,
+        )
+        return _safe_default()
+
+    # json.loads can return non-dict values (e.g. a bare string, list, or null).
+    if not isinstance(data, dict):
+        _log.warning(
+            "parse_news_risk: expected a JSON object, got %s — returning safe default (INV-02)",
+            type(data).__name__,
+        )
+        return _safe_default()
+
+    try:
+        verdict = NewsRiskVerdict.model_validate(data)
+    except ValidationError as exc:
+        _log.warning(
+            "parse_news_risk: pydantic validation failed (%s) — returning safe default (INV-02)",
+            exc,
+        )
+        return _safe_default()
+    except Exception as exc:  # noqa: BLE001 — catch-all for absolute safety (INV-02)
+        _log.warning(
+            "parse_news_risk: unexpected error (%s: %s) — returning safe default (INV-02)",
+            type(exc).__name__,
+            exc,
+        )
+        return _safe_default()
+
+    return verdict

--- a/hermes_integration/prompts/news_risk.md
+++ b/hermes_integration/prompts/news_risk.md
@@ -1,0 +1,71 @@
+# Prompt: News-Risk Assessment
+
+**Used by:** Hermes daily watchlist job  
+**For:** Each surviving watchlist candidate, after the deterministic calendar gate  
+**Returns:** A single JSON object — no prose, no markdown, no explanation outside the JSON  
+
+---
+
+## Instructions
+
+You are a conservative forex risk analyst. Your job is to assess whether upcoming economic
+calendar events pose a meaningful risk to a candidate trade on **{{instrument}}**
+(currencies: **{{base_currency}}** / **{{quote_currency}}**).
+
+You will be given:
+- A list of upcoming calendar events within the trade's risk window for both currencies.
+- The candidate's direction (LONG or SHORT) and the approximate entry window.
+
+Your response must be **exactly one JSON object** matching this schema — nothing else:
+
+```json
+{
+  "event_risk": "high" | "medium" | "low",
+  "reason": "<concise explanation, ≤ 120 characters>",
+  "suggest_action": "proceed" | "reduce_size" | "skip"
+}
+```
+
+**Field rules (strict — these are validated by machine):**
+- `event_risk`: one of the three strings above, lowercase, no variations.
+- `reason`: a plain string; no quotes-within-quotes; no newlines; ≤ 120 characters.
+- `suggest_action`: one of the three strings above, with underscore, lowercase, no variations.
+
+**Do not** wrap in markdown fences. **Do not** add commentary before or after the JSON.
+**Do not** include extra fields. Output only the JSON object, nothing else.
+
+---
+
+## Risk-assessment guidance
+
+**Default toward higher risk when uncertain.** The cost of a missed trade is an opportunity
+lost; the cost of a bad trade is real money. When in doubt, set `event_risk` to `"high"` and
+`suggest_action` to `"skip"`.
+
+| Condition | Recommended verdict |
+|---|---|
+| High-impact event within 4 hours of entry for either currency | `event_risk: "high"`, `suggest_action: "skip"` |
+| Medium-impact event within 1 hour, or high-impact within 4–12 hours | `event_risk: "medium"`, `suggest_action: "reduce_size"` |
+| Low-impact only, or no events near entry window | `event_risk: "low"`, `suggest_action: "proceed"` |
+| Conflicting signals or ambiguous timing | `event_risk: "high"`, `suggest_action: "skip"` |
+| Claude is uncertain about impact or timing | `event_risk: "high"`, `suggest_action: "skip"` |
+
+---
+
+## Input data
+
+**Instrument:** {{instrument}}  
+**Base currency:** {{base_currency}}  
+**Quote currency:** {{quote_currency}}  
+**Direction:** {{direction}}  
+**Approximate entry window:** {{entry_window_utc}} UTC  
+
+**Upcoming calendar events (next 12 hours, both currencies):**
+
+{{calendar_events}}
+
+*(If the list is empty, there are no known scheduled events for either currency in the next 12 hours.)*
+
+---
+
+Respond now with **only** the JSON object.

--- a/tests/test_news_risk.py
+++ b/tests/test_news_risk.py
@@ -1,0 +1,441 @@
+"""Tests for hermes_integration.news_risk — INV-02 enforcement.
+
+Coverage:
+    - NewsRiskVerdict: valid construction, field access, strict enum rejection.
+    - parse_news_risk: well-formed JSON → valid verdict.
+    - Malformed inputs → safe default (suggest_action="skip"), no exception,
+      never "proceed" (INV-02 exhaustive battery).
+
+No live Claude / Anthropic calls anywhere in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from hermes_integration.news_risk import NewsRiskVerdict, parse_news_risk
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_JSON_PROCEED = json.dumps(
+    {
+        "event_risk": "low",
+        "reason": "No high-impact events in window",
+        "suggest_action": "proceed",
+    }
+)
+
+_GOOD_JSON_SKIP = json.dumps(
+    {
+        "event_risk": "high",
+        "reason": "NFP release within 2 hours of entry window",
+        "suggest_action": "skip",
+    }
+)
+
+_GOOD_JSON_REDUCE = json.dumps(
+    {
+        "event_risk": "medium",
+        "reason": "Medium-impact CPI near entry; reduce exposure",
+        "suggest_action": "reduce_size",
+    }
+)
+
+_SAFE_DEFAULT_REASON = "unparseable response — defaulting to skip"
+
+
+def _is_safe_default(verdict: NewsRiskVerdict) -> bool:
+    """Return True if verdict is the INV-02 safe default (skip)."""
+    return (
+        verdict.event_risk == "high"
+        and verdict.suggest_action == "skip"
+        and "defaulting to skip" in verdict.reason
+    )
+
+
+# ---------------------------------------------------------------------------
+# NewsRiskVerdict — model validation
+# ---------------------------------------------------------------------------
+
+
+class TestNewsRiskVerdictModel:
+    """NewsRiskVerdict field validation and strict enum enforcement."""
+
+    def test_valid_proceed(self) -> None:
+        v = NewsRiskVerdict(event_risk="low", reason="quiet week", suggest_action="proceed")
+        assert v.event_risk == "low"
+        assert v.suggest_action == "proceed"
+        assert v.reason == "quiet week"
+
+    def test_valid_skip(self) -> None:
+        v = NewsRiskVerdict(event_risk="high", reason="NFP imminent", suggest_action="skip")
+        assert v.event_risk == "high"
+        assert v.suggest_action == "skip"
+
+    def test_valid_reduce_size(self) -> None:
+        v = NewsRiskVerdict(event_risk="medium", reason="CPI nearby", suggest_action="reduce_size")
+        assert v.event_risk == "medium"
+        assert v.suggest_action == "reduce_size"
+
+    def test_all_event_risk_values(self) -> None:
+        for risk in ("high", "medium", "low"):
+            v = NewsRiskVerdict(event_risk=risk, reason="ok", suggest_action="proceed")  # type: ignore[arg-type]
+            assert v.event_risk == risk
+
+    def test_all_suggest_action_values(self) -> None:
+        for action in ("proceed", "reduce_size", "skip"):
+            v = NewsRiskVerdict(event_risk="low", reason="ok", suggest_action=action)  # type: ignore[arg-type]
+            assert v.suggest_action == action
+
+    def test_rejects_bad_event_risk_catastrophic(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="catastrophic", reason="x", suggest_action="skip")  # type: ignore[arg-type]
+
+    def test_rejects_bad_event_risk_critical(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="critical", reason="x", suggest_action="skip")  # type: ignore[arg-type]
+
+    def test_rejects_bad_event_risk_none(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk=None, reason="x", suggest_action="skip")  # type: ignore[arg-type]
+
+    def test_rejects_bad_suggest_action_trade(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="trade")  # type: ignore[arg-type]
+
+    def test_rejects_bad_suggest_action_allow(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="allow")  # type: ignore[arg-type]
+
+    def test_rejects_missing_event_risk(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(reason="x", suggest_action="skip")  # type: ignore[call-arg]
+
+    def test_rejects_missing_suggest_action(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="low", reason="x")  # type: ignore[call-arg]
+
+    def test_rejects_missing_reason(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(event_risk="low", suggest_action="proceed")  # type: ignore[call-arg]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            NewsRiskVerdict(
+                event_risk="low",
+                reason="x",
+                suggest_action="proceed",
+                extra_field="unexpected",  # type: ignore[call-arg]
+            )
+
+
+# ---------------------------------------------------------------------------
+# parse_news_risk — well-formed input
+# ---------------------------------------------------------------------------
+
+
+class TestParseNewsRiskWellFormed:
+    """parse_news_risk returns a valid verdict for well-formed Claude JSON."""
+
+    def test_proceed_verdict(self) -> None:
+        v = parse_news_risk(_GOOD_JSON_PROCEED)
+        assert v.event_risk == "low"
+        assert v.suggest_action == "proceed"
+        assert v.reason == "No high-impact events in window"
+
+    def test_skip_verdict(self) -> None:
+        v = parse_news_risk(_GOOD_JSON_SKIP)
+        assert v.event_risk == "high"
+        assert v.suggest_action == "skip"
+
+    def test_reduce_size_verdict(self) -> None:
+        v = parse_news_risk(_GOOD_JSON_REDUCE)
+        assert v.event_risk == "medium"
+        assert v.suggest_action == "reduce_size"
+
+    def test_returns_news_risk_verdict_type(self) -> None:
+        v = parse_news_risk(_GOOD_JSON_PROCEED)
+        assert isinstance(v, NewsRiskVerdict)
+
+    def test_all_event_risk_values_round_trip(self) -> None:
+        for risk in ("high", "medium", "low"):
+            raw = json.dumps(
+                {"event_risk": risk, "reason": "test", "suggest_action": "proceed"}
+            )
+            v = parse_news_risk(raw)
+            assert v.event_risk == risk
+
+    def test_all_suggest_action_values_round_trip(self) -> None:
+        for action in ("proceed", "reduce_size", "skip"):
+            raw = json.dumps(
+                {"event_risk": "low", "reason": "test", "suggest_action": action}
+            )
+            v = parse_news_risk(raw)
+            assert v.suggest_action == action
+
+
+# ---------------------------------------------------------------------------
+# parse_news_risk — malformed input → safe default (INV-02 exhaustive battery)
+# ---------------------------------------------------------------------------
+
+
+class TestParseNewsRiskMalformedInputs:
+    """Each malformed input must: return safe default, never raise, never proceed (INV-02)."""
+
+    # -- Invalid JSON --
+
+    def test_invalid_json_string(self) -> None:
+        v = parse_news_risk("this is not json")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_invalid_json_partial(self) -> None:
+        v = parse_news_risk('{"event_risk": "high"')  # truncated
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_invalid_json_prose_response(self) -> None:
+        v = parse_news_risk("The news risk is high because of the upcoming NFP.")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_invalid_json_markdown_wrapped(self) -> None:
+        # Claude sometimes wraps in code fences despite instructions.
+        v = parse_news_risk(
+            '```json\n{"event_risk":"low","reason":"ok","suggest_action":"proceed"}\n```'
+        )
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Empty / whitespace --
+
+    def test_empty_string(self) -> None:
+        v = parse_news_risk("")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_whitespace_only(self) -> None:
+        v = parse_news_risk("   \n\t  ")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Missing required fields --
+
+    def test_missing_suggest_action(self) -> None:
+        raw = json.dumps({"event_risk": "low", "reason": "quiet week"})
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_missing_event_risk(self) -> None:
+        raw = json.dumps({"reason": "quiet week", "suggest_action": "proceed"})
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_missing_reason(self) -> None:
+        raw = json.dumps({"event_risk": "low", "suggest_action": "proceed"})
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_missing_all_fields(self) -> None:
+        v = parse_news_risk("{}")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Out-of-enum values --
+
+    def test_bad_event_risk_catastrophic(self) -> None:
+        raw = json.dumps(
+            {"event_risk": "catastrophic", "reason": "doom", "suggest_action": "skip"}
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_bad_event_risk_extreme(self) -> None:
+        raw = json.dumps(
+            {"event_risk": "extreme", "reason": "doom", "suggest_action": "skip"}
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_bad_suggest_action_trade(self) -> None:
+        raw = json.dumps(
+            {"event_risk": "low", "reason": "ok", "suggest_action": "trade"}
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_bad_suggest_action_allow(self) -> None:
+        raw = json.dumps(
+            {"event_risk": "low", "reason": "ok", "suggest_action": "allow"}
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_bad_suggest_action_go(self) -> None:
+        raw = json.dumps(
+            {"event_risk": "low", "reason": "ok", "suggest_action": "go"}
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Wrong JSON types --
+
+    def test_json_array_not_object(self) -> None:
+        raw = json.dumps(
+            [{"event_risk": "low", "reason": "ok", "suggest_action": "proceed"}]
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_json_null(self) -> None:
+        v = parse_news_risk("null")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_json_bare_string(self) -> None:
+        v = parse_news_risk('"proceed"')
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_json_number(self) -> None:
+        v = parse_news_risk("42")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_json_boolean(self) -> None:
+        v = parse_news_risk("true")
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_event_risk_is_null(self) -> None:
+        raw = json.dumps({"event_risk": None, "reason": "ok", "suggest_action": "proceed"})
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    def test_suggest_action_is_null(self) -> None:
+        raw = json.dumps({"event_risk": "low", "reason": "ok", "suggest_action": None})
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Extra fields (model forbids extras) --
+
+    def test_extra_field_rejected(self) -> None:
+        raw = json.dumps(
+            {
+                "event_risk": "low",
+                "reason": "ok",
+                "suggest_action": "proceed",
+                "confidence": 0.9,
+            }
+        )
+        v = parse_news_risk(raw)
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- Low-confidence / ambiguous prose from Claude --
+
+    def test_ambiguous_text_response(self) -> None:
+        v = parse_news_risk(
+            "I'm not sure about the risk level. It could be high or medium "
+            "depending on the market reaction."
+        )
+        assert _is_safe_default(v)
+        assert v.suggest_action == "skip"
+
+    # -- INV-02 core invariant: never "proceed" on parse failure --
+
+    def test_never_returns_proceed_on_failure(self) -> None:
+        """Malformed inputs must never return suggest_action='proceed' (INV-02)."""
+        bad_inputs = [
+            "",
+            "not json",
+            "null",
+            "[]",
+            "{}",
+            '{"event_risk":"catastrophic","reason":"x","suggest_action":"skip"}',
+            '{"event_risk":"low","reason":"x","suggest_action":"trade"}',
+            '{"reason":"x","suggest_action":"proceed"}',
+        ]
+        for raw in bad_inputs:
+            v = parse_news_risk(raw)
+            assert v.suggest_action != "proceed", (
+                f"INV-02 violated: parse_news_risk returned 'proceed' for bad input: {raw!r}"
+            )
+
+    # -- No exception raised (INV-02) --
+
+    def test_never_raises_on_any_input(self) -> None:
+        """parse_news_risk must never raise, regardless of input (INV-02)."""
+        bad_inputs = [
+            "",
+            "not json",
+            '{"event_risk":"catastrophic","reason":"x","suggest_action":"skip"}',
+            '{"reason":"x","suggest_action":"proceed"}',
+            "null",
+            "[]",
+            '{"event_risk": "low"}',
+            "true",
+            "42",
+            '"a bare string"',
+        ]
+        for raw in bad_inputs:
+            try:
+                parse_news_risk(raw)
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(
+                    f"parse_news_risk raised {type(exc).__name__} for input {raw!r}: {exc}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# parse_news_risk — logging behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestParseNewsRiskLogging:
+    """Failures are logged at WARNING; no secrets leak."""
+
+    def test_logs_warning_on_invalid_json(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.news_risk"):
+            parse_news_risk("not json at all")
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_logs_warning_on_empty(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.news_risk"):
+            parse_news_risk("")
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_logs_warning_on_bad_enum(self, caplog: pytest.LogCaptureFixture) -> None:
+        raw = json.dumps(
+            {"event_risk": "catastrophic", "reason": "x", "suggest_action": "skip"}
+        )
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.news_risk"):
+            parse_news_risk(raw)
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_no_secret_token_in_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """INV-08: no secret values appear in log output."""
+        sensitive = "sk-live-VERY_SECRET_TOKEN_12345"
+        with caplog.at_level(logging.DEBUG, logger="hermes_integration.news_risk"):
+            parse_news_risk(sensitive)
+        for record in caplog.records:
+            assert sensitive not in record.message, (
+                "INV-08: a secret token appeared in the log output"
+            )


### PR DESCRIPTION
Closes #53.

## Summary

Implements the canonical INV-02 feature: structured Claude output parsing with a safe default.

- `hermes_integration/` new package
- `NewsRiskVerdict` pydantic v2 model with strict `Literal` enums (`event_risk`, `suggest_action`) and `extra="forbid"`
- `parse_news_risk(raw: str) -> NewsRiskVerdict` — INV-02 enforcement boundary: any failure (invalid JSON, missing field, out-of-enum, empty, wrong type) returns `suggest_action="skip"` and logs; never raises, never returns "proceed" on a failure path
- `hermes_integration/prompts/news_risk.md` — prompt template with `{{instrument}}`, `{{base_currency}}`, `{{quote_currency}}`, `{{direction}}`, `{{entry_window_utc}}`, `{{calendar_events}}` placeholders; instructs Claude to emit only the JSON object; biases toward skip/reduce_size under uncertainty

## Test plan

- [x] `pytest tests/test_news_risk.py -v` → 50 passed, exit 0
- [x] `pytest -q` (full suite) → 473 passed, exit 0
- [x] `mypy hermes_integration/` → "Success: no issues found in 2 source files", exit 0
- [x] No `anthropic` SDK dep (D-P2-3); `pyproject.toml` untouched
- [x] Malformed-input battery: invalid JSON, partial JSON, markdown-fenced JSON, empty string, whitespace, missing each required field, bad enum values (`catastrophic`, `extreme`, `trade`, `allow`, `go`), JSON array, null, bare string, number, boolean, null field values, extra fields, ambiguous prose — each → `suggest_action="skip"`, no exception (INV-02)
- [x] INV-02 invariant sweeps: `test_never_returns_proceed_on_failure`, `test_never_raises_on_any_input`
- [x] INV-08: `test_no_secret_token_in_logs` confirms no secrets leak