### PR TITLE
chore: P2 packaging (signals/hermes_integration) + matplotlib

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 
 ## Stack at a Glance
 
-Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · pyarrow>=14 · httpx>=0.27 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
+Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python-dotenv>=1.0 · pandas>=2.0 · python-dateutil>=2.8 · pyarrow>=14 · httpx>=0.27 · matplotlib>=3.7 · custom event-driven backtest engine · walk-forward validator · Hermes Agent (Nous Research) · anthropic SDK · SQLite→PostgreSQL · Parquet · Streamlit + TW Lightweight Charts
 
 **Dev deps (optional group):** pytest>=7.4 · mypy>=1.8 · responses>=0.25 (HTTP mock for OANDA unit tests) · hypothesis>=6.0 (property-based tests for the backtest engine — no-look-ahead / fill / cost invariants)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dateutil>=2.8",
     "pyarrow>=14",
     "httpx>=0.27",
+    "matplotlib>=3.7",
 ]
 
 [project.optional-dependencies]
@@ -35,7 +36,7 @@ py-modules = ["cli"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["config*", "data*", "strategies*", "backtest*", "scripts*"]
+include = ["config*", "data*", "strategies*", "backtest*", "scripts*", "signals*", "hermes_integration*"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
Coordinator edit before the Phase 2 fan-out: declares the new signals* + hermes_integration* packages in setuptools discovery and adds matplotlib>=3.7 (chart-generation). Avoids fan-out pyproject collisions.