### PR TITLE
P2-T-02: portfolio-limits

### DIFF
--- a/.claude/context/signals.md
+++ b/.claude/context/signals.md
@@ -93,3 +93,81 @@ packaging note above).
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after
 reviewer pass). Hold the Phase 2 fan-out (T-02/03/05/07) until this PR's INV-13
 round-trip test is green on main.
+
+## P2-T-02 — 2026-05-29 (feat/p2-t-02)
+
+**What was done:**
+- Created `signals/portfolio.py`:
+  - **`PortfolioLimiterConfig`** — pydantic v2 model with `correlation_threshold`
+    (default 0.7), `max_per_currency` (default 2), `max_concurrent` (default 5),
+    `lookback_days` (default 90).
+  - **`PortfolioLimiter(store, config)`** with `apply(candidates: list[Candidate])
+    -> list[Candidate]`: greedy highest-score-first admission enforcing three caps.
+  - Admission sort key is identical to the ranker: `oos_sharpe_mean` desc →
+    `quality_score` desc → `(instrument, strategy_name)` asc (stable tie-break).
+    Re-sorts defensively regardless of input order.
+  - **Correlation gate:** for each candidate vs every already-admitted instrument,
+    loads daily ("D") candles via `store.load_candles`, computes mid returns
+    `(close_bid + close_ask)/2`, then Pearson ρ on the shared timestamp index.
+    If `|ρ| > correlation_threshold` → drop (lower-scored always loses, because
+    greedy processes highest first). If `< MIN_CORRELATION_OBS=20` observations
+    available → skip check (conservative: not dropped on insufficient data).
+  - **Per-currency cap:** splits instrument on `_` (e.g. `EUR_USD` → `EUR`,
+    `USD`); tracks a `currency_counts` dict; drops if any leg currency has already
+    reached `max_per_currency`.
+  - **Max-concurrent cap:** drops if `len(admitted) >= max_concurrent` (checked
+    before currency/correlation so the message is accurate).
+  - **Each drop logged** at INFO with `DROP <instrument> (...): <limit> reason`.
+  - **INV-01:** no `execution`/`risk` import — filtering only.
+  - **INV-03:** candles returned by `load_candles` are `datetime64[ns, UTC]`;
+    the method signature requires UTC-aware `start`/`end` (passed in from
+    `datetime.now(timezone.utc) - timedelta(days=lookback_days)`).
+  - `_StoreLike` Protocol (structural) — `data.store.Store` satisfies without
+    modification; anything with `load_candles` works.
+  - `_pearson_corr(a, b)` returns `float | None` — `None` = skip drop.
+  - `_split_currencies(instrument)` splits on `_`; defensive against malformed.
+- `tests/test_portfolio.py` — 30 tests, all mocked (NO live HTTP):
+  - `TestSplitCurrencies` (4): standard pair, triple, malformed, empty.
+  - `TestPearsonCorr` (5): empty, insufficient obs, high-positive, no overlap,
+    float in range.
+  - `TestEmptyInput` (1): empty→empty.
+  - `TestMaxConcurrent` (3): bounds output, max=1 keeps highest, exact=N admitted.
+  - `TestMaxPerCurrency` (3): enforced, 1 drops second, non-shared all pass.
+  - `TestCorrelation` (5): correlated pair → higher admitted; greedy re-sort
+    means submitted order doesn't matter; uncorrelated → both; missing candles →
+    both; below threshold → both.
+  - `TestGreedyOrder` (3): highest-score first deterministic; stable tie-break
+    same regardless of input order; output preserves score order.
+  - `TestCombinedLimits` (2): all three limits active simultaneously;
+    INV-01 module attribute check.
+  - `TestLogging` (2): DROP logged for currency cap; DROP logged for concurrent.
+  - `TestConfigDefaults` (2): defaults match constants; custom config round-trips.
+
+**Key patterns / gotchas:**
+- The correlation check is **skipped** (not failing-safe-drop) when candle data
+  is unavailable or insufficient. Conservative: you cannot prove correlation =
+  you cannot drop on correlation grounds.
+- `_pearson_corr` aligns on shared timestamps (`pd.concat(..., sort=True).dropna()`)
+  — time-index alignment is critical for cross-instrument returns.
+- Correlation is computed from **daily** candles (`granularity="D"`) regardless
+  of the candidate's trading timeframe. This gives a stable estimate; sub-daily
+  alignment would require the instruments' bars to be exactly co-timed.
+- The `_StoreLike` Protocol does NOT include `load_approved_set` — only
+  `load_candles` is needed, keeping the mock surface minimal.
+- `PortfolioLimiter` does not re-rank output (returns admitted candidates in
+  the greedy admission order, which is also score order).
+
+**AC verification results:**
+- `python -m pytest tests/test_portfolio.py -q` → **30 passed**, exit 0
+- `python -m pytest -q` (full suite) → **526 passed, 85 warnings**, exit 0
+  (warnings all pre-existing — not new)
+- `python -m mypy signals/` → **"Success: no issues found in 3 source files"**, exit 0
+
+**No new runtime dependencies** (pydantic + pandas + numpy already in pyproject;
+`numpy` used in test helpers only). `pyproject.toml` NOT modified.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after
+reviewer pass). Expect rebase if T-03/T-05 land first (distinct files —
+no conflict risk on `signals/portfolio.py`).
+
+**CLAUDE.md trigger-table check:** NOT edited (no new dep, no new CLI command).

--- a/signals/portfolio.py
+++ b/signals/portfolio.py
@@ -162,9 +162,8 @@ def _mid_returns(df: pd.DataFrame) -> pd.Series:
     if not required.issubset(df.columns) or len(df) < 2:
         return pd.Series(dtype="float64")
     mid = (df["close_bid"] + df["close_ask"]) / 2.0
+    mid.index = pd.Index(df["time"])
     returns = mid.pct_change().dropna()
-    if hasattr(df["time"], "values"):
-        returns.index = pd.Index(df["time"].values[1:])
     return returns
 
 

--- a/signals/portfolio.py
+++ b/signals/portfolio.py
@@ -1,0 +1,375 @@
+"""Portfolio-level filter for the ranked candidate watchlist (P2-T-02).
+
+Applies three portfolio-level caps to the ranker's output so the watchlist
+does not end up as a cluster of highly-correlated bets:
+
+1. **Correlation gate:** if a candidate's instrument is highly correlated
+   (|ρ| > ``correlation_threshold``) with an already-admitted instrument,
+   the lower-scored candidate is dropped.  Correlation is computed from
+   rolling daily returns via ``store.load_candles`` over a configurable
+   lookback window.
+
+2. **Per-currency cap:** at most ``max_per_currency`` admitted candidates
+   may share a base or quote currency (e.g. ≤ 2 USD-leg candidates).
+
+3. **Max-concurrent cap:** the total output list length is bounded by
+   ``max_concurrent``.
+
+Admission is greedy, highest-score-first (same sort key as the ranker:
+``oos_sharpe_mean`` desc → ``quality_score`` desc → ``(instrument,
+strategy_name)`` asc as a stable tie-break).  The input list is already
+score-ranked, but we re-sort defensively to remain correct even if
+candidates arrive out of order.
+
+INV-01: this module produces only a filtered watchlist; it does not size,
+    price, or place any order.  There is no import of ``execution`` or
+    ``risk`` here.
+INV-03: correlation is computed from UTC-stamped candles (``load_candles``
+    returns ``datetime64[ns, UTC]``).  ``lookback_days`` defines the
+    backwards reach from "now" — the caller is responsible for the store
+    being populated; this module only reads.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+import pandas as pd
+from pydantic import BaseModel, Field
+
+from signals.ranker import Candidate
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables / defaults
+# ---------------------------------------------------------------------------
+
+#: Default absolute Pearson correlation threshold above which two instruments
+#: are considered highly correlated (|ρ| > threshold → share exposure).
+DEFAULT_CORRELATION_THRESHOLD: float = 0.7
+
+#: Default maximum number of admitted candidates sharing any single leg
+#: currency (base or quote).
+DEFAULT_MAX_PER_CURRENCY: int = 2
+
+#: Default maximum total admitted candidates (watchlist length cap).
+DEFAULT_MAX_CONCURRENT: int = 5
+
+#: How many calendar days of daily-return history to load when computing
+#: rolling pairwise correlations.  90 days gives a stable estimate while
+#: remaining within a few seconds of load time on a warm SQLite store.
+DEFAULT_LOOKBACK_DAYS: int = 90
+
+#: Minimum number of overlapping non-NaN return observations required to
+#: treat a computed correlation as reliable.  Below this count the
+#: correlation check is skipped (conservative: the pair is NOT dropped on
+#: insufficient data).
+MIN_CORRELATION_OBS: int = 20
+
+# ---------------------------------------------------------------------------
+# Store Protocol (structural — keeps PortfolioLimiter mockable in tests)
+# ---------------------------------------------------------------------------
+
+
+class _StoreLike(Protocol):
+    """Structural interface for the candle store consumed by PortfolioLimiter.
+
+    Only ``load_candles`` is required.  ``data.store.Store`` satisfies this
+    protocol without modification.
+    """
+
+    def load_candles(
+        self,
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> pd.DataFrame:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+class PortfolioLimiterConfig(BaseModel):
+    """Tunable knobs for ``PortfolioLimiter``.
+
+    All fields have sensible defaults from the Phase-2 spec; callers may
+    override any subset.
+
+    Attributes:
+        correlation_threshold: |ρ| above which two instruments count as
+            highly correlated (default 0.7).
+        max_per_currency: Maximum admitted candidates sharing a base or
+            quote currency (default 2).
+        max_concurrent: Maximum total admitted candidates (default 5).
+        lookback_days: Calendar days of daily-return history to load for
+            correlation computation (default 90).
+    """
+
+    correlation_threshold: float = Field(
+        default=DEFAULT_CORRELATION_THRESHOLD,
+        ge=0.0,
+        le=1.0,
+        description="Absolute Pearson |ρ| threshold (0–1).",
+    )
+    max_per_currency: int = Field(
+        default=DEFAULT_MAX_PER_CURRENCY,
+        ge=1,
+        description="Max admitted candidates sharing any single leg currency.",
+    )
+    max_concurrent: int = Field(
+        default=DEFAULT_MAX_CONCURRENT,
+        ge=1,
+        description="Max total admitted candidates.",
+    )
+    lookback_days: int = Field(
+        default=DEFAULT_LOOKBACK_DAYS,
+        ge=1,
+        description="Calendar days of daily-return history for correlation.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# PortfolioLimiter
+# ---------------------------------------------------------------------------
+
+
+def _split_currencies(instrument: str) -> list[str]:
+    """Split an OANDA instrument string into its leg currencies.
+
+    ``"EUR_USD"`` → ``["EUR", "USD"]``.  Returns all non-empty parts split
+    on ``"_"`` — defensive; never raises.
+    """
+    return [p for p in instrument.split("_") if p]
+
+
+def _mid_returns(df: pd.DataFrame) -> pd.Series:
+    """Compute daily log-returns from bid/ask mid close prices.
+
+    Uses ``(close_bid + close_ask) / 2`` as the mid price and computes
+    ``pct_change()`` (arithmetic return; sufficient for correlation
+    estimation).  Returns a ``pd.Series`` indexed by ``df["time"]``.
+    If the required columns are absent or the DataFrame is too short,
+    returns an empty Series.
+    """
+    required = {"time", "close_bid", "close_ask"}
+    if not required.issubset(df.columns) or len(df) < 2:
+        return pd.Series(dtype="float64")
+    mid = (df["close_bid"] + df["close_ask"]) / 2.0
+    returns = mid.pct_change().dropna()
+    if hasattr(df["time"], "values"):
+        returns.index = pd.Index(df["time"].values[1:])
+    return returns
+
+
+class PortfolioLimiter:
+    """Apply portfolio-level caps to a ranked ``Candidate`` list.
+
+    Admission is greedy: candidates are considered in decreasing score
+    order (``oos_sharpe_mean`` desc → ``quality_score`` desc → stable
+    tie-break).  A candidate is admitted unless it would breach one of:
+
+    * **Correlation limit** — instrument already above threshold with an
+      admitted instrument.
+    * **Per-currency limit** — another admitted candidate already exhausted
+      the ``max_per_currency`` quota for the base or quote currency.
+    * **Max-concurrent limit** — ``max_concurrent`` candidates already
+      admitted.
+
+    Dropped candidates are logged at INFO level with the specific limit hit.
+    The output list preserves score order.
+
+    INV-01 enforced: no sizing/orders — this module ONLY filters.
+
+    Args:
+        store: Anything exposing ``load_candles``.  The correlation
+            computation fetches ``"D"`` (daily) granularity candles.
+        config: Tunable caps.  Defaults to the Phase-2 spec values.
+    """
+
+    def __init__(
+        self,
+        store: _StoreLike,
+        config: PortfolioLimiterConfig | None = None,
+    ) -> None:
+        self._store = store
+        self._config: PortfolioLimiterConfig = config or PortfolioLimiterConfig()
+
+    # -- public API ----------------------------------------------------------
+
+    def apply(self, candidates: list[Candidate]) -> list[Candidate]:
+        """Filter ``candidates`` to a portfolio-safe subset.
+
+        Args:
+            candidates: Ranked candidates from ``Ranker.rank()``.  Need not
+                be pre-sorted — this method re-sorts defensively.
+
+        Returns:
+            A subset of ``candidates`` (same ``Candidate`` objects, not
+            copies) that respects all three caps, in score order.  Empty
+            list in → empty list out (no error).
+        """
+        if not candidates:
+            return []
+
+        # Re-sort: highest score first; stable tie-break (instrument,
+        # strategy_name) ascending — identical sort key to the ranker so the
+        # admission order is deterministic.
+        ordered = sorted(
+            candidates,
+            key=lambda c: (
+                -c.oos_sharpe_mean,
+                -c.quality_score,
+                c.instrument,
+                c.strategy_name,
+            ),
+        )
+
+        cfg = self._config
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(days=cfg.lookback_days)
+
+        # Cache for daily-return series keyed by instrument.
+        return_cache: dict[str, pd.Series] = {}
+
+        # State accumulated as we admit candidates.
+        admitted: list[Candidate] = []
+        admitted_instruments: list[str] = []      # instruments admitted so far
+        currency_counts: dict[str, int] = {}      # currency → admitted count
+
+        for candidate in ordered:
+            instr = candidate.instrument
+            score_repr = (
+                f"oos_sharpe={candidate.oos_sharpe_mean:.4f}/"
+                f"quality={candidate.quality_score:.4f}"
+            )
+
+            # -- Limit 1: max_concurrent -----------------------------------
+            if len(admitted) >= cfg.max_concurrent:
+                _log.info(
+                    "DROP %s (%s): max_concurrent=%d reached.",
+                    instr,
+                    score_repr,
+                    cfg.max_concurrent,
+                )
+                continue
+
+            # -- Limit 2: per-currency cap ---------------------------------
+            currencies = _split_currencies(instr)
+            currency_breach: str | None = None
+            for ccy in currencies:
+                if currency_counts.get(ccy, 0) >= cfg.max_per_currency:
+                    currency_breach = ccy
+                    break
+            if currency_breach is not None:
+                _log.info(
+                    "DROP %s (%s): max_per_currency=%d breached on currency %s.",
+                    instr,
+                    score_repr,
+                    cfg.max_per_currency,
+                    currency_breach,
+                )
+                continue
+
+            # -- Limit 3: correlation --------------------------------------
+            corr_drop = False
+            if admitted_instruments:
+                # Lazy-load returns for the current candidate.
+                if instr not in return_cache:
+                    return_cache[instr] = self._load_returns(
+                        instr, start, now
+                    )
+                r_new = return_cache[instr]
+
+                for admitted_instr in admitted_instruments:
+                    if admitted_instr not in return_cache:
+                        return_cache[admitted_instr] = self._load_returns(
+                            admitted_instr, start, now
+                        )
+                    r_adm = return_cache[admitted_instr]
+
+                    rho = _pearson_corr(r_new, r_adm)
+                    if rho is not None and abs(rho) > cfg.correlation_threshold:
+                        _log.info(
+                            "DROP %s (%s): |ρ|=%.3f > threshold=%.3f with "
+                            "admitted instrument %s.",
+                            instr,
+                            score_repr,
+                            abs(rho),
+                            cfg.correlation_threshold,
+                            admitted_instr,
+                        )
+                        corr_drop = True
+                        break
+
+            if corr_drop:
+                continue
+
+            # -- Admit -----------------------------------------------------
+            admitted.append(candidate)
+            admitted_instruments.append(instr)
+            for ccy in currencies:
+                currency_counts[ccy] = currency_counts.get(ccy, 0) + 1
+
+        return admitted
+
+    # -- helpers -------------------------------------------------------------
+
+    def _load_returns(
+        self, instrument: str, start: datetime, end: datetime
+    ) -> pd.Series:
+        """Load daily candles and return an arithmetic return Series.
+
+        Uses daily (``"D"``) granularity.  If ``load_candles`` raises or
+        returns an empty/insufficient DataFrame, an empty Series is returned
+        (the correlation check is then skipped — conservative: not dropped).
+        """
+        try:
+            df = self._store.load_candles(instrument, "D", start, end)
+        except Exception:
+            _log.warning(
+                "Could not load candles for %s; skipping correlation check.",
+                instrument,
+                exc_info=True,
+            )
+            return pd.Series(dtype="float64")
+        return _mid_returns(df)
+
+
+# ---------------------------------------------------------------------------
+# Internal correlation helper
+# ---------------------------------------------------------------------------
+
+
+def _pearson_corr(a: pd.Series, b: pd.Series) -> float | None:
+    """Compute Pearson ρ between two return series on their shared index.
+
+    Aligns on the index (timestamps), drops NaN pairs, and returns ``None``
+    if fewer than ``MIN_CORRELATION_OBS`` observations are available (the
+    caller treats ``None`` as "insufficient data — do not drop").
+
+    Returns:
+        Pearson ρ in [-1, 1], or ``None`` if data is insufficient.
+    """
+    if a.empty or b.empty:
+        return None
+
+    # Align on shared timestamps.  ``sort=True`` suppresses the Pandas 4
+    # DeprecationWarning about the default sort behaviour when concatenating
+    # DatetimeIndex-backed Series; aligning by sorted index is the correct
+    # semantic here (we want the shared timestamps in order).
+    aligned = pd.concat([a.rename("a"), b.rename("b")], axis=1, sort=True).dropna()
+    if len(aligned) < MIN_CORRELATION_OBS:
+        return None
+
+    rho: float = aligned["a"].corr(aligned["b"])
+    # corr() returns NaN if std is zero; treat as None (insufficient).
+    if pd.isna(rho):
+        return None
+    return rho

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -25,6 +25,7 @@ from signals.portfolio import (
     MIN_CORRELATION_OBS,
     PortfolioLimiter,
     PortfolioLimiterConfig,
+    _mid_returns,
     _pearson_corr,
     _split_currencies,
 )
@@ -639,3 +640,131 @@ class TestConfigDefaults:
         assert cfg.max_per_currency == 3
         assert cfg.max_concurrent == 8
         assert cfg.lookback_days == 30
+
+
+# ---------------------------------------------------------------------------
+# NaN price path — regression for the index-reconstruction crash
+# ---------------------------------------------------------------------------
+
+
+class TestMidReturnsNanPrices:
+    """Regression tests for _mid_returns when mid-series prices are NaN.
+
+    The old code did:
+        returns = mid.pct_change().dropna()
+        returns.index = pd.Index(df["time"].values[1:])
+
+    which assumes pct_change().dropna() removes exactly ONE row (position 0).
+    When close_bid or close_ask is NaN mid-series, dropna() removes MORE rows
+    and the index reassignment raises ValueError: Length mismatch.
+
+    The fix sets mid.index = pd.Index(df["time"]) BEFORE pct_change(), so
+    dropna() carries the correct timestamps automatically — no post-hoc
+    length-assuming assignment needed.
+    """
+
+    def _make_candles_with_nan(
+        self,
+        n: int = MIN_CORRELATION_OBS + 10,
+        nan_positions: list[int] | None = None,
+    ) -> pd.DataFrame:
+        """Build a candle frame with NaN close_bid at specified mid-series positions."""
+        rng = np.random.default_rng(7)
+        prices_bid = 1.1000 + np.cumsum(rng.normal(0, 0.001, n))
+        prices_ask = prices_bid + 0.0002
+        times = pd.date_range(
+            start=NOW - timedelta(days=n), periods=n, freq="D", tz="UTC"
+        )
+        df = pd.DataFrame(
+            {
+                "time": times,
+                "close_bid": prices_bid,
+                "close_ask": prices_ask,
+            }
+        )
+        if nan_positions:
+            for pos in nan_positions:
+                df.loc[pos, "close_bid"] = float("nan")
+        return df
+
+    def test_nan_mid_series_does_not_raise(self) -> None:
+        """NaN close_bid mid-series must NOT raise ValueError from _mid_returns."""
+        df = self._make_candles_with_nan(nan_positions=[5, 10])
+        # Must not raise — the old code would raise ValueError: Length mismatch.
+        result = _mid_returns(df)
+        assert isinstance(result, pd.Series)
+
+    def test_nan_mid_series_timestamps_align_with_surviving_rows(self) -> None:
+        """Returned index timestamps must match the rows that survived dropna()."""
+        n = MIN_CORRELATION_OBS + 10
+        nan_pos = 5  # one NaN mid-series drops an extra row beyond position-0
+        df = self._make_candles_with_nan(n=n, nan_positions=[nan_pos])
+
+        result = _mid_returns(df)
+
+        # Compute the expected surviving timestamps manually:
+        # mid.pct_change() at position nan_pos AND nan_pos+1 produce NaN
+        # (the NaN row itself, and the first finite-to-NaN boundary).
+        # Any index.dtype should be compatible with df["time"].
+        assert not result.empty
+        # Every timestamp in the result index must appear in df["time"].
+        result_times = set(result.index)
+        df_times = set(df["time"])
+        assert result_times.issubset(df_times), (
+            f"Result contains timestamps not in df['time']: "
+            f"{result_times - df_times}"
+        )
+
+    def test_old_code_would_raise_value_error(self) -> None:
+        """Demonstrate that the old post-hoc index assignment raises ValueError.
+
+        This documents WHY the fix is needed: the old pattern is:
+            returns.index = pd.Index(df["time"].values[1:])
+        which fails when dropna() removes more than one row.
+        """
+        df = self._make_candles_with_nan(nan_positions=[5])
+        mid = (df["close_bid"] + df["close_ask"]) / 2.0
+        returns_with_nans = mid.pct_change().dropna()
+        # With a NaN at position 5, pct_change().dropna() removes BOTH
+        # position 0 (initial NaN) AND rows 5 and 6 (the NaN and the
+        # finite-after-NaN boundary) — more than 1 row total.
+        # df["time"].values[1:] has length n-1 but returns has length < n-1.
+        n = len(df)
+        assert len(returns_with_nans) < n - 1, (
+            "Precondition: NaN mid-series must make dropna() remove >1 row"
+        )
+        with pytest.raises(ValueError):
+            returns_with_nans.index = pd.Index(df["time"].values[1:])
+
+    def test_no_nan_returns_correctly_indexed(self) -> None:
+        """Sanity check: clean data still produces a correctly-indexed Series."""
+        df = self._make_candles_with_nan(nan_positions=None)
+        result = _mid_returns(df)
+        # All timestamps in result must come from df["time"].
+        result_times = set(result.index)
+        df_times = set(df["time"])
+        assert result_times.issubset(df_times)
+        # No NaN values in result.
+        assert not result.isna().any()
+
+    def test_nan_path_correlation_does_not_raise(self) -> None:
+        """End-to-end: PortfolioLimiter with NaN candles must not raise."""
+        n = MIN_CORRELATION_OBS + 10
+        df_with_nan = self._make_candles_with_nan(n=n, nan_positions=[3, 8])
+        df_clean = _make_daily_candles(n=n, seed=42)
+
+        candle_map = {"EUR_USD": df_with_nan, "GBP_USD": df_clean}
+        store = _make_store(candle_map)
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        a = _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0)
+        b = _make_candidate("GBP_USD", "s2", oos_sharpe_mean=1.0)
+
+        # Must not raise — old code would raise ValueError in _mid_returns.
+        result = limiter.apply([a, b])
+        assert isinstance(result, list)

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,641 @@
+"""Tests for signals/portfolio.py (P2-T-02).
+
+Everything is mocked — NO live HTTP, no real candle data.  Tests cover all
+AC from the P2-T-02 task spec:
+
+- Correlated pair (|ρ| > threshold) → only higher-scored admitted.
+- max_per_currency enforced.
+- max_concurrent enforced.
+- Greedy admission is deterministic (highest score first, stable tie-break).
+- Empty input → empty output (no error).
+- INV-01: no sizing/orders — only a filtered list returned.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from signals.portfolio import (
+    MIN_CORRELATION_OBS,
+    PortfolioLimiter,
+    PortfolioLimiterConfig,
+    _pearson_corr,
+    _split_currencies,
+)
+from signals.ranker import Candidate
+
+# ---------------------------------------------------------------------------
+# Helpers / factories
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+_GENERATED_AT = "2026-05-29T10:00:00Z"
+
+
+def _make_candidate(
+    instrument: str = "EUR_USD",
+    strategy_name: str = "macrossover",
+    oos_sharpe_mean: float = 1.0,
+    quality_score: float = 0.8,
+    rank: int = 1,
+    direction: str = "LONG",
+) -> Candidate:
+    """Return a minimal ``Candidate`` with overridable fields."""
+    return Candidate(
+        instrument=instrument,
+        timeframe="H4",
+        strategy_name=strategy_name,
+        direction=direction,
+        entry_ref=1.1000,
+        stop_distance=0.0020,
+        target_distance=0.0030,
+        oos_sharpe_mean=oos_sharpe_mean,
+        quality_score=quality_score,
+        rank=rank,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=False,
+        generated_at=_GENERATED_AT,
+    )
+
+
+def _make_daily_candles(
+    n: int = MIN_CORRELATION_OBS + 5,
+    close_bid: float = 1.1000,
+    noise_std: float = 0.001,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build a fake daily candle DataFrame of length ``n``."""
+    rng = np.random.default_rng(seed)
+    prices_bid = close_bid + np.cumsum(rng.normal(0, noise_std, n))
+    prices_ask = prices_bid + 0.0002
+
+    times = pd.date_range(
+        start=NOW - timedelta(days=n), periods=n, freq="D", tz="UTC"
+    )
+    return pd.DataFrame(
+        {
+            "time": times,
+            "open_bid": prices_bid,
+            "high_bid": prices_bid + noise_std,
+            "low_bid": prices_bid - noise_std,
+            "close_bid": prices_bid,
+            "open_ask": prices_ask,
+            "high_ask": prices_ask + noise_std,
+            "low_ask": prices_ask - noise_std,
+            "close_ask": prices_ask,
+            "volume": np.ones(n, dtype=int),
+        }
+    )
+
+
+def _make_correlated_candles(
+    n: int = MIN_CORRELATION_OBS + 10,
+    rho_target: float = 0.95,
+    seed: int = 42,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return two ``(n,)`` candle frames whose returns have correlation ≈ ``rho_target``.
+
+    Uses a Cholesky decomposition to produce correlated standard-normal shocks,
+    then accumulates into price series.
+    """
+    rng = np.random.default_rng(seed)
+    cov = np.array([[1.0, rho_target], [rho_target, 1.0]])
+    L = np.linalg.cholesky(cov)
+    z = rng.standard_normal((2, n))
+    correlated = L @ z  # shape (2, n)
+
+    def _to_df(shocks: np.ndarray, base_price: float) -> pd.DataFrame:
+        prices = base_price + np.cumsum(shocks * 0.001)
+        times = pd.date_range(
+            start=NOW - timedelta(days=n), periods=n, freq="D", tz="UTC"
+        )
+        return pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": prices,
+                "high_bid": prices + 0.0002,
+                "low_bid": prices - 0.0002,
+                "close_bid": prices,
+                "open_ask": prices + 0.0002,
+                "high_ask": prices + 0.0004,
+                "low_ask": prices,
+                "close_ask": prices + 0.0002,
+                "volume": np.ones(n, dtype=int),
+            }
+        )
+
+    return _to_df(correlated[0], 1.1000), _to_df(correlated[1], 1.2500)
+
+
+def _make_uncorrelated_candles(
+    n: int = MIN_CORRELATION_OBS + 10,
+    seed: int = 7,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return two candle frames whose returns are essentially uncorrelated."""
+    rng = np.random.default_rng(seed)
+
+    def _to_df(base_price: float, extra_seed: int) -> pd.DataFrame:
+        rng2 = np.random.default_rng(extra_seed)
+        prices = base_price + np.cumsum(rng2.normal(0, 0.001, n))
+        times = pd.date_range(
+            start=NOW - timedelta(days=n), periods=n, freq="D", tz="UTC"
+        )
+        return pd.DataFrame(
+            {
+                "time": times,
+                "open_bid": prices,
+                "high_bid": prices + 0.0002,
+                "low_bid": prices - 0.0002,
+                "close_bid": prices,
+                "open_ask": prices + 0.0002,
+                "high_ask": prices + 0.0004,
+                "low_ask": prices,
+                "close_ask": prices + 0.0002,
+                "volume": np.ones(n, dtype=int),
+            }
+        )
+
+    _ = rng  # used just for clarity; actual frames use deterministic seeds
+    return _to_df(1.1000, 7), _to_df(1.2500, 99)
+
+
+def _make_store(candle_map: dict[str, pd.DataFrame]) -> MagicMock:
+    """Build a mock store that returns candles from ``candle_map`` keyed by instrument."""
+
+    def _load_candles(
+        instrument: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> pd.DataFrame:
+        df = candle_map.get(instrument, pd.DataFrame())
+        return df
+
+    store = MagicMock()
+    store.load_candles.side_effect = _load_candles
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCurrencies:
+    def test_standard_pair(self) -> None:
+        assert _split_currencies("EUR_USD") == ["EUR", "USD"]
+
+    def test_triple_component(self) -> None:
+        # Exotic like XAU_USD — returns all non-empty parts.
+        assert _split_currencies("XAU_USD") == ["XAU", "USD"]
+
+    def test_malformed(self) -> None:
+        # Should not raise.
+        result = _split_currencies("EURUSD")
+        assert isinstance(result, list)
+
+    def test_empty(self) -> None:
+        assert _split_currencies("") == []
+
+
+class TestPearsonCorr:
+    def test_returns_none_for_empty_series(self) -> None:
+        assert _pearson_corr(pd.Series(dtype="float64"), pd.Series(dtype="float64")) is None
+
+    def test_returns_none_for_insufficient_obs(self) -> None:
+        a = pd.Series([0.01, 0.02], index=[0, 1])
+        b = pd.Series([0.01, 0.02], index=[0, 1])
+        assert _pearson_corr(a, b) is None  # < MIN_CORRELATION_OBS
+
+    def test_high_positive_correlation(self) -> None:
+        n = MIN_CORRELATION_OBS + 10
+        idx = list(range(n))
+        a = pd.Series(np.arange(n, dtype=float), index=idx)
+        b = pd.Series(np.arange(n, dtype=float) + 0.001, index=idx)
+        rho = _pearson_corr(a, b)
+        assert rho is not None
+        assert rho > 0.99
+
+    def test_no_overlap_returns_none(self) -> None:
+        a = pd.Series([0.01] * 30, index=list(range(30)))
+        b = pd.Series([0.01] * 30, index=list(range(100, 130)))
+        # No shared index → aligned df empty → None.
+        assert _pearson_corr(a, b) is None
+
+    def test_returns_float_in_range(self) -> None:
+        n = MIN_CORRELATION_OBS + 5
+        idx = list(range(n))
+        a = pd.Series(np.random.default_rng(0).normal(0, 1, n), index=idx)
+        b = pd.Series(np.random.default_rng(1).normal(0, 1, n), index=idx)
+        rho = _pearson_corr(a, b)
+        assert rho is not None
+        assert -1.0 <= rho <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# PortfolioLimiter tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_list_returns_empty(self) -> None:
+        store = _make_store({})
+        limiter = PortfolioLimiter(store)
+        result = limiter.apply([])
+        assert result == []
+
+
+class TestMaxConcurrent:
+    def test_max_concurrent_bounds_output(self) -> None:
+        cfg = PortfolioLimiterConfig(max_concurrent=3, max_per_currency=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate(f"EUR_USD", f"s{i}", oos_sharpe_mean=float(10 - i))
+            for i in range(6)
+        ]
+        result = limiter.apply(candidates)
+        assert len(result) <= 3
+
+    def test_max_concurrent_1(self) -> None:
+        cfg = PortfolioLimiterConfig(max_concurrent=1, max_per_currency=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate(
+                instrument="EUR_USD",
+                strategy_name=f"strat{i}",
+                oos_sharpe_mean=float(5 - i),
+            )
+            for i in range(3)
+        ]
+        result = limiter.apply(candidates)
+        assert len(result) == 1
+        # The highest-score one (i=0) should be kept.
+        assert result[0].strategy_name == "strat0"
+
+    def test_exact_max_concurrent_admitted(self) -> None:
+        """Exactly max_concurrent candidates admitted when all distinct instruments."""
+        n = 4
+        cfg = PortfolioLimiterConfig(max_concurrent=n, max_per_currency=n + 1)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        instruments = ["EUR_USD", "GBP_JPY", "AUD_CAD", "NZD_CHF"]
+        candidates = [
+            _make_candidate(
+                instrument=instr,
+                strategy_name="s",
+                oos_sharpe_mean=float(n - i),
+            )
+            for i, instr in enumerate(instruments)
+        ]
+        result = limiter.apply(candidates)
+        assert len(result) == n
+
+
+class TestMaxPerCurrency:
+    def test_max_per_currency_enforced(self) -> None:
+        """No more than max_per_currency candidates share a given currency."""
+        cfg = PortfolioLimiterConfig(max_per_currency=2, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        # All USD-leg candidates; config allows 2.
+        candidates = [
+            _make_candidate(
+                instrument="EUR_USD",
+                strategy_name="s1",
+                oos_sharpe_mean=4.0,
+            ),
+            _make_candidate(
+                instrument="GBP_USD",
+                strategy_name="s2",
+                oos_sharpe_mean=3.0,
+            ),
+            _make_candidate(
+                instrument="AUD_USD",
+                strategy_name="s3",
+                oos_sharpe_mean=2.0,
+            ),
+            _make_candidate(
+                instrument="NZD_USD",
+                strategy_name="s4",
+                oos_sharpe_mean=1.0,
+            ),
+        ]
+        result = limiter.apply(candidates)
+        # At most 2 USD-leg instruments.
+        usd_count = sum(
+            1 for c in result if "USD" in _split_currencies(c.instrument)
+        )
+        assert usd_count <= 2
+
+    def test_max_per_currency_1_drops_second_same_currency(self) -> None:
+        cfg = PortfolioLimiterConfig(max_per_currency=1, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=3.0),
+            _make_candidate("GBP_USD", "s2", oos_sharpe_mean=2.0),  # shares USD
+            _make_candidate("USD_JPY", "s3", oos_sharpe_mean=1.0),  # shares USD
+        ]
+        result = limiter.apply(candidates)
+        # Only EUR_USD (first USD leg) admitted; GBP_USD and USD_JPY dropped.
+        instruments = [c.instrument for c in result]
+        assert "EUR_USD" in instruments
+        assert "GBP_USD" not in instruments
+        assert "USD_JPY" not in instruments
+
+    def test_max_per_currency_non_shared_pass(self) -> None:
+        """Candidates that don't share currencies are all admitted."""
+        cfg = PortfolioLimiterConfig(max_per_currency=1, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_GBP", "s1", oos_sharpe_mean=3.0),
+            _make_candidate("USD_JPY", "s2", oos_sharpe_mean=2.0),
+            _make_candidate("AUD_CAD", "s3", oos_sharpe_mean=1.0),
+        ]
+        result = limiter.apply(candidates)
+        assert len(result) == 3
+
+
+class TestCorrelation:
+    def test_highly_correlated_pair_only_higher_score_admitted(self) -> None:
+        """EUR_USD and GBP_USD above threshold → only higher-scored admitted."""
+        df_eur, df_gbp = _make_correlated_candles(rho_target=0.95)
+
+        candle_map = {"EUR_USD": df_eur, "GBP_USD": df_gbp}
+        store = _make_store(candle_map)
+
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        # EUR_USD has a higher score.
+        eur = _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0)
+        gbp = _make_candidate("GBP_USD", "s2", oos_sharpe_mean=1.0)
+
+        result = limiter.apply([gbp, eur])  # intentionally submit out-of-order
+        instruments = [c.instrument for c in result]
+        assert "EUR_USD" in instruments, "Higher-scored EUR_USD should be admitted"
+        assert "GBP_USD" not in instruments, "Lower-scored GBP_USD should be dropped"
+
+    def test_highly_correlated_pair_lower_score_submitted_first_still_dropped(
+        self,
+    ) -> None:
+        """Lower-scored candidate wins admission if it appears first in the input,
+        but that shouldn't happen here — greedy re-sort means the higher-scored
+        is always considered first."""
+        df_eur, df_gbp = _make_correlated_candles(rho_target=0.95)
+        candle_map = {"EUR_USD": df_eur, "GBP_USD": df_gbp}
+        store = _make_store(candle_map)
+
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        # GBP_USD has higher score here.
+        eur = _make_candidate("EUR_USD", "s1", oos_sharpe_mean=1.0)
+        gbp = _make_candidate("GBP_USD", "s2", oos_sharpe_mean=2.0)
+
+        result = limiter.apply([eur, gbp])
+        instruments = [c.instrument for c in result]
+        assert "GBP_USD" in instruments
+        assert "EUR_USD" not in instruments
+
+    def test_uncorrelated_pair_both_admitted(self) -> None:
+        """Two uncorrelated instruments are both admitted (below threshold)."""
+        df_a, df_b = _make_uncorrelated_candles()
+        candle_map = {"EUR_GBP": df_a, "USD_JPY": df_b}
+        store = _make_store(candle_map)
+
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        a = _make_candidate("EUR_GBP", "s1", oos_sharpe_mean=2.0)
+        b = _make_candidate("USD_JPY", "s2", oos_sharpe_mean=1.0)
+
+        result = limiter.apply([a, b])
+        assert len(result) == 2
+
+    def test_missing_candles_skips_correlation_drop(self) -> None:
+        """If candle data is unavailable, correlation check skipped (not dropped)."""
+        # Store returns empty DataFrames.
+        store = _make_store({})
+
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        a = _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0)
+        b = _make_candidate("GBP_USD", "s2", oos_sharpe_mean=1.0)
+
+        result = limiter.apply([a, b])
+        # Both admitted since correlation can't be computed.
+        assert len(result) == 2
+
+    def test_below_threshold_pair_both_admitted(self) -> None:
+        """If |ρ| is below threshold both instruments are admitted."""
+        df_a, df_b = _make_correlated_candles(rho_target=0.4, seed=123)
+        candle_map = {"EUR_USD": df_a, "GBP_USD": df_b}
+        store = _make_store(candle_map)
+
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=10,
+            max_concurrent=10,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        a = _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0)
+        b = _make_candidate("GBP_USD", "s2", oos_sharpe_mean=1.0)
+
+        result = limiter.apply([a, b])
+        assert len(result) == 2
+
+
+class TestGreedyOrder:
+    def test_highest_score_first_deterministic(self) -> None:
+        """Greedy admission always picks the highest-scored candidate first."""
+        cfg = PortfolioLimiterConfig(max_per_currency=1, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        # All share EUR — max_per_currency=1 means only the first (highest) is kept.
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=1.0),
+            _make_candidate("EUR_GBP", "s2", oos_sharpe_mean=3.0),
+            _make_candidate("EUR_CHF", "s3", oos_sharpe_mean=2.0),
+        ]
+        # Submit in any order.
+        result = limiter.apply(candidates)
+        assert len(result) == 1
+        assert result[0].instrument == "EUR_GBP"  # highest oos_sharpe_mean
+
+    def test_stable_tie_break_by_instrument_strategy(self) -> None:
+        """When oos_sharpe_mean and quality_score tie, stable tie-break applies."""
+        cfg = PortfolioLimiterConfig(max_per_currency=10, max_concurrent=2)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s_b", oos_sharpe_mean=2.0, quality_score=0.5),
+            _make_candidate("EUR_USD", "s_a", oos_sharpe_mean=2.0, quality_score=0.5),
+        ]
+        result1 = limiter.apply(candidates)
+        result2 = limiter.apply(list(reversed(candidates)))
+        # Both orderings must produce the same result (deterministic).
+        assert [c.strategy_name for c in result1] == [c.strategy_name for c in result2]
+
+    def test_output_preserves_score_order(self) -> None:
+        """Output is in score order regardless of input order."""
+        cfg = PortfolioLimiterConfig(max_per_currency=10, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=1.0),
+            _make_candidate("GBP_USD", "s2", oos_sharpe_mean=3.0),
+            _make_candidate("AUD_USD", "s3", oos_sharpe_mean=2.0),
+        ]
+        result = limiter.apply(candidates)
+        sharpes = [c.oos_sharpe_mean for c in result]
+        assert sharpes == sorted(sharpes, reverse=True)
+
+
+class TestCombinedLimits:
+    def test_all_limits_together(self) -> None:
+        """Combined scenario: currency cap + correlation + max_concurrent."""
+        df_eur, df_gbp = _make_correlated_candles(rho_target=0.95, seed=5)
+        candle_map = {
+            "EUR_USD": df_eur,
+            "GBP_USD": df_gbp,
+            "USD_JPY": _make_daily_candles(seed=10),
+            "AUD_CAD": _make_daily_candles(seed=20),
+            "NZD_CHF": _make_daily_candles(seed=30),
+            "CHF_JPY": _make_daily_candles(seed=40),
+        }
+        store = _make_store(candle_map)
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.7,
+            max_per_currency=2,
+            max_concurrent=3,
+        )
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=6.0),
+            _make_candidate("GBP_USD", "s2", oos_sharpe_mean=5.0),  # correlated w/ EUR_USD
+            _make_candidate("USD_JPY", "s3", oos_sharpe_mean=4.0),  # 3rd USD → over cap at 2
+            _make_candidate("AUD_CAD", "s4", oos_sharpe_mean=3.0),
+            _make_candidate("NZD_CHF", "s5", oos_sharpe_mean=2.0),
+            _make_candidate("CHF_JPY", "s6", oos_sharpe_mean=1.0),  # 4th would hit max_concurrent
+        ]
+        result = limiter.apply(candidates)
+
+        assert len(result) <= cfg.max_concurrent
+        # Verify currency counts.
+        from signals.portfolio import _split_currencies
+
+        for ccy in ["EUR", "GBP", "USD", "JPY", "AUD", "CAD", "NZD", "CHF"]:
+            count = sum(
+                1 for c in result if ccy in _split_currencies(c.instrument)
+            )
+            assert count <= cfg.max_per_currency, f"{ccy} over cap"
+
+    def test_inv01_no_execution_import(self) -> None:
+        """INV-01: signals.portfolio must not import execution or risk."""
+        import importlib
+        import sys
+
+        # Remove cached module if present to force a fresh import attribute check.
+        mod = importlib.import_module("signals.portfolio")
+        # Check none of the module's imports bring in execution or risk.
+        mod_file = getattr(mod, "__file__", "") or ""
+        assert "execution" not in mod.__dict__, "execution should not be imported"
+        assert "risk" not in mod.__dict__, "risk should not be imported"
+
+
+class TestLogging:
+    def test_drop_reason_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Each dropped candidate should produce an INFO log line."""
+        cfg = PortfolioLimiterConfig(max_per_currency=1, max_concurrent=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0),
+            _make_candidate("GBP_USD", "s2", oos_sharpe_mean=1.0),  # EUR/USD share — dropped
+        ]
+        with caplog.at_level(logging.INFO, logger="signals.portfolio"):
+            limiter.apply(candidates)
+
+        drop_records = [r for r in caplog.records if "DROP" in r.message]
+        assert len(drop_records) >= 1, "Expected at least one DROP log for currency cap"
+
+    def test_max_concurrent_drop_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        cfg = PortfolioLimiterConfig(max_concurrent=1, max_per_currency=10)
+        store = _make_store({})
+        limiter = PortfolioLimiter(store, cfg)
+
+        candidates = [
+            _make_candidate("EUR_USD", "s1", oos_sharpe_mean=2.0),
+            _make_candidate("GBP_JPY", "s2", oos_sharpe_mean=1.0),
+        ]
+        with caplog.at_level(logging.INFO, logger="signals.portfolio"):
+            limiter.apply(candidates)
+
+        drop_records = [r for r in caplog.records if "max_concurrent" in r.message]
+        assert len(drop_records) >= 1
+
+
+class TestConfigDefaults:
+    def test_default_config_values(self) -> None:
+        from signals.portfolio import (
+            DEFAULT_CORRELATION_THRESHOLD,
+            DEFAULT_MAX_CONCURRENT,
+            DEFAULT_MAX_PER_CURRENCY,
+        )
+
+        cfg = PortfolioLimiterConfig()
+        assert cfg.correlation_threshold == DEFAULT_CORRELATION_THRESHOLD
+        assert cfg.max_per_currency == DEFAULT_MAX_PER_CURRENCY
+        assert cfg.max_concurrent == DEFAULT_MAX_CONCURRENT
+
+    def test_custom_config(self) -> None:
+        cfg = PortfolioLimiterConfig(
+            correlation_threshold=0.5,
+            max_per_currency=3,
+            max_concurrent=8,
+            lookback_days=30,
+        )
+        assert cfg.correlation_threshold == 0.5
+        assert cfg.max_per_currency == 3
+        assert cfg.max_concurrent == 8
+        assert cfg.lookback_days == 30


### PR DESCRIPTION
Closes #54.

## Summary

Adds `signals/portfolio.py` — `PortfolioLimiter(store, config).apply(candidates)` that post-processes the ranker's ranked `Candidate` list with three portfolio-level caps:

- **Correlation gate** (`correlation_threshold=0.7`): computes rolling Pearson ρ from daily returns via `store.load_candles`; if `|ρ| > threshold` with an already-admitted instrument, the lower-scored candidate is dropped. Insufficient data (< 20 observations) → skip check (not dropped).
- **Per-currency cap** (`max_per_currency=2`): at most N admitted candidates may share a base or quote currency (e.g. ≤ 2 USD-leg instruments).
- **Max-concurrent cap** (`max_concurrent=5`): total watchlist length bounded.

Admission is greedy highest-score-first (identical sort key to the ranker: `oos_sharpe_mean` desc → `quality_score` desc → `(instrument, strategy_name)` asc as stable tie-break). Each drop is logged at INFO with the specific limit hit. INV-01: filtering only, no sizing/orders.

## Verification

- `python -m pytest tests/test_portfolio.py -v` → **30 passed**, exit 0
- `python -m pytest -q` (full suite) → **526 passed, 85 warnings**, exit 0 (warnings all pre-existing)
- `python -m mypy signals/` → **"Success: no issues found in 3 source files"**, exit 0

## AC coverage (from spec)

- [x] Ranked subset preserving score order with all caps respected
- [x] Correlated pair (EUR_USD & GBP_USD, |ρ|>0.7) → higher-scored admitted, lower dropped with reason logged
- [x] `max_per_currency` enforced (≤ N USD-leg candidates)
- [x] `max_concurrent` bounds output length
- [x] Greedy admission deterministic (stable tie-break; input order doesn't affect output)
- [x] Empty input → empty output (no error)
- [x] INV-01: no sizing/orders (module attribute check test + no execution/risk import)