### PR TITLE
P2-T-05: watchlist-narration

### DIFF
--- a/.claude/context/hermes_integration.md
+++ b/.claude/context/hermes_integration.md
@@ -56,3 +56,56 @@ does not need updating for offline unit tests.
 **CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P2-T-05 — 2026-05-29 (feat/p2-t-05)
+
+**What was done:**
+- Created `hermes_integration/narration.py` with:
+  - `fallback_narration(candidate: Candidate) -> str` — deterministic one-liner from the
+    candidate's flat INV-13 fields (`strategy_name`, `direction`, `instrument`, `timeframe`,
+    `oos_sharpe_mean`, `news_flag`). Always returns a non-empty string; never raises.
+    Wraps the entire body in `try/except Exception` for an ultra-minimal last-resort path.
+  - `should_use_fallback(claude_response: str) -> bool` — helper for callers: True if the
+    Claude response is empty/whitespace-only or exceeds `_MAX_NARRATION_LENGTH` (280 chars).
+- Created `hermes_integration/prompts/narration.md` — prompt template instructing Claude to
+  return exactly one plain-English line (no JSON, no markdown), grounded only in the six
+  supplied fields: `{{instrument}}`, `{{timeframe}}`, `{{strategy_name}}`, `{{direction}}`,
+  `{{oos_sharpe_mean}}`, `{{news_flag}}`. No secrets (INV-08).
+- Created `tests/test_narration.py` — 51 tests, zero live Claude/Anthropic calls:
+  - `TestFallbackNarrationBasic` (8 tests): returns string, never empty, no newlines,
+    contains instrument/timeframe/strategy/sharpe, reasonable length.
+  - `TestFallbackNarrationDirections` (2 tests): LONG/SHORT both produce valid output.
+  - `TestFallbackNarrationStrategies` (12 tests): all 6 shipped strategy prefixes × 2
+    checks (non-empty, no newline).
+  - `TestFallbackNarrationNewsFlag` (3 tests): news_flag False/True; True mentions news.
+  - `TestFallbackNarrationNeverRaises` (6 tests): parametrised across all strategy/direction
+    combos — no exception.
+  - `TestShouldUseFallback` (8 tests): empty/whitespace/over-length → True; at-max/below →
+    False; normal response → False.
+  - `TestNarrationIsCosmetic` (5 tests): the critical NOT-INV-02 battery — empty/whitespace/
+    over-long Claude response → fallback used, candidate rank unchanged (kept); valid response
+    used directly; no veto/skip/suggest_action in fallback output.
+  - `TestNoSecretsInNarration` (6 tests): INV-08 sweep over 6 secret patterns.
+  - `TestFallbackNarrationLogging` (1 test): no WARNING logged on normal path.
+
+**CRITICAL distinction from news_risk (NOT INV-02):**
+- Narration is cosmetic presentation only — it does not feed any automated decision.
+- An unusable Claude response → `should_use_fallback` returns True → caller uses
+  `fallback_narration`; the **candidate is kept on the watchlist** (no veto, no drop).
+- INV-02's safe-skip default must NOT be applied here. Documented explicitly in the module
+  docstring so a future reader does not mis-apply the news-risk pattern to narration.
+- `fallback_narration` never returns anything resembling a `suggest_action` verdict.
+
+**No anthropic SDK dep** (D-P2-3 enforced).
+**pyproject.toml untouched** — no new dependencies.
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
+
+**AC verification results:**
+- `pytest tests/test_narration.py -v` → 51 passed, exit 0
+- `pytest -q` (full suite) → 547 passed, exit 0
+- `mypy hermes_integration/` → "Success: no issues found in 3 source files", exit 0
+
+**New dependency added to pyproject.toml?** NO (no new deps; pydantic already present).
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/hermes_integration/narration.py
+++ b/hermes_integration/narration.py
@@ -1,0 +1,142 @@
+"""Watchlist narration — cosmetic presentation layer (NOT INV-02).
+
+Owns the Fathom-side support for Claude's per-candidate one-line narration:
+
+  * ``fallback_narration(candidate)`` — a deterministic one-liner built from
+    the candidate's flat fields.  Always returns a non-empty string; never
+    raises.  Used when Claude is unavailable or returns an unusable response.
+
+**CRITICAL distinction from news_risk (NOT INV-02):**
+    Narration is a *cosmetic* layer — it is presentation only and does not
+    feed any automated decision (filtering, ranking, or sizing).  Therefore:
+
+    - An empty, whitespace-only, or over-long Claude response → caller uses
+      ``fallback_narration``; **the candidate is kept on the watchlist**.
+    - There is **no safe-skip veto here**.  INV-02's "fail safe = drop the
+      candidate" rule applies *only* to outputs that feed automated decisions
+      (e.g. news-risk verdicts).  Applying INV-02's veto to narration would
+      let a cosmetic-layer hiccup silently shrink the watchlist — exactly what
+      the spec prohibits.
+    - A future reader must NOT add a ``suggest_action="skip"`` default here.
+      If narration fails, use ``fallback_narration`` and move on.
+
+This module is fully unit-testable offline.  No ``anthropic`` SDK dependency
+(D-P2-3): Claude is invoked Hermes-side.
+
+INV-08: No secrets, tokens, or API keys are referenced here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from signals.ranker import Candidate
+
+_log = logging.getLogger(__name__)
+
+# Maximum character length for a Claude-supplied narration to be considered
+# usable.  Anything longer is treated as unusable → fallback.
+_MAX_NARRATION_LENGTH: int = 280
+
+
+# ---------------------------------------------------------------------------
+# fallback_narration — the always-safe, deterministic path
+# ---------------------------------------------------------------------------
+
+
+def fallback_narration(candidate: Candidate) -> str:
+    """Build a deterministic one-line narration from the candidate's flat fields.
+
+    This is the guaranteed fallback path used when Claude is unavailable or
+    returns an unusable response.  It is derived entirely from the candidate's
+    own fields — no invented numbers, no external calls.
+
+    **Never raises.  Never returns an empty string.**
+
+    The candidate is **never dropped** because of a narration failure; this
+    function exists solely so the caller always has *something* to show the
+    trader.  See module docstring for the INV-02 non-applicability note.
+
+    Args:
+        candidate: A ranked ``Candidate`` from ``signals.ranker``.
+
+    Returns:
+        A concise plain-English one-liner describing the candidate.
+
+    Examples:
+        >>> from signals.ranker import Candidate
+        >>> c = Candidate(
+        ...     instrument="GBP_USD", timeframe="H4", strategy_name="donchian_20",
+        ...     direction="LONG", entry_ref=1.2750, stop_distance=0.0030,
+        ...     target_distance=0.0045, oos_sharpe_mean=0.25, quality_score=0.8,
+        ...     rank=1, spread_ok=True, session_ok=True, news_flag=False,
+        ...     generated_at="2026-05-29T06:00:00Z",
+        ... )
+        >>> fallback_narration(c)
+        'Donchian_20 long on GBP/USD H4, OOS Sharpe 0.25.'
+    """
+    try:
+        instrument_display = candidate.instrument.replace("_", "/")
+        direction_display = candidate.direction.capitalize()
+        sharpe_display = f"{candidate.oos_sharpe_mean:.2f}"
+        news_suffix = (
+            " Medium-impact news nearby." if candidate.news_flag else ""
+        )
+        line = (
+            f"{candidate.strategy_name} {direction_display} on "
+            f"{instrument_display} {candidate.timeframe}, "
+            f"OOS Sharpe {sharpe_display}.{news_suffix}"
+        )
+        # Defensive: strip leading/trailing whitespace; should always be
+        # non-empty given the template, but guard explicitly.
+        line = line.strip()
+        if not line:
+            # Should never happen — but if it does, return the bare minimum.
+            return (
+                f"Signal on {candidate.instrument} "
+                f"({candidate.timeframe}): {candidate.direction}."
+            )
+        return line
+    except Exception as exc:  # noqa: BLE001 — catch-all; narration must never raise
+        _log.warning(
+            "fallback_narration: unexpected error (%s: %s) — returning bare fallback.",
+            type(exc).__name__,
+            exc,
+        )
+        # Ultra-minimal last resort — uses only basic attribute access.
+        return f"Signal on {getattr(candidate, 'instrument', '?')}."
+
+
+# ---------------------------------------------------------------------------
+# should_use_fallback — helper for callers
+# ---------------------------------------------------------------------------
+
+
+def should_use_fallback(claude_response: str) -> bool:
+    """Return True when a Claude narration response is unusable.
+
+    Callers should use this to decide whether to display ``claude_response``
+    or substitute ``fallback_narration(candidate)`` instead.
+
+    A response is unusable if it is:
+    - Empty or whitespace-only.
+    - Over ``_MAX_NARRATION_LENGTH`` characters (likely a hallucination or
+      multi-sentence output instead of the required one-liner).
+
+    **This function never drops a candidate** — it only signals to the caller
+    whether to swap in the fallback string.  The candidate is always kept.
+    (NOT INV-02 — see module docstring.)
+
+    Args:
+        claude_response: The raw string returned by Claude.
+
+    Returns:
+        ``True`` if the fallback should be used; ``False`` if the response is
+        usable as-is.
+    """
+    stripped = claude_response.strip() if claude_response else ""
+    if not stripped:
+        return True
+    if len(stripped) > _MAX_NARRATION_LENGTH:
+        return True
+    return False

--- a/hermes_integration/prompts/narration.md
+++ b/hermes_integration/prompts/narration.md
@@ -1,0 +1,49 @@
+# Prompt: Watchlist Narration
+
+**Used by:** Hermes daily watchlist job  
+**For:** Each surviving, ranked candidate — after portfolio limits, news-risk assessment, and ranking  
+**Returns:** Exactly one plain-English line — no JSON, no markdown, no formatting
+
+---
+
+## Instructions
+
+You are a concise forex trading assistant. Your job is to write a single, plain-English sentence
+that explains *why* this pair is on today's watchlist. Ground your sentence **only** in the
+facts supplied below. Do not invent numbers, levels, or events that are not in the input.
+
+**Your response must be exactly one line of plain text** — no JSON, no markdown, no bullet
+points, no parenthetical footnotes, no trailing punctuation beyond a full stop. Aim for
+≤ 140 characters. If you cannot produce a meaningful sentence from the facts given, write:
+`Strategy signal on {{instrument}} ({{timeframe}}) — {{direction}}, OOS Sharpe {{oos_sharpe_mean}}.`
+
+---
+
+## Supplied facts
+
+| Field | Value |
+|---|---|
+| Instrument | {{instrument}} |
+| Timeframe | {{timeframe}} |
+| Strategy | {{strategy_name}} |
+| Direction | {{direction}} |
+| OOS Sharpe (mean) | {{oos_sharpe_mean}} |
+| News flag | {{news_flag}} |
+
+*(Only these facts are available. Do not reference spreads, session status, entry price,
+stop distance, or any other field not listed above.)*
+
+---
+
+## Output rules (strictly enforced)
+
+- **One line only.** A response with a newline character anywhere is unusable.
+- **Plain text only.** No JSON, no markdown fences, no asterisks, no backticks.
+- **No invented numbers.** Use only `{{oos_sharpe_mean}}` from the table — no other levels.
+- **No secrets or tokens** (INV-08).
+- If `{{news_flag}}` is `true`, mention that a medium-impact event is nearby; if `false`,
+  omit news entirely.
+
+---
+
+Respond now with **only** the one-line narration sentence.

--- a/tests/test_narration.py
+++ b/tests/test_narration.py
@@ -1,0 +1,395 @@
+"""Tests for hermes_integration.narration — watchlist-narration (P2-T-05).
+
+Coverage:
+    - fallback_narration: produces a non-empty one-liner for any candidate
+      (LONG/SHORT, each shipped strategy prefix).
+    - should_use_fallback: empty/whitespace/over-long Claude response → True;
+      normal response → False.
+    - Narration failure is COSMETIC — empty/unusable Claude response → fallback
+      used, candidate unaffected (NOT an INV-02 veto, candidate is KEPT).
+    - fallback_narration never raises on any valid Candidate.
+    - INV-08: no secrets or tokens in module or fallback output.
+
+No live Claude / Anthropic calls anywhere in this module.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hermes_integration.narration import (
+    _MAX_NARRATION_LENGTH,
+    fallback_narration,
+    should_use_fallback,
+)
+from signals.ranker import Candidate
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    instrument: str = "EUR_USD",
+    timeframe: str = "H1",
+    strategy_name: str = "macrossover_10_50",
+    direction: str = "LONG",
+    oos_sharpe_mean: float = 0.30,
+    news_flag: bool = False,
+) -> Candidate:
+    """Build a minimal valid Candidate for testing."""
+    return Candidate(
+        instrument=instrument,
+        timeframe=timeframe,
+        strategy_name=strategy_name,
+        direction=direction,
+        entry_ref=1.1000,
+        stop_distance=0.0020,
+        target_distance=0.0030,
+        oos_sharpe_mean=oos_sharpe_mean,
+        quality_score=0.75,
+        rank=1,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=news_flag,
+        generated_at="2026-05-29T08:00:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationBasic
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationBasic:
+    """Basic contract: non-empty, one-liner, no exception."""
+
+    def test_returns_string(self) -> None:
+        c = _make_candidate()
+        result = fallback_narration(c)
+        assert isinstance(result, str)
+
+    def test_never_empty(self) -> None:
+        c = _make_candidate()
+        result = fallback_narration(c)
+        assert result.strip() != ""
+
+    def test_no_newlines(self) -> None:
+        """Result must be a single line."""
+        c = _make_candidate()
+        result = fallback_narration(c)
+        assert "\n" not in result
+
+    def test_contains_instrument(self) -> None:
+        c = _make_candidate(instrument="GBP_USD")
+        result = fallback_narration(c)
+        # Instrument displayed as GBP/USD or GBP_USD — either is fine.
+        assert "GBP" in result and "USD" in result
+
+    def test_contains_timeframe(self) -> None:
+        c = _make_candidate(timeframe="H4")
+        result = fallback_narration(c)
+        assert "H4" in result
+
+    def test_contains_strategy(self) -> None:
+        c = _make_candidate(strategy_name="donchian_20")
+        result = fallback_narration(c)
+        assert "donchian_20" in result.lower() or "donchian" in result.lower()
+
+    def test_contains_sharpe(self) -> None:
+        c = _make_candidate(oos_sharpe_mean=0.42)
+        result = fallback_narration(c)
+        assert "0.42" in result
+
+    def test_reasonable_length(self) -> None:
+        """Should be well under 280 characters for default fields."""
+        c = _make_candidate()
+        result = fallback_narration(c)
+        assert len(result) <= _MAX_NARRATION_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationDirections
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationDirections:
+    """One-liner for both LONG and SHORT."""
+
+    def test_long_direction(self) -> None:
+        c = _make_candidate(direction="LONG")
+        result = fallback_narration(c)
+        assert result.strip() != ""
+        assert "long" in result.lower() or "LONG" in result
+
+    def test_short_direction(self) -> None:
+        c = _make_candidate(direction="SHORT")
+        result = fallback_narration(c)
+        assert result.strip() != ""
+        assert "short" in result.lower() or "SHORT" in result
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationStrategies
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationStrategies:
+    """One-liner for each shipped strategy prefix (INV-13 requirement)."""
+
+    @pytest.mark.parametrize(
+        "strategy_name",
+        [
+            "macrossover_10_50",
+            "donchian_20",
+            "bollinger_20_2",
+            "rsi_14_30_70",
+            "roc_10_eur_usd_h1",
+            "session_20",
+        ],
+    )
+    def test_strategy_produces_nonempty_narration(self, strategy_name: str) -> None:
+        c = _make_candidate(strategy_name=strategy_name)
+        result = fallback_narration(c)
+        assert result.strip() != ""
+
+    @pytest.mark.parametrize(
+        "strategy_name",
+        [
+            "macrossover_10_50",
+            "donchian_20",
+            "bollinger_20_2",
+            "rsi_14_30_70",
+            "roc_10_eur_usd_h1",
+            "session_20",
+        ],
+    )
+    def test_strategy_no_newline(self, strategy_name: str) -> None:
+        c = _make_candidate(strategy_name=strategy_name)
+        result = fallback_narration(c)
+        assert "\n" not in result
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationNewsFlag
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationNewsFlag:
+    """news_flag=True vs False produce valid outputs."""
+
+    def test_no_news_flag(self) -> None:
+        c = _make_candidate(news_flag=False)
+        result = fallback_narration(c)
+        assert result.strip() != ""
+
+    def test_news_flag_true_mentions_news(self) -> None:
+        c = _make_candidate(news_flag=True)
+        result = fallback_narration(c)
+        assert result.strip() != ""
+        # The spec says fold the news verdict in when news_flag is True.
+        assert "news" in result.lower() or "event" in result.lower()
+
+    def test_news_flag_false_no_news_mention(self) -> None:
+        c = _make_candidate(news_flag=False)
+        result = fallback_narration(c)
+        # When no news flag, the narration should not invent a news warning.
+        assert "news" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationNeverRaises
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationNeverRaises:
+    """fallback_narration must never raise on a valid Candidate."""
+
+    @pytest.mark.parametrize(
+        "instrument,timeframe,strategy_name,direction,oos_sharpe_mean,news_flag",
+        [
+            ("EUR_USD", "H1", "macrossover_10_50", "LONG", 0.30, False),
+            ("GBP_USD", "H4", "donchian_20", "SHORT", 0.15, True),
+            ("USD_JPY", "D", "bollinger_20_2", "LONG", 0.50, False),
+            ("AUD_USD", "M30", "rsi_14_30_70", "SHORT", 0.22, True),
+            ("EUR_JPY", "H1", "roc_10_eur_usd_h1", "LONG", 0.18, False),
+            ("USD_CAD", "H4", "session_20", "SHORT", 0.35, True),
+        ],
+    )
+    def test_no_exception(
+        self,
+        instrument: str,
+        timeframe: str,
+        strategy_name: str,
+        direction: str,
+        oos_sharpe_mean: float,
+        news_flag: bool,
+    ) -> None:
+        c = _make_candidate(
+            instrument=instrument,
+            timeframe=timeframe,
+            strategy_name=strategy_name,
+            direction=direction,
+            oos_sharpe_mean=oos_sharpe_mean,
+            news_flag=news_flag,
+        )
+        # Must not raise.
+        result = fallback_narration(c)
+        assert isinstance(result, str)
+        assert result.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# TestShouldUseFallback
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseFallback:
+    """should_use_fallback correctly identifies unusable Claude responses."""
+
+    def test_empty_string_uses_fallback(self) -> None:
+        assert should_use_fallback("") is True
+
+    def test_whitespace_only_uses_fallback(self) -> None:
+        assert should_use_fallback("   ") is True
+        assert should_use_fallback("\n\t  \n") is True
+
+    def test_none_like_empty_string_uses_fallback(self) -> None:
+        # API contracts return str; but guard empty string defensively.
+        assert should_use_fallback("") is True
+
+    def test_over_length_uses_fallback(self) -> None:
+        long_response = "A" * (_MAX_NARRATION_LENGTH + 1)
+        assert should_use_fallback(long_response) is True
+
+    def test_exactly_at_max_length_ok(self) -> None:
+        at_max = "A" * _MAX_NARRATION_LENGTH
+        assert should_use_fallback(at_max) is False
+
+    def test_one_under_max_length_ok(self) -> None:
+        one_under = "A" * (_MAX_NARRATION_LENGTH - 1)
+        assert should_use_fallback(one_under) is False
+
+    def test_normal_response_does_not_use_fallback(self) -> None:
+        good_response = (
+            "Donchian 20-bar breakout long on GBP/USD H4, OOS Sharpe 0.25."
+        )
+        assert should_use_fallback(good_response) is False
+
+    def test_minimal_response_does_not_use_fallback(self) -> None:
+        assert should_use_fallback("Signal on EUR/USD.") is False
+
+
+# ---------------------------------------------------------------------------
+# TestNarrationIsCosmetic — NOT INV-02 (most important safety property)
+# ---------------------------------------------------------------------------
+
+
+class TestNarrationIsCosmetic:
+    """Narration failure is COSMETIC — candidate is NEVER dropped/vetoed.
+
+    These tests verify the critical distinction from news_risk:
+    - An empty Claude response → fallback is used, not a veto.
+    - An over-long Claude response → fallback is used, not a veto.
+    - should_use_fallback returns True (use fallback), NOT a "skip" verdict.
+    - Calling fallback_narration on the candidate succeeds (candidate kept).
+
+    A candidate being "kept" is modelled here by verifying that:
+    1. should_use_fallback signals the unusable response.
+    2. fallback_narration returns a valid string for the same candidate.
+    3. There is NO veto/skip/drop object anywhere in the narration path.
+    """
+
+    def _simulate_narration_pipeline(
+        self, candidate: Candidate, claude_response: str
+    ) -> tuple[str, bool]:
+        """Simulate the caller's decision logic.
+
+        Returns (narration_text, used_fallback).
+        The candidate is ALWAYS kept regardless of used_fallback.
+        """
+        if should_use_fallback(claude_response):
+            return fallback_narration(candidate), True
+        return claude_response.strip(), False
+
+    def test_empty_claude_response_uses_fallback_candidate_kept(self) -> None:
+        c = _make_candidate()
+        narration, used_fallback = self._simulate_narration_pipeline(c, "")
+        assert used_fallback is True
+        assert narration.strip() != ""
+        # No veto — candidate is still the same object, unmodified.
+        assert c.rank == 1  # candidate unchanged
+
+    def test_whitespace_claude_response_uses_fallback_candidate_kept(self) -> None:
+        c = _make_candidate()
+        narration, used_fallback = self._simulate_narration_pipeline(c, "   \n  ")
+        assert used_fallback is True
+        assert narration.strip() != ""
+        assert c.rank == 1
+
+    def test_over_long_claude_response_uses_fallback_candidate_kept(self) -> None:
+        c = _make_candidate()
+        too_long = "Word " * 100  # well over 280 chars
+        narration, used_fallback = self._simulate_narration_pipeline(c, too_long)
+        assert used_fallback is True
+        assert narration.strip() != ""
+        assert c.rank == 1
+
+    def test_valid_claude_response_used_directly(self) -> None:
+        c = _make_candidate()
+        good = "Donchian breakout long on EUR/USD H1, OOS Sharpe 0.30."
+        narration, used_fallback = self._simulate_narration_pipeline(c, good)
+        assert used_fallback is False
+        assert narration == good
+
+    def test_no_veto_object_returned(self) -> None:
+        """Narration path must never return anything resembling a veto/skip verdict."""
+        c = _make_candidate()
+        result = fallback_narration(c)
+        # The narration module must not produce skip/veto/drop keywords that
+        # could be confused with a news-risk verdict.
+        assert "suggest_action" not in result
+        assert "skip" not in result.lower().split()  # "skip" as a standalone word
+
+
+# ---------------------------------------------------------------------------
+# TestNoSecretsInNarration — INV-08
+# ---------------------------------------------------------------------------
+
+
+class TestNoSecretsInNarration:
+    """INV-08: fallback_narration output must not contain tokens or keys."""
+
+    _SECRET_PATTERNS = [
+        "OANDA_API_KEY",
+        "api_key",
+        "sk-",
+        "Bearer ",
+        "Authorization:",
+        "password",
+    ]
+
+    @pytest.mark.parametrize("pattern", _SECRET_PATTERNS)
+    def test_no_secret_pattern_in_fallback(self, pattern: str) -> None:
+        c = _make_candidate()
+        result = fallback_narration(c)
+        assert pattern not in result
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackNarrationLogging
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackNarrationLogging:
+    """Logging behaviour: no warning on normal path; warning on error path."""
+
+    def test_no_warning_on_normal_call(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        c = _make_candidate()
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.narration"):
+            fallback_narration(c)
+        assert caplog.records == []


### PR DESCRIPTION
Closes #56.

## Summary

Implements P2-T-05 (`hermes_integration/narration.py` + prompt).

- `fallback_narration(candidate: Candidate) -> str` — deterministic one-liner from the
  candidate's flat INV-13 fields. Never raises, never empty.
- `should_use_fallback(claude_response: str) -> bool` — helper callers use to decide
  whether to swap in the fallback string.
- `hermes_integration/prompts/narration.md` — prompt template asking Claude for one
  plain-English line grounded only in the six supplied facts (no JSON, no invented numbers).
- `tests/test_narration.py` — 51 tests; 547 total passing.

## Critical design point: NOT INV-02

Narration is cosmetic presentation — it does not feed any automated decision. An
unusable Claude response → caller uses `fallback_narration`; **the candidate is kept on
the watchlist**. There is no safe-skip veto here. INV-02's fail-safe-drop rule applies
only to outputs feeding automated decisions (e.g. `news_risk`). This is documented
explicitly in the module docstring to prevent future mis-application.

## Verification

```
pytest tests/test_narration.py -v   → 51 passed, exit 0
pytest -q                           → 547 passed, exit 0
mypy hermes_integration/            → Success: no issues found in 3 source files, exit 0
```

No new dependencies. `pyproject.toml` untouched. No `anthropic` SDK dep (D-P2-3).