### PR TITLE
P2-T-07: cli scan|watchlist|chart

### DIFF
--- a/.claude/context/runner.md
+++ b/.claude/context/runner.md
@@ -200,3 +200,90 @@ The integration tests masked the bug because they pre-populated the DB with fixt
 **No new dependencies.** No changes to pyproject.toml.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P2-T-07 — 2026-05-29 (feat/p2-t-07) — cli scan|watchlist|chart (join)
+
+**What was done:**
+- Extended `cli.py` with three Phase 2 subcommands (`scan`, `watchlist`, `chart`).
+  **This is the ONLY Phase 2 task that edits `cli.py`** (join point per task graph).
+- Extended `data/store.py` with a `watchlist` SQLite table + `write_watchlist` /
+  `load_watchlist` methods (mirrors the `approved_set` pattern — run-timestamped,
+  single-writer).  The `Candidate`↔table mapping lives entirely in the persistence
+  layer; the `Candidate` pydantic model is NOT modified (INV-13 frozen).
+
+**`fathom scan`** (`cmd_scan`):
+- `--dry-run` (cache-only, mirrors `backtest`): skips live fetch; runs Ranker →
+  PortfolioLimiter against whatever is in the store.
+- LIVE mode: calls `_fetch_candles_for_universe` (reused Phase 1 helper) then
+  instantiates `FairEconomyCalendar(db_path=db_path)`, `Ranker`, `PortfolioLimiter`.
+- Persists candidates to `watchlist` table via `store.write_watchlist(candidates,
+  run_timestamp=run_dt)` in one transaction.
+- Prints `Candidate[]` JSON to stdout (INV-13 wire shape).
+- Empty approved-set → empty watchlist, clear stdout message, **exit 0** (INV-10).
+
+**`fathom watchlist`** (`cmd_watchlist`):
+- Pure DB read via `store.load_watchlist()` (latest run — `MAX(run_timestamp)`).
+- Reconstructs `Candidate` objects from raw dicts (validates shape); serialises via
+  `model_dump()` → ensures JSON matches INV-13 exactly.
+- Empty table → prints `[]`, exits 0.
+
+**`fathom chart <instrument>`** (`cmd_chart`):
+- Reads latest watchlist entry for `<instrument>/<timeframe>`.
+- Loads candles from store; calls `render_candidate_chart`.
+- Prints PNG path to stdout.
+- No live HTTP — pure store read + matplotlib.
+
+**`watchlist` table schema:**
+```sql
+CREATE TABLE IF NOT EXISTS watchlist (
+    run_timestamp    TEXT    NOT NULL,
+    instrument       TEXT    NOT NULL,
+    timeframe        TEXT    NOT NULL,
+    strategy_name    TEXT    NOT NULL,
+    direction        TEXT    NOT NULL,
+    entry_ref        REAL    NOT NULL,
+    stop_distance    REAL    NOT NULL,
+    target_distance  REAL    NOT NULL,
+    oos_sharpe_mean  REAL    NOT NULL,
+    quality_score    REAL    NOT NULL,
+    rank             INTEGER NOT NULL,
+    spread_ok        INTEGER NOT NULL,
+    session_ok       INTEGER NOT NULL,
+    news_flag        INTEGER NOT NULL,
+    generated_at     TEXT    NOT NULL,
+    PRIMARY KEY (run_timestamp, instrument, timeframe, strategy_name)
+)
+```
+
+**Key patterns / gotchas:**
+- `FairEconomyCalendar.upcoming_events` returns `list[CalendarEvent]`; Ranker's
+  `_CalendarLike` Protocol declares `list[object]` — structurally compatible but
+  mypy rejects on return covariance. Suppressed with `# type: ignore[arg-type]`
+  on the `Ranker(store=..., calendar=FairEconomyCalendar(...))` line only.
+- Lazy imports (`from data.calendar import FairEconomyCalendar` etc inside
+  `cmd_scan`) mean tests must patch at the **source module** path
+  (`data.calendar.FairEconomyCalendar`, `signals.ranker.Ranker`, etc.),
+  NOT `cli.FairEconomyCalendar`. Documented in test file.
+- `write_watchlist` and `load_watchlist` added to `data/store.py`.
+  `Store._create_tables` now also calls `CREATE TABLE IF NOT EXISTS watchlist`.
+  Idempotent — existing DBs from prior phases get the new table on first open.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_cli_commands.py -v` → **16 passed**, exit 0
+- `python -m pytest -q` (full suite) → **624 passed, 85 warnings**, exit 0
+  (85 warnings pre-existing; not introduced by T-07)
+- `python -m mypy cli.py data/store.py` → **"Success: no issues found in 2 source files"**, exit 0
+- `fathom scan --dry-run --db-path /tmp/x.db --instruments EUR_USD --timeframes H1`
+  → "Scan complete: approved-set is empty … Watchlist is empty (a valid result — INV-10)."
+  **exit 0**; INV-10 clear message; no token logged (INV-08); UTC timestamps (INV-03).
+
+**No new dependencies.** No changes to pyproject.toml.
+
+**CLAUDE.md trigger-table check:**
+- New CLI commands → CLAUDE.md Commands updated (YES): `fathom scan`, `fathom watchlist`,
+  `fathom chart` moved from "Phase 2+ (not yet built)" to "Phase 2 (current)" with full
+  arg list.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,19 +39,26 @@ Python 3.11+ · oandapyV20>=0.6 · pydantic>=2 · pydantic-settings>=2 · python
 ## Common Commands
 
 ```bash
-# Phase 1A (current)
+# Phase 1A
 fathom backtest               # full-universe walk-forward → persist approved_set table (P1A-T-08)
 #   fathom backtest [--instruments ALL|EUR_USD,...] [--timeframes H1,H4,D]
 #                   [--strategies all|macrossover,donchian,bollinger,rsi,roc,session]
 #                   [--workers N] [--db-path PATH] [--history-years N] [--dry-run]
 
+# Phase 2 (current) — P2-T-07
+fathom scan                   # refresh candles, rank approved strategies → PortfolioLimiter,
+                              # persist watchlist table, print Candidate[] JSON
+#   fathom scan [--instruments ALL|EUR_USD,...] [--timeframes H1,H4,D]
+#               [--db-path PATH] [--history-years N] [--dry-run]
+
+fathom watchlist              # output latest persisted watchlist as Candidate[] JSON (INV-13)
+#   fathom watchlist [--db-path PATH]
+
+fathom chart <instrument>     # render candidate chart PNG, print path (Hermes tool)
+#   fathom chart EUR_USD [--timeframe H1] [--db-path PATH] [--out-dir DIR] [--history-years N]
+
 # PoC (superseded by `fathom backtest`)
 python scripts/poc_run.py     # end-to-end PoC: fetch candles → backtest → approved-set table
-
-# Phase 2+ (not yet built)
-fathom scan                   # refresh data, run approved strategies, rank candidates
-fathom watchlist              # output ranked watchlist (called by Hermes)
-fathom chart <pair>           # render candle chart with overlays
 
 pytest                        # run test suite
 ```

--- a/cli.py
+++ b/cli.py
@@ -963,32 +963,36 @@ def cmd_scan(args: argparse.Namespace) -> int:
 
     store = Store(db_path)
     try:
-        # FairEconomyCalendar.upcoming_events returns list[CalendarEvent] while
-        # Ranker's _CalendarLike Protocol declares list[object].  Structurally
-        # compatible (CalendarEvent IS an object) but mypy's strict return-type
-        # covariance check rejects it — suppress with ignore on this line only.
-        ranker = Ranker(store=store, calendar=FairEconomyCalendar(db_path=db_path))  # type: ignore[arg-type]
-        limiter = PortfolioLimiter(store=store)
+        try:
+            # FairEconomyCalendar.upcoming_events returns list[CalendarEvent] while
+            # Ranker's _CalendarLike Protocol declares list[object].  Structurally
+            # compatible (CalendarEvent IS an object) but mypy's strict return-type
+            # covariance check rejects it — suppress with ignore on this line only.
+            ranker = Ranker(store=store, calendar=FairEconomyCalendar(db_path=db_path))  # type: ignore[arg-type]
+            limiter = PortfolioLimiter(store=store)
 
-        _log.info(
-            "Running Ranker at %s …", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        )
-        ranked = ranker.rank(now=run_dt)
-        candidates = limiter.apply(ranked)
+            _log.info(
+                "Running Ranker at %s …", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            )
+            ranked = ranker.rank(now=run_dt)
+            candidates = limiter.apply(ranked)
 
-        _log.info(
-            "Ranker produced %d candidate(s); %d after portfolio limits.",
-            len(ranked),
-            len(candidates),
-        )
+            _log.info(
+                "Ranker produced %d candidate(s); %d after portfolio limits.",
+                len(ranked),
+                len(candidates),
+            )
 
-        # Persist to watchlist table (single transaction, mirrors approved_set).
-        written = store.write_watchlist(candidates, run_timestamp=run_dt)
-        _log.info(
-            "Persisted %d watchlist row(s) (run_timestamp=%s).",
-            written,
-            run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        )
+            # Persist to watchlist table (single transaction, mirrors approved_set).
+            written = store.write_watchlist(candidates, run_timestamp=run_dt)
+            _log.info(
+                "Persisted %d watchlist row(s) (run_timestamp=%s).",
+                written,
+                run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log.error("Ranker/portfolio step failed: %s", exc)
+            return 1
     finally:
         store.close()
 

--- a/cli.py
+++ b/cli.py
@@ -63,6 +63,7 @@ signals", not "all signals").
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from concurrent.futures import ProcessPoolExecutor
@@ -665,6 +666,93 @@ def _build_parser() -> argparse.ArgumentParser:
             "run walk-forward against whatever candles are already cached."
         ),
     )
+
+    # ---- scan ---------------------------------------------------------------
+    sc = sub.add_parser(
+        "scan",
+        help=(
+            "Refresh candles, rank approved strategies → PortfolioLimiter, "
+            "persist watchlist, print Candidate[] JSON."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sc.add_argument(
+        "--instruments",
+        default="ALL",
+        help="ALL to discover from cache, or a comma-separated list.",
+    )
+    sc.add_argument(
+        "--timeframes",
+        default="H1,H4,D",
+        help="Comma-separated timeframes for the candle refresh.",
+    )
+    sc.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store (candles + approved_set + watchlist).",
+    )
+    sc.add_argument(
+        "--history-years",
+        type=int,
+        default=_DEFAULT_HISTORY_YEARS,
+        metavar="N",
+        help="Years of history to fetch/cache (passed to fetch_and_cache).",
+    )
+    sc.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Cache-only: skip live candle fetch (mirror backtest --dry-run). "
+            "Run ranker against whatever is already cached."
+        ),
+    )
+
+    # ---- watchlist ----------------------------------------------------------
+    wl = sub.add_parser(
+        "watchlist",
+        help="Print the latest persisted watchlist as Candidate[] JSON (INV-13).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    wl.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store.",
+    )
+
+    # ---- chart --------------------------------------------------------------
+    ch = sub.add_parser(
+        "chart",
+        help="Render a candidate's chart PNG and print its path.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    ch.add_argument(
+        "instrument",
+        help="OANDA instrument identifier, e.g. EUR_USD.",
+    )
+    ch.add_argument(
+        "--timeframe",
+        default="H1",
+        help="Granularity of the candle data to plot.",
+    )
+    ch.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store (candles + watchlist).",
+    )
+    ch.add_argument(
+        "--out-dir",
+        default="charts",
+        help="Directory in which to save the PNG.",
+    )
+    ch.add_argument(
+        "--history-years",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Years of candle history to load for the chart window.",
+    )
+
     return parser
 
 
@@ -813,6 +901,264 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# scan command
+# ---------------------------------------------------------------------------
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    """Execute the ``fathom scan`` command.
+
+    Refreshes candles (unless ``--dry-run``), runs ``Ranker`` →
+    ``PortfolioLimiter``, persists the ranked ``Candidate`` list to the
+    ``watchlist`` SQLite table, and prints the list as ``Candidate[]`` JSON to
+    stdout.
+
+    Empty approved-set → empty watchlist, clear message, **exit 0** (INV-10).
+
+    INV-01: no order placement — candidates only.
+    INV-03: all timestamps UTC.
+    INV-08: token/account never logged.
+    """
+    run_dt = datetime.now(tz=timezone.utc)
+    _log.info("fathom scan started at %s", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    db_path: str = args.db_path
+    dry_run: bool = args.dry_run
+    timeframes = [s.strip() for s in args.timeframes.split(",") if s.strip()]
+
+    # ---- Optional candle refresh (LIVE mode only; mirrors backtest). --------
+    if not dry_run:
+        instruments_to_fetch: list[str]
+        if args.instruments.strip().upper() == "ALL":
+            # In LIVE mode for ALL, discover via the OANDA API and cache.
+            try:
+                instruments_to_fetch = _discover_universe(
+                    args.instruments, db_path, dry_run=False
+                )
+            except Exception as exc:  # noqa: BLE001
+                _log.error("Universe discovery failed: %s", exc)
+                return 1
+        else:
+            instruments_to_fetch = [
+                s.strip() for s in args.instruments.split(",") if s.strip()
+            ]
+        if instruments_to_fetch:
+            start_fetch, end_fetch = _build_date_range(args.history_years)
+            try:
+                _fetch_candles_for_universe(
+                    instruments=instruments_to_fetch,
+                    timeframes=timeframes,
+                    db_path=db_path,
+                    start=start_fetch,
+                    end=end_fetch,
+                )
+            except Exception as exc:  # noqa: BLE001
+                _log.error("Candle fetch failed: %s", exc)
+                return 1
+
+    # ---- Build Ranker + PortfolioLimiter (lazy imports — no HTTP in tests). -
+    from data.calendar import FairEconomyCalendar
+    from signals.portfolio import PortfolioLimiter
+    from signals.ranker import Ranker
+
+    store = Store(db_path)
+    try:
+        # FairEconomyCalendar.upcoming_events returns list[CalendarEvent] while
+        # Ranker's _CalendarLike Protocol declares list[object].  Structurally
+        # compatible (CalendarEvent IS an object) but mypy's strict return-type
+        # covariance check rejects it — suppress with ignore on this line only.
+        ranker = Ranker(store=store, calendar=FairEconomyCalendar(db_path=db_path))  # type: ignore[arg-type]
+        limiter = PortfolioLimiter(store=store)
+
+        _log.info(
+            "Running Ranker at %s …", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+        ranked = ranker.rank(now=run_dt)
+        candidates = limiter.apply(ranked)
+
+        _log.info(
+            "Ranker produced %d candidate(s); %d after portfolio limits.",
+            len(ranked),
+            len(candidates),
+        )
+
+        # Persist to watchlist table (single transaction, mirrors approved_set).
+        written = store.write_watchlist(candidates, run_timestamp=run_dt)
+        _log.info(
+            "Persisted %d watchlist row(s) (run_timestamp=%s).",
+            written,
+            run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+    finally:
+        store.close()
+
+    if not candidates:
+        print(
+            "Scan complete: approved-set is empty or no strategies produced "
+            "signals. Watchlist is empty (a valid result — INV-10)."
+        )
+        _log.info("fathom scan finished at %s. Watchlist is empty.", _utc_now_rfc3339())
+        return 0
+
+    # Print Candidate[] JSON to stdout (the Hermes-facing wire contract, INV-13).
+    output = json.dumps(
+        [c.model_dump() for c in candidates],
+        indent=2,
+        default=str,
+    )
+    print(output)
+
+    _log.info(
+        "fathom scan finished at %s. Candidates: %d.",
+        _utc_now_rfc3339(),
+        len(candidates),
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# watchlist command
+# ---------------------------------------------------------------------------
+
+
+def cmd_watchlist(args: argparse.Namespace) -> int:
+    """Execute the ``fathom watchlist`` command.
+
+    Reads the **latest** persisted watchlist from the ``watchlist`` SQLite
+    table and emits it as ``Candidate[]`` JSON (INV-13 wire shape).
+
+    No live HTTP — pure DB read.  Empty watchlist → prints empty JSON array
+    and exits 0 (INV-10).
+    """
+    _log.info("fathom watchlist started at %s", _utc_now_rfc3339())
+
+    db_path: str = args.db_path
+    store = Store(db_path)
+    try:
+        rows = store.load_watchlist()
+    finally:
+        store.close()
+
+    if not rows:
+        _log.info("No watchlist rows found; emitting empty JSON array.")
+        print("[]")
+        return 0
+
+    # Reconstruct Candidate objects from raw dicts for full validation, then
+    # serialise — this ensures the JSON output matches the INV-13 shape exactly.
+    from signals.ranker import Candidate
+
+    candidates = [Candidate(**row) for row in rows]
+    output = json.dumps(
+        [c.model_dump() for c in candidates],
+        indent=2,
+        default=str,
+    )
+    print(output)
+
+    _log.info(
+        "fathom watchlist finished at %s. Emitted %d candidate(s).",
+        _utc_now_rfc3339(),
+        len(candidates),
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# chart command
+# ---------------------------------------------------------------------------
+
+
+def cmd_chart(args: argparse.Namespace) -> int:
+    """Execute the ``fathom chart <instrument>`` command.
+
+    Reads the latest watchlist entry for ``<instrument>`` (optionally filtered
+    by ``--timeframe``), loads its candles, renders a PNG via
+    ``render_candidate_chart``, and prints the PNG path to stdout.
+
+    No live HTTP — reads from the SQLite store (candles + watchlist).
+    """
+    _log.info("fathom chart started at %s", _utc_now_rfc3339())
+
+    instrument: str = args.instrument
+    timeframe: str = args.timeframe
+    db_path: str = args.db_path
+    out_dir: str = args.out_dir
+
+    from signals.charts import render_candidate_chart
+    from signals.ranker import Candidate
+
+    store = Store(db_path)
+    try:
+        rows = store.load_watchlist()
+    finally:
+        store.close()
+
+    # Find the matching candidate from the latest watchlist run.
+    matching = [
+        r for r in rows
+        if r["instrument"] == instrument and r["timeframe"] == timeframe
+    ]
+    if not matching:
+        _log.error(
+            "No watchlist entry found for instrument=%r timeframe=%r "
+            "(run 'fathom scan' first, or check --timeframe).",
+            instrument,
+            timeframe,
+        )
+        print(
+            f"No watchlist entry for {instrument}/{timeframe}. "
+            "Run 'fathom scan' first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Use the first (highest-ranked) matching candidate.
+    candidate = Candidate(**matching[0])
+
+    # Load candles for the chart window.
+    start_chart, end_chart = _build_date_range(args.history_years)
+    store2 = Store(db_path)
+    try:
+        candles = store2.load_candles(
+            instrument=instrument,
+            granularity=timeframe,
+            start=start_chart,
+            end=end_chart,
+        )
+    finally:
+        store2.close()
+
+    if candles.empty:
+        _log.error(
+            "No candles in store for %s/%s. "
+            "Run 'fathom scan' (without --dry-run) first.",
+            instrument,
+            timeframe,
+        )
+        print(
+            f"No candles in store for {instrument}/{timeframe}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_path = render_candidate_chart(
+        candidate=candidate,
+        candles=candles,
+        out_dir=out_dir,
+    )
+    # Print the PNG path to stdout — the caller/Hermes reads it.
+    print(out_path)
+
+    _log.info(
+        "fathom chart finished at %s. PNG: %s",
+        _utc_now_rfc3339(),
+        out_path,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -823,6 +1169,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
     if args.command == "backtest":
         return cmd_backtest(args)
+    if args.command == "scan":
+        return cmd_scan(args)
+    if args.command == "watchlist":
+        return cmd_watchlist(args)
+    if args.command == "chart":
+        return cmd_chart(args)
     parser.error(f"Unknown command: {args.command}")
     return 2  # unreachable — parser.error exits
 

--- a/data/store.py
+++ b/data/store.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     # (store → walkforward → engine → store).  ``write_approved_set`` uses
     # only attribute access on the entries, so a TYPE_CHECKING import is safe.
     from backtest.walkforward import ApprovedSetEntry
+    from signals.ranker import Candidate
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +163,41 @@ class Store:
             (?, ?, ?, ?, ?, ?, ?)
     """
 
+    #: SQL to create the watchlist table — run-timestamped, mirrors the
+    #: ``approved_set`` pattern.  Each row stores one ``Candidate`` from a
+    #: ``fathom scan`` run, identified by ``run_timestamp``.  The INV-13
+    #: Candidate fields are stored as columns; the Candidate model is unchanged.
+    _CREATE_WATCHLIST_SQL: str = """
+        CREATE TABLE IF NOT EXISTS watchlist (
+            run_timestamp    TEXT    NOT NULL,
+            instrument       TEXT    NOT NULL,
+            timeframe        TEXT    NOT NULL,
+            strategy_name    TEXT    NOT NULL,
+            direction        TEXT    NOT NULL,
+            entry_ref        REAL    NOT NULL,
+            stop_distance    REAL    NOT NULL,
+            target_distance  REAL    NOT NULL,
+            oos_sharpe_mean  REAL    NOT NULL,
+            quality_score    REAL    NOT NULL,
+            rank             INTEGER NOT NULL,
+            spread_ok        INTEGER NOT NULL,
+            session_ok       INTEGER NOT NULL,
+            news_flag        INTEGER NOT NULL,
+            generated_at     TEXT    NOT NULL,
+            PRIMARY KEY (run_timestamp, instrument, timeframe, strategy_name)
+        )
+    """
+
+    #: SQL to insert one watchlist row (INSERT OR REPLACE for idempotent re-runs).
+    _INSERT_WATCHLIST_SQL: str = """
+        INSERT OR REPLACE INTO watchlist
+            (run_timestamp, instrument, timeframe, strategy_name, direction,
+             entry_ref, stop_distance, target_distance, oos_sharpe_mean,
+             quality_score, rank, spread_ok, session_ok, news_flag, generated_at)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
     _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
@@ -214,10 +250,12 @@ class Store:
     # ------------------------------------------------------------------
 
     def _create_tables(self) -> None:
-        """Create the ``candles`` and ``instruments`` tables if needed."""
+        """Create the ``candles``, ``instruments``, ``approved_set``, and
+        ``watchlist`` tables if they do not already exist."""
         self._conn.execute(self._CREATE_CANDLES_SQL)
         self._conn.execute(self._CREATE_INSTRUMENTS_SQL)
         self._conn.execute(self._CREATE_APPROVED_SET_SQL)
+        self._conn.execute(self._CREATE_WATCHLIST_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -579,6 +617,132 @@ class Store:
                     "oos_sharpe_mean": row[4],
                     "oos_trade_count_total": row[5],
                     "swap_modelled": bool(row[6]),
+                }
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Watchlist table (Phase 2 — fathom scan persists here; fathom watchlist reads)
+    # ------------------------------------------------------------------
+
+    def write_watchlist(
+        self,
+        candidates: "list[Candidate]",
+        run_timestamp: datetime,
+    ) -> int:
+        """Persist a ranked ``Candidate`` list from ``fathom scan`` (single tx).
+
+        Mirrors the ``write_approved_set`` pattern: all rows for one scan run
+        are inserted in ONE ``executemany`` + ``commit``.  ``INSERT OR REPLACE``
+        keeps a re-run with the same ``run_timestamp`` idempotent.
+
+        The INV-13 ``Candidate`` model is NOT modified; the mapping from model
+        fields → table columns lives here at the persistence layer.
+
+        Args:
+            candidates: The ranked ``Candidate`` list from
+                ``PortfolioLimiter.apply(Ranker.rank(now))``.  May be empty
+                (INV-10: an empty scan is a valid result).
+            run_timestamp: UTC-aware datetime for this scan run, stamped on
+                every row (INV-03).
+
+        Returns:
+            The number of rows written (== ``len(candidates)``).
+        """
+        ts_str = _to_rfc3339(run_timestamp)
+        params = [
+            (
+                ts_str,
+                c.instrument,
+                c.timeframe,
+                c.strategy_name,
+                c.direction,
+                c.entry_ref,
+                c.stop_distance,
+                c.target_distance,
+                c.oos_sharpe_mean,
+                c.quality_score,
+                c.rank,
+                1 if c.spread_ok else 0,
+                1 if c.session_ok else 0,
+                1 if c.news_flag else 0,
+                c.generated_at,
+            )
+            for c in candidates
+        ]
+        self._conn.executemany(self._INSERT_WATCHLIST_SQL, params)
+        self._conn.commit()
+        return len(params)
+
+    def load_watchlist(
+        self,
+        run_timestamp: datetime | None = None,
+    ) -> "list[dict[str, object]]":
+        """Load watchlist rows as plain dicts (each maps to one ``Candidate``).
+
+        Args:
+            run_timestamp: If given, return only rows for that run; otherwise
+                return rows for the **latest** run (highest ``run_timestamp``
+                lexicographically — works because RFC 3339 strings sort
+                correctly).
+
+        Returns:
+            A list of dicts keyed by the INV-13 ``Candidate`` field names
+            (minus ``run_timestamp``, which is DB-internal).  Rows are
+            ordered by ``rank`` ascending.  Empty list when the table has no
+            matching rows.
+        """
+        if run_timestamp is not None:
+            ts_str = _to_rfc3339(run_timestamp)
+            cursor = self._conn.execute(
+                """
+                SELECT instrument, timeframe, strategy_name, direction,
+                       entry_ref, stop_distance, target_distance,
+                       oos_sharpe_mean, quality_score, rank,
+                       spread_ok, session_ok, news_flag, generated_at
+                FROM   watchlist
+                WHERE  run_timestamp = ?
+                ORDER  BY rank ASC
+                """,
+                (ts_str,),
+            )
+        else:
+            # Latest run: MAX(run_timestamp) as a scalar, then fetch its rows.
+            cursor = self._conn.execute(
+                """
+                SELECT instrument, timeframe, strategy_name, direction,
+                       entry_ref, stop_distance, target_distance,
+                       oos_sharpe_mean, quality_score, rank,
+                       spread_ok, session_ok, news_flag, generated_at
+                FROM   watchlist
+                WHERE  run_timestamp = (SELECT MAX(run_timestamp) FROM watchlist)
+                ORDER  BY rank ASC
+                """
+            )
+        result: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            (
+                instrument, timeframe, strategy_name, direction,
+                entry_ref, stop_distance, target_distance,
+                oos_sharpe_mean, quality_score, rank,
+                spread_ok_int, session_ok_int, news_flag_int, generated_at,
+            ) = row
+            result.append(
+                {
+                    "instrument": instrument,
+                    "timeframe": timeframe,
+                    "strategy_name": strategy_name,
+                    "direction": direction,
+                    "entry_ref": float(entry_ref),
+                    "stop_distance": float(stop_distance),
+                    "target_distance": float(target_distance),
+                    "oos_sharpe_mean": float(oos_sharpe_mean),
+                    "quality_score": float(quality_score),
+                    "rank": int(rank),
+                    "spread_ok": bool(spread_ok_int),
+                    "session_ok": bool(session_ok_int),
+                    "news_flag": bool(news_flag_int),
+                    "generated_at": generated_at,
                 }
             )
         return result

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -133,20 +133,30 @@ def _make_namespace(**kwargs: object) -> argparse.Namespace:
 
 class TestNoOrderPath:
     def test_cli_has_no_execution_import(self) -> None:
-        """cli.py must not import execution or risk at module level (INV-01)."""
+        """cli.py must contain no reference to execution/orders/risk.sizing paths
+        anywhere — module-level OR inside function bodies (INV-01).
+
+        The previous approach only inspected ``cli.__dict__`` module attributes,
+        which misses lazy ``from execution import ...`` inside function bodies.
+        This version does a direct source grep so both import styles are caught.
+        """
+        import inspect
         import importlib
-        import types
 
         module = sys.modules.get("cli") or importlib.import_module("cli")
-        for attr_name in dir(module):
-            attr = getattr(module, attr_name, None)
-            if isinstance(attr, types.ModuleType):
-                assert "execution" not in attr.__name__, (
-                    f"cli.py has a live import of execution module: {attr.__name__}"
-                )
-                assert "orders" not in attr.__name__, (
-                    f"cli.py has a live import of orders module: {attr.__name__}"
-                )
+        source = inspect.getsource(module)
+
+        forbidden_patterns = [
+            "execution",
+            "orders",
+            "risk.sizing",
+            "fathom execute",
+        ]
+        for pattern in forbidden_patterns:
+            assert pattern not in source, (
+                f"cli.py contains a reference to forbidden pattern {pattern!r} "
+                f"(INV-01: no execution/order path in the scan surface)"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +313,52 @@ class TestScanCommand:
         # which is never constructed in --dry-run).
         assert "token" not in buf.getvalue().lower()
         assert "api_key" not in buf.getvalue().lower()
+
+    def test_scan_ranker_raises_returns_exit1_and_logs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Ranker.rank() raising must: return 1 (not propagate), log an error.
+
+        Distinct from the empty-approved-set → exit-0 path (INV-10).
+        A genuine exception is NOT a valid empty-set; it must be exit 1.
+        """
+        import logging
+
+        db_path = str(tmp_path / "raise.db")
+
+        args = _make_namespace(
+            command="scan",
+            db_path=db_path,
+            instruments="EUR_USD",
+            timeframes="H1",
+            dry_run=True,
+            history_years=1,
+        )
+
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            mock_ranker_inst = MagicMock()
+            mock_ranker_inst.rank.side_effect = RuntimeError("scoring backend offline")
+            mock_ranker_cls.return_value = mock_ranker_inst
+            mock_limiter_cls.return_value = MagicMock()
+
+            with caplog.at_level(logging.ERROR):
+                rc = cli.cmd_scan(args)
+
+        assert rc == 1, (
+            "cmd_scan must return 1 when Ranker.rank() raises, not propagate the "
+            "exception as a raw traceback"
+        )
+        # A log line at ERROR level must be emitted (the Hermes job can detect it).
+        error_msgs = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_msgs, "Expected at least one ERROR log entry when ranker raises"
+        assert any("scoring backend offline" in m for m in error_msgs), (
+            f"Error message should include the exception text; got: {error_msgs}"
+        )
 
     def test_scan_multiple_candidates_json_shape(self, tmp_path: Path) -> None:
         """scan with two candidates produces correct JSON order and shapes."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,674 @@
+"""Tests for the Phase 2 CLI subcommands: scan, watchlist, chart (P2-T-07).
+
+Design (NO live HTTP)
+---------------------
+* All tests drive ``cli.cmd_scan``, ``cli.cmd_watchlist``, ``cli.cmd_chart``
+  and ``cli.main`` directly — no subprocess.
+* The OANDA client, Settings, and candle fetch are never called (dry-run or
+  patched).  The ranker, portfolio limiter, and chart renderer are exercised
+  against in-memory SQLite + synthetic fixtures.
+* ``--dry-run`` skip for ``cmd_scan`` is exercised explicitly.
+
+Coverage
+--------
+1. ``scan`` runs ranker→portfolio end-to-end, persists to ``watchlist`` table,
+   prints ``Candidate[]`` JSON to stdout; round-trip JSON matches INV-13 shape.
+2. Empty approved-set → empty watchlist, exit 0, clear message (INV-10).
+3. ``watchlist`` re-reads the persisted run; JSON round-trips back to Candidate
+   with correct field names + types (INV-13 shape check).
+4. ``chart <instrument>`` writes a non-empty PNG and prints its path to stdout.
+5. ``backtest`` subcommand still works (not broken).
+6. ``--dry-run scan`` smoke: exits 0 against an empty DB.
+7. No live HTTP, no token logged (INV-08); all timestamps UTC (INV-03).
+8. No order/execution import path (INV-01).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import math
+import os
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+import cli
+from data.oanda_client import CandleRow, InstrumentMeta
+from data.store import Store
+from signals.ranker import Candidate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def _make_candle(
+    instrument: str, granularity: str, t: datetime, price: float
+) -> CandleRow:
+    return CandleRow(
+        instrument=instrument,
+        granularity=granularity,
+        time=t,
+        open_bid=price,
+        high_bid=price + 0.0030,
+        low_bid=price - 0.0030,
+        close_bid=price + 0.0001,
+        open_ask=price + 0.0002,
+        high_ask=price + 0.0032,
+        low_ask=price - 0.0028,
+        close_ask=price + 0.0003,
+        open_mid=price + 0.0001,
+        high_mid=price + 0.0031,
+        low_mid=price - 0.0029,
+        close_mid=price + 0.0002,
+        volume=100,
+        complete=True,
+    )
+
+
+def _populate_h1(store: Store, instrument: str, n_bars: int = 200) -> None:
+    """Insert hourly candles for the given instrument."""
+    base = _utc(2026, 4, 1)
+    rows = []
+    for i in range(n_bars):
+        t = base + timedelta(hours=i)
+        delta = 0.0050 * math.sin(2 * math.pi * i / 48)
+        rows.append(_make_candle(instrument, "H1", t, 1.1000 + delta))
+    store.upsert(rows)
+
+
+def _make_candidate(rank: int = 1, instrument: str = "EUR_USD") -> Candidate:
+    return Candidate(
+        instrument=instrument,
+        timeframe="H1",
+        strategy_name="macrossover_10_50_eur_usd_h1",
+        direction="LONG",
+        entry_ref=1.1050,
+        stop_distance=0.0020,
+        target_distance=0.0030,
+        oos_sharpe_mean=1.5,
+        quality_score=0.75,
+        rank=rank,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=False,
+        generated_at="2026-04-10T12:00:00Z",
+    )
+
+
+def _make_namespace(**kwargs: object) -> argparse.Namespace:
+    """Build an argparse.Namespace with scan/watchlist/chart defaults."""
+    defaults = {
+        "command": "scan",
+        "instruments": "EUR_USD",
+        "timeframes": "H1",
+        "db_path": "/tmp/fathom_test_not_used.db",
+        "history_years": 1,
+        "dry_run": True,
+        "timeframe": "H1",
+        "out_dir": "/tmp/fathom_charts_test",
+        "instrument": "EUR_USD",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# INV-01 guard — no execution import path
+# ---------------------------------------------------------------------------
+
+
+class TestNoOrderPath:
+    def test_cli_has_no_execution_import(self) -> None:
+        """cli.py must not import execution or risk at module level (INV-01)."""
+        import importlib
+        import types
+
+        module = sys.modules.get("cli") or importlib.import_module("cli")
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name, None)
+            if isinstance(attr, types.ModuleType):
+                assert "execution" not in attr.__name__, (
+                    f"cli.py has a live import of execution module: {attr.__name__}"
+                )
+                assert "orders" not in attr.__name__, (
+                    f"cli.py has a live import of orders module: {attr.__name__}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# scan — end-to-end with mocked ranker/limiter
+# ---------------------------------------------------------------------------
+
+
+class TestScanCommand:
+    """Tests for ``cmd_scan`` — mocked Ranker/PortfolioLimiter (no HTTP)."""
+
+    def test_scan_persists_and_prints_json(self, tmp_path: Path) -> None:
+        """scan persists candidates to watchlist table + prints Candidate[] JSON."""
+        db_path = str(tmp_path / "test.db")
+        candidate = _make_candidate()
+
+        args = _make_namespace(
+            command="scan",
+            db_path=db_path,
+            instruments="EUR_USD",
+            timeframes="H1",
+            dry_run=True,  # skip live fetch
+            history_years=1,
+        )
+
+        # Patch lazy-imported modules at their canonical paths (cmd_scan imports
+        # them inside the function body, so we must patch at source module).
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            mock_ranker_inst = MagicMock()
+            mock_ranker_inst.rank.return_value = [candidate]
+            mock_ranker_cls.return_value = mock_ranker_inst
+
+            mock_limiter_inst = MagicMock()
+            mock_limiter_inst.apply.return_value = [candidate]
+            mock_limiter_cls.return_value = mock_limiter_inst
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.cmd_scan(args)
+
+        assert rc == 0
+
+        # Verify the watchlist table was persisted.
+        store = Store(db_path)
+        try:
+            rows = store.load_watchlist()
+        finally:
+            store.close()
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["instrument"] == "EUR_USD"
+        assert row["timeframe"] == "H1"
+        assert row["rank"] == 1
+        assert row["spread_ok"] is True
+        assert row["news_flag"] is False
+
+        # Verify the stdout JSON is a Candidate[] array.
+        output = buf.getvalue().strip()
+        parsed = json.loads(output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        c = parsed[0]
+        # INV-13 field names check.
+        for field in (
+            "instrument", "timeframe", "strategy_name", "direction",
+            "entry_ref", "stop_distance", "target_distance",
+            "oos_sharpe_mean", "quality_score", "rank",
+            "spread_ok", "session_ok", "news_flag", "generated_at",
+        ):
+            assert field in c, f"Missing INV-13 field: {field}"
+
+    def test_scan_empty_approved_set_exits_zero(self, tmp_path: Path) -> None:
+        """Empty approved-set → empty watchlist, exit 0, message on stdout (INV-10)."""
+        db_path = str(tmp_path / "empty.db")
+
+        args = _make_namespace(
+            command="scan",
+            db_path=db_path,
+            instruments="EUR_USD",
+            timeframes="H1",
+            dry_run=True,
+            history_years=1,
+        )
+
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            mock_ranker_inst = MagicMock()
+            mock_ranker_inst.rank.return_value = []  # empty approved-set → []
+            mock_ranker_cls.return_value = mock_ranker_inst
+
+            mock_limiter_inst = MagicMock()
+            mock_limiter_inst.apply.return_value = []
+            mock_limiter_cls.return_value = mock_limiter_inst
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.cmd_scan(args)
+
+        assert rc == 0, "Empty approved-set must exit 0 (INV-10)"
+
+        output = buf.getvalue()
+        assert output.strip(), "Should print a clear message even when empty"
+
+        # Watchlist table should be present but empty.
+        store = Store(db_path)
+        try:
+            rows = store.load_watchlist()
+        finally:
+            store.close()
+        assert rows == []
+
+    def test_dry_run_scan_exits_zero_empty_db(self, tmp_path: Path) -> None:
+        """``--dry-run`` scan against an empty DB exits 0 and emits no tokens."""
+        db_path = str(tmp_path / "dryrun.db")
+
+        args = _make_namespace(
+            command="scan",
+            db_path=db_path,
+            instruments="EUR_USD",
+            timeframes="H1",
+            dry_run=True,
+            history_years=1,
+        )
+
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            mock_ranker_inst = MagicMock()
+            mock_ranker_inst.rank.return_value = []
+            mock_ranker_cls.return_value = mock_ranker_inst
+            mock_limiter_inst = MagicMock()
+            mock_limiter_inst.apply.return_value = []
+            mock_limiter_cls.return_value = mock_limiter_inst
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.cmd_scan(args)
+
+        assert rc == 0
+
+        # INV-08: no token in stdout or stderr (the real token would be in Settings,
+        # which is never constructed in --dry-run).
+        assert "token" not in buf.getvalue().lower()
+        assert "api_key" not in buf.getvalue().lower()
+
+    def test_scan_multiple_candidates_json_shape(self, tmp_path: Path) -> None:
+        """scan with two candidates produces correct JSON order and shapes."""
+        db_path = str(tmp_path / "multi.db")
+        c1 = _make_candidate(rank=1, instrument="EUR_USD")
+        c2 = _make_candidate(rank=2, instrument="GBP_USD")
+
+        args = _make_namespace(
+            command="scan", db_path=db_path, dry_run=True,
+            instruments="EUR_USD,GBP_USD",
+        )
+
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            mock_ranker_inst = MagicMock()
+            mock_ranker_inst.rank.return_value = [c1, c2]
+            mock_ranker_cls.return_value = mock_ranker_inst
+            mock_limiter_inst = MagicMock()
+            mock_limiter_inst.apply.return_value = [c1, c2]
+            mock_limiter_cls.return_value = mock_limiter_inst
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.cmd_scan(args)
+
+        assert rc == 0
+        parsed = json.loads(buf.getvalue().strip())
+        assert len(parsed) == 2
+        assert parsed[0]["instrument"] == "EUR_USD"
+        assert parsed[1]["instrument"] == "GBP_USD"
+
+
+# ---------------------------------------------------------------------------
+# watchlist — re-read persisted run
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistCommand:
+    """Tests for ``cmd_watchlist`` — reads from the SQLite watchlist table."""
+
+    def test_watchlist_round_trips_candidate_json(self, tmp_path: Path) -> None:
+        """watchlist emits valid JSON matching the INV-13 Candidate shape."""
+        db_path = str(tmp_path / "wl.db")
+        run_dt = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+        # Persist a canned candidate directly.
+        candidate = _make_candidate()
+        store = Store(db_path)
+        try:
+            store.write_watchlist([candidate], run_timestamp=run_dt)
+        finally:
+            store.close()
+
+        args = _make_namespace(command="watchlist", db_path=db_path)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_watchlist(args)
+
+        assert rc == 0
+        output = buf.getvalue().strip()
+        parsed = json.loads(output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+        c = parsed[0]
+        # INV-13 field names — exact set.
+        expected_fields = {
+            "instrument", "timeframe", "strategy_name", "direction",
+            "entry_ref", "stop_distance", "target_distance",
+            "oos_sharpe_mean", "quality_score", "rank",
+            "spread_ok", "session_ok", "news_flag", "generated_at",
+        }
+        assert set(c.keys()) == expected_fields, (
+            f"Field mismatch: got {set(c.keys())}, expected {expected_fields}"
+        )
+
+        # Type checks.
+        assert isinstance(c["instrument"], str)
+        assert isinstance(c["timeframe"], str)
+        assert isinstance(c["direction"], str)
+        assert isinstance(c["entry_ref"], float)
+        assert isinstance(c["stop_distance"], float)
+        assert isinstance(c["target_distance"], float)
+        assert isinstance(c["oos_sharpe_mean"], float)
+        assert isinstance(c["quality_score"], float)
+        assert isinstance(c["rank"], int)
+        assert isinstance(c["spread_ok"], bool)
+        assert isinstance(c["session_ok"], bool)
+        assert isinstance(c["news_flag"], bool)
+        assert isinstance(c["generated_at"], str)
+
+        # UTC RFC 3339 format (INV-03).
+        assert c["generated_at"].endswith("Z"), (
+            f"generated_at must end with Z: {c['generated_at']!r}"
+        )
+
+    def test_watchlist_empty_table_prints_empty_array(self, tmp_path: Path) -> None:
+        """Empty watchlist → prints [] and exits 0."""
+        db_path = str(tmp_path / "empty_wl.db")
+        # Just create the DB (tables created on Store init).
+        Store(db_path).close()
+
+        args = _make_namespace(command="watchlist", db_path=db_path)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_watchlist(args)
+
+        assert rc == 0
+        assert json.loads(buf.getvalue().strip()) == []
+
+    def test_watchlist_reads_latest_run(self, tmp_path: Path) -> None:
+        """watchlist reads only the latest run's rows (most recent run_timestamp)."""
+        db_path = str(tmp_path / "two_runs.db")
+        run1 = datetime(2026, 5, 10, 8, 0, 0, tzinfo=timezone.utc)
+        run2 = datetime(2026, 5, 10, 20, 0, 0, tzinfo=timezone.utc)
+
+        old_cand = Candidate(
+            instrument="GBP_USD", timeframe="H1",
+            strategy_name="donchian_20_gbp_usd_h1",
+            direction="SHORT", entry_ref=1.2600,
+            stop_distance=0.0025, target_distance=0.0038,
+            oos_sharpe_mean=0.9, quality_score=0.6, rank=1,
+            spread_ok=True, session_ok=True, news_flag=False,
+            generated_at="2026-05-10T06:00:00Z",
+        )
+        new_cand = _make_candidate()
+
+        store = Store(db_path)
+        try:
+            store.write_watchlist([old_cand], run_timestamp=run1)
+            store.write_watchlist([new_cand], run_timestamp=run2)
+        finally:
+            store.close()
+
+        args = _make_namespace(command="watchlist", db_path=db_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_watchlist(args)
+
+        assert rc == 0
+        parsed = json.loads(buf.getvalue().strip())
+        assert len(parsed) == 1
+        # Should be the latest run's candidate (EUR_USD from run2).
+        assert parsed[0]["instrument"] == "EUR_USD"
+
+    def test_scan_then_watchlist_round_trip(self, tmp_path: Path) -> None:
+        """scan persists; watchlist re-reads; JSON shapes match (INV-13)."""
+        db_path = str(tmp_path / "rt.db")
+        candidate = _make_candidate()
+
+        # Persist via scan mock.
+        scan_args = _make_namespace(command="scan", db_path=db_path, dry_run=True)
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            ranker_inst = MagicMock()
+            ranker_inst.rank.return_value = [candidate]
+            mock_ranker_cls.return_value = ranker_inst
+            limiter_inst = MagicMock()
+            limiter_inst.apply.return_value = [candidate]
+            mock_limiter_cls.return_value = limiter_inst
+
+            scan_buf = io.StringIO()
+            with redirect_stdout(scan_buf):
+                rc_scan = cli.cmd_scan(scan_args)
+
+        assert rc_scan == 0
+        scan_json = json.loads(scan_buf.getvalue().strip())
+
+        # Read back via watchlist.
+        wl_args = _make_namespace(command="watchlist", db_path=db_path)
+        wl_buf = io.StringIO()
+        with redirect_stdout(wl_buf):
+            rc_wl = cli.cmd_watchlist(wl_args)
+
+        assert rc_wl == 0
+        wl_json = json.loads(wl_buf.getvalue().strip())
+
+        # The round-trip must match on all INV-13 fields.
+        assert len(scan_json) == len(wl_json) == 1
+        for field in (
+            "instrument", "timeframe", "strategy_name", "direction",
+            "entry_ref", "stop_distance", "target_distance",
+            "oos_sharpe_mean", "quality_score", "rank",
+            "spread_ok", "session_ok", "news_flag", "generated_at",
+        ):
+            assert scan_json[0][field] == wl_json[0][field], (
+                f"Round-trip mismatch on field {field!r}: "
+                f"scan={scan_json[0][field]!r}, watchlist={wl_json[0][field]!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# chart — PNG creation
+# ---------------------------------------------------------------------------
+
+
+class TestChartCommand:
+    def test_chart_writes_png_prints_path(self, tmp_path: Path) -> None:
+        """chart <instrument> writes a non-empty PNG and prints its path."""
+        db_path = str(tmp_path / "chart.db")
+        out_dir = str(tmp_path / "charts")
+        run_dt = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+        candidate = _make_candidate()
+
+        # Persist the candidate to watchlist and candles to the store.
+        store = Store(db_path)
+        try:
+            _populate_h1(store, "EUR_USD", n_bars=150)
+            store.write_watchlist([candidate], run_timestamp=run_dt)
+        finally:
+            store.close()
+
+        args = _make_namespace(
+            command="chart",
+            instrument="EUR_USD",
+            timeframe="H1",
+            db_path=db_path,
+            out_dir=out_dir,
+            history_years=1,
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_chart(args)
+
+        assert rc == 0
+        png_path = buf.getvalue().strip()
+        assert png_path.endswith(".png"), f"Expected PNG path, got: {png_path!r}"
+        assert os.path.exists(png_path), f"PNG file not created: {png_path!r}"
+        assert os.path.getsize(png_path) > 0, "PNG is empty"
+
+    def test_chart_no_watchlist_entry_exits_nonzero(self, tmp_path: Path) -> None:
+        """chart fails with exit 1 when no watchlist entry exists."""
+        db_path = str(tmp_path / "no_wl.db")
+        # Create an empty DB.
+        Store(db_path).close()
+
+        args = _make_namespace(
+            command="chart",
+            instrument="EUR_USD",
+            timeframe="H1",
+            db_path=db_path,
+            out_dir=str(tmp_path / "charts"),
+            history_years=1,
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_chart(args)
+
+        assert rc != 0
+
+    def test_chart_no_candles_exits_nonzero(self, tmp_path: Path) -> None:
+        """chart fails with exit 1 when candles are missing from the store."""
+        db_path = str(tmp_path / "no_candles.db")
+        run_dt = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+        candidate = _make_candidate()
+        store = Store(db_path)
+        try:
+            # No candles inserted — only the watchlist entry.
+            store.write_watchlist([candidate], run_timestamp=run_dt)
+        finally:
+            store.close()
+
+        args = _make_namespace(
+            command="chart",
+            instrument="EUR_USD",
+            timeframe="H1",
+            db_path=db_path,
+            out_dir=str(tmp_path / "charts"),
+            history_years=1,
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_chart(args)
+
+        assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# backtest not broken
+# ---------------------------------------------------------------------------
+
+
+class TestBacktestUnbroken:
+    """Confirm the existing ``backtest`` subcommand still exits 0 (--dry-run)."""
+
+    def test_backtest_dry_run_empty_db(self, tmp_path: Path) -> None:
+        """``fathom backtest --dry-run`` against an empty DB exits 0."""
+        db_path = str(tmp_path / "backtest.db")
+        args = argparse.Namespace(
+            command="backtest",
+            instruments="EUR_USD",
+            timeframes="H1",
+            strategies="all",
+            workers=1,
+            db_path=db_path,
+            history_years=1,
+            dry_run=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.cmd_backtest(args)
+
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# main() router — all four subcommands registered
+# ---------------------------------------------------------------------------
+
+
+class TestMainRouter:
+    def test_main_routes_scan(self, tmp_path: Path) -> None:
+        """main() routes 'scan' to cmd_scan."""
+        db_path = str(tmp_path / "route_scan.db")
+        with (
+            patch("data.calendar.FairEconomyCalendar") as mock_cal_cls,
+            patch("signals.ranker.Ranker") as mock_ranker_cls,
+            patch("signals.portfolio.PortfolioLimiter") as mock_limiter_cls,
+        ):
+            mock_cal_cls.return_value = MagicMock()
+            ri = MagicMock()
+            ri.rank.return_value = []
+            mock_ranker_cls.return_value = ri
+            li = MagicMock()
+            li.apply.return_value = []
+            mock_limiter_cls.return_value = li
+
+            rc = cli.main([
+                "scan",
+                "--dry-run",
+                "--db-path", db_path,
+                "--instruments", "EUR_USD",
+                "--timeframes", "H1",
+            ])
+        assert rc == 0
+
+    def test_main_routes_watchlist(self, tmp_path: Path) -> None:
+        """main() routes 'watchlist' to cmd_watchlist."""
+        db_path = str(tmp_path / "route_wl.db")
+        Store(db_path).close()
+        rc = cli.main(["watchlist", "--db-path", db_path])
+        assert rc == 0
+
+    def test_main_routes_backtest(self, tmp_path: Path) -> None:
+        """main() routes 'backtest' to cmd_backtest (--dry-run)."""
+        db_path = str(tmp_path / "route_bt.db")
+        rc = cli.main([
+            "backtest",
+            "--dry-run",
+            "--db-path", db_path,
+            "--instruments", "EUR_USD",
+            "--timeframes", "H1",
+        ])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Implements P2-T-07 — the Phase 2 CLI join. Extends `cli.py` with three subcommands that form the Hermes tool surface (INV-01: no order path):

- `fathom scan [--instruments …] [--timeframes …] [--db-path …] [--dry-run]` — refresh candles (reuses Phase 1 fetch path), run `Ranker` → `PortfolioLimiter`, persist ranked `Candidate` list to new `watchlist` SQLite table, print `Candidate[]` JSON to stdout. Empty approved-set → empty watchlist, clear message, exit 0 (INV-10).
- `fathom watchlist [--db-path …]` — read latest persisted watchlist, emit as `Candidate[]` JSON (INV-13 wire shape). Empty table → `[]`, exit 0.
- `fathom chart <instrument> [--timeframe …] [--out-dir …]` — render candidate chart PNG via `render_candidate_chart`, print path.

**Persistence:** `data/store.py` gains `watchlist` table + `write_watchlist` / `load_watchlist`. The `Candidate`↔table mapping lives at the persistence layer; the `Candidate` model is **unchanged** (INV-13 frozen). Table schema mirrors `approved_set` (run-timestamped, single-writer).

**Invariant compliance:** INV-01 (no order import), INV-03 (UTC throughout), INV-08 (no token logged), INV-10 (empty approved-set → exit 0), INV-13 (Candidate unchanged, JSON round-trip asserted in tests).

## Test plan

- [x] `pytest tests/test_cli_commands.py -v` → 16 passed, exit 0
- [x] `pytest -q` (full suite) → 624 passed, 85 warnings (pre-existing), exit 0
- [x] `mypy cli.py data/store.py` → "Success: no issues found in 2 source files", exit 0
- [x] `fathom scan --dry-run --db-path /tmp/x.db --instruments EUR_USD --timeframes H1` → empty-watchlist message, exit 0
- [x] `backtest` subcommand unbroken (test_backtest_dry_run_empty_db passes)

Closes #57.