### PR TITLE
P2-T-06: hermes daily job artefacts

### DIFF
--- a/.claude/context/hermes_integration.md
+++ b/.claude/context/hermes_integration.md
@@ -109,3 +109,71 @@ does not need updating for offline unit tests.
 
 **New dependency added to pyproject.toml?** NO (no new deps; pydantic already present).
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P2-T-06 — 2026-05-29 (feat/p2-t-06)
+
+**What was done:**
+- Created `hermes_integration/jobs/daily.md` — the plain-English Hermes daily job
+  definition with:
+  - Trigger: weekday, post-NY-close (22:00 UTC default), cron `0 22 * * 1-5`.
+  - 5 ordered step headings:
+    1. `fathom scan` (stdout JSON directly — NOT `fathom watchlist`)
+    2. Per-candidate Claude news-risk via `parse_news_risk` (INV-02):
+       skip→veto / reduce_size→flag / proceed→keep
+    3. `fathom chart <instrument>` per surviving candidate
+    4. Claude narration via `should_use_fallback` + `fallback_narration` (cosmetic, NOT INV-02)
+    5. Deliver ranked watchlist + charts to Discord via Hermes gateway
+  - Failure modes table: empty watchlist → "no candidates today" (INV-10); malformed Claude
+    → skip (INV-02); narration failure → fallback (candidate kept, not vetoed); chart failure
+    → skip chart, candidate kept; Discord failure → retry per Hermes gateway.
+  - Operator runbook: register job in Hermes, wire CLI as tool (scan/watchlist/chart ONLY —
+    INV-01), connect Discord gateway + Anthropic key via .env (never committed — INV-08),
+    dry-run verification steps, T-08 acceptance gate note.
+  - Allowed tools table: `fathom scan`, `fathom watchlist`, `fathom chart`. No execute/orders/risk.
+- Created `tests/test_hermes_job.py` — 42 lint assertions:
+  - File existence.
+  - Ordered step headings (anchored to `^### Step N` — avoids inline "go to Step 5" false matches).
+  - Each step contains its expected content (scan/news-risk/chart/narration/deliver).
+  - Allowed tools referenced (scan/watchlist/chart).
+  - Forbidden tools absent: `fathom execute`, `fathom orders`, `fathom risk` (INV-01).
+  - Hermes-never-places-orders statement present (INV-01).
+  - INV-01 boundary in operator runbook section.
+  - skip→veto / reduce_size→flag / proceed→keep mapping.
+  - Empty-watchlist path + "no candidates today" message + exit 0 (INV-10).
+  - Malformed-Claude → skip (INV-02); fallback_narration present; narration keeps candidate.
+  - Operator runbook: registration, CLI-as-tool, Discord, Anthropic key, .env-never-committed.
+  - No hardcoded secrets in file (INV-08).
+  - scan stdout primary / watchlist as persisted-read accessor.
+
+**INV-01 design decision:**
+- `daily.md` allowed-tools table and operator runbook both explicitly name `scan`, `watchlist`,
+  `chart` as the only permitted tools. The runbook states: "Never register any order, execute,
+  or risk tool". `fathom execute`, `fathom orders`, `fathom risk` do not appear in the file.
+- The lint test has 5 dedicated INV-01 assertions + an ordered-step content check.
+
+**AMBIGUOUS-03 resolution confirmed:**
+- Step 1 explicitly states: "Use `fathom scan`'s stdout directly — do NOT call `fathom watchlist`
+  as the primary source." (`fathom watchlist` is the persisted-read accessor for re-reads / Phase 5.)
+
+**AMBIGUOUS-01 resolution confirmed:**
+- Step 2 notes that `fathom scan` has already applied the deterministic news gate (high-impact →
+  dropped, medium → `news_flag: true`); the Claude news-risk step is the finer qualitative veto
+  on survivors. Two layers explicitly described as non-contradictory.
+
+**No anthropic SDK dep** (D-P2-3 enforced — Hermes calls Claude; Fathom owns parsers).
+**pyproject.toml untouched** — configuration artefact only; no new dependencies.
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
+
+**AC verification results:**
+- `pytest tests/test_hermes_job.py -v` → 42 passed, exit 0
+- `pytest -q` (full suite) → 667 passed, exit 0
+- `mypy tests/test_hermes_job.py` → "Success: no issues found in 1 source file", exit 0
+- `mypy hermes_integration/` → "Success: no issues found in 3 source files", exit 0
+- Pre-existing mypy errors (87, in test_news_risk/test_ranker/test_charts from prior tasks) — not introduced by T-06.
+
+**New dependency added to pyproject.toml?** NO.
+**New CLI command?** NO.
+**PR:** https://github.com/saambaby/fathom/pull/67
+**Merge plan:** `gh pr merge 67 --squash --delete-branch` (lead action after reviewer pass)

--- a/hermes_integration/jobs/daily.md
+++ b/hermes_integration/jobs/daily.md
@@ -1,0 +1,340 @@
+# Fathom Daily Watchlist Job
+
+**Job type:** Hermes scheduled job (plain-English definition)
+**Phase:** Phase 2 — Watchlist → Discord
+**Last updated:** 2026-05-29
+**Invariants:** INV-01, INV-02, INV-08, INV-10
+
+---
+
+## Purpose
+
+Deliver a ranked, Claude-enriched watchlist to the trader's Discord channel on
+each weekday after the major session close. Hermes runs the Fathom CLI to
+produce candidates, applies a qualitative Claude news-risk veto per candidate,
+renders a chart PNG per survivor, generates a one-line Claude narration per
+chart, and posts the full bundle to Discord.
+
+**The job ends at Discord delivery. Hermes never places orders (INV-01).**
+
+---
+
+## Trigger
+
+- **Schedule:** Monday–Friday (weekdays only; skip weekend days).
+- **Time:** Post-New-York-session close — default `22:00` in the operator's
+  local timezone (recommended: configure as UTC, e.g. `22:00 UTC`). Adjust to
+  post-London or post-Tokyo as preferred.
+- **Hermes cron expression (example, UTC):**
+  ```
+  0 22 * * 1-5
+  ```
+  Change `22` to the hour that aligns with your preferred session close.
+
+---
+
+## Allowed Fathom CLI tools (INV-01)
+
+Hermes is granted access to **exactly three** Fathom CLI subcommands:
+
+| Tool | Purpose |
+|------|---------|
+| `fathom scan` | Refresh candles, rank approved strategies, apply portfolio limits, emit `Candidate[]` JSON on stdout. |
+| `fathom watchlist` | Re-read the latest persisted watchlist (for manual re-runs or re-delivery). |
+| `fathom chart <instrument>` | Render a chart PNG for one instrument; print the PNG path to stdout. |
+
+**Hermes must NOT be given access to any order, execution, or risk tool.**
+`execution/orders.py` and any order-placement API are explicitly off-limits.
+Permitted tool references: `scan`, `watchlist`, `chart` — no others.
+
+This boundary is the canonical INV-01 enforcement point. The worst a
+prompt-injected headline can do is produce a bad *suggestion* that gets
+vetoed or down-ranked; it can never produce a bad *trade* because Hermes
+holds no order authority.
+
+---
+
+## Ordered job steps
+
+### Step 1 — Run `fathom scan`
+
+```
+fathom scan [--db-path <path>] [--timeframes H1,H4,D]
+```
+
+- Reads the approved-set from the SQLite store (the INV-10 gate).
+- Refreshes candles from OANDA (unless `--dry-run`).
+- Runs `Ranker` → `PortfolioLimiter`.
+- **Persists the ranked `Candidate[]` to the watchlist table.**
+- Emits `Candidate[]` JSON on **stdout** (INV-13 shape).
+
+**Use `fathom scan`'s stdout directly — do NOT call `fathom watchlist` as the
+primary source.** (`fathom watchlist` is the persisted-read accessor for
+re-reads and the Phase 5 panel; the daily job consumes the fresh stdout JSON.)
+
+> **Empty watchlist (INV-10):** if `fathom scan` emits the empty-watchlist
+> message (no JSON array or an empty `[]`), skip all remaining per-candidate
+> steps and go directly to Step 5 — post "no candidates today" to Discord.
+> Exit 0. This is a valid result, not an error.
+
+The `Candidate[]` JSON already embeds the deterministic news gate:
+- High-impact calendar events within the trade window → candidate already
+  **dropped** before this step.
+- Medium-impact events within the trade window → `news_flag: true` on the
+  candidate (still present in stdout).
+
+---
+
+### Step 2 — Per-candidate news-risk assessment (Claude, per-candidate loop)
+
+For **each** candidate in the stdout JSON, call Claude with the
+`hermes_integration/prompts/news_risk.md` prompt template, substituting:
+
+| Placeholder | Source |
+|-------------|--------|
+| `{{instrument}}` | `candidate.instrument` |
+| `{{base_currency}}` | first 3 chars of `candidate.instrument` |
+| `{{quote_currency}}` | last 3 chars of `candidate.instrument` |
+| `{{direction}}` | `candidate.direction` |
+| `{{entry_window_utc}}` | estimated entry window (UTC, RFC 3339) |
+| `{{calendar_events}}` | upcoming events from the economic calendar |
+
+Parse Claude's response with `parse_news_risk(raw: str) -> NewsRiskVerdict`
+from `hermes_integration/news_risk.py` (INV-02 enforcement boundary):
+
+| `suggest_action` | Action |
+|------------------|--------|
+| `"skip"` | **Veto the candidate.** Remove it from the list; do not render chart or narration. |
+| `"reduce_size"` | **Flag the candidate.** Keep it; mark it with a `reduce_size` flag for the Discord post. |
+| `"proceed"` | **Keep the candidate unchanged.** |
+
+> **Malformed/unavailable Claude response (INV-02):** `parse_news_risk`
+> defaults to `suggest_action="skip"` on any parse, validation, or network
+> failure. The candidate is vetoed. This is the safe default — a missed
+> opportunity is cheaper than an unchecked trade. The caller must never catch
+> this and substitute "proceed".
+
+After Step 2, the candidate list contains only `proceed` and `reduce_size`
+survivors.
+
+---
+
+### Step 3 — Chart generation (per surviving candidate)
+
+For **each** surviving candidate (not vetoed in Step 2), call:
+
+```
+fathom chart <instrument> [--timeframe <tf>] [--db-path <path>]
+```
+
+where `<instrument>` is `candidate.instrument` and `<tf>` is
+`candidate.timeframe`.
+
+- Returns the PNG file path on stdout.
+- The PNG shows entry/stop/target levels and the signal bar.
+
+> **Chart failure:** if `fathom chart` exits non-zero or produces no path,
+> skip the chart for that candidate (log the failure). The candidate remains
+> on the watchlist — chart failure is non-fatal. Proceed to narration for
+> that candidate without a chart attachment.
+
+---
+
+### Step 4 — Narration (Claude, per surviving candidate)
+
+For **each** surviving candidate, call Claude with the
+`hermes_integration/prompts/narration.md` prompt template, substituting:
+
+| Placeholder | Source |
+|-------------|--------|
+| `{{instrument}}` | `candidate.instrument` |
+| `{{timeframe}}` | `candidate.timeframe` |
+| `{{strategy_name}}` | `candidate.strategy_name` |
+| `{{direction}}` | `candidate.direction` |
+| `{{oos_sharpe_mean}}` | `candidate.oos_sharpe_mean` |
+| `{{news_flag}}` | `candidate.news_flag` |
+
+Claude returns exactly one plain-English line (no JSON, no markdown).
+
+**Usability check (not INV-02):** use `should_use_fallback(claude_response)`
+from `hermes_integration/narration.py`:
+
+- If `True` (empty, whitespace-only, or over 280 chars) → substitute
+  `fallback_narration(candidate)` from `hermes_integration/narration.py`.
+- If `False` → use Claude's response directly.
+
+> **Narration failure is cosmetic only — the candidate is always kept.**
+> Unlike news-risk (INV-02), a narration hiccup does NOT veto the candidate.
+> The fallback is a deterministic one-liner built from the candidate's own
+> fields; it is always non-empty and never raises.
+
+---
+
+### Step 5 — Deliver to Discord via Hermes gateway
+
+Assemble the message and post to the configured Discord channel:
+
+**Non-empty watchlist format (per candidate, ranked by `rank` field):**
+
+```
+[rank]. <instrument> <timeframe> | <strategy_name> | <direction>
+  <narration_line>
+  [NEWS FLAG: reduce_size] (only if reduce_size from Step 2)
+  [Attachment: chart PNG] (if chart rendered successfully in Step 3)
+```
+
+**Empty watchlist:**
+
+```
+Fathom daily scan — no candidates today. (YYYY-MM-DD UTC)
+```
+
+Post this message even if the scan produced zero candidates (INV-10).
+
+> **Discord delivery failure:** retry per Hermes' gateway retry policy. The
+> watchlist is persisted by `fathom scan` in the SQLite store regardless; it
+> can be re-read via `fathom watchlist` for a manual re-delivery. Delivery
+> failure does not constitute a job failure from Fathom's perspective.
+
+---
+
+## Failure modes and safe defaults
+
+| Failure | Behaviour |
+|---------|-----------|
+| `fathom scan` empty watchlist | Post "no candidates today" to Discord; exit 0. |
+| `fathom scan` exits non-zero | Abort job; post error notice to Discord (optional); log. |
+| Claude news-risk malformed/unavailable | `parse_news_risk` returns `skip`; candidate vetoed (INV-02). |
+| Claude narration malformed/unavailable | Use `fallback_narration`; candidate kept (NOT INV-02). |
+| `fathom chart` non-zero exit | Skip chart for that candidate; candidate kept; log. |
+| Discord delivery failure | Retry per Hermes gateway policy; watchlist persisted for re-read. |
+| Prompt injection in calendar headline | Can produce at most a bad suggestion that gets vetoed/down-ranked; can never produce a trade (INV-01). |
+
+---
+
+## Operator runbook
+
+### Prerequisites
+
+Before registering this job, ensure the following are available:
+
+1. **Hermes Agent** — a running Hermes instance with cron scheduling enabled.
+2. **Fathom CLI** — installed in a virtualenv accessible to Hermes:
+   ```
+   pip install -e /path/to/fathom
+   ```
+   Verify: `fathom --help` lists `scan`, `watchlist`, `chart`, `backtest`.
+3. **Fathom data store populated** — run at least one `fathom backtest` and
+   `fathom scan` (with live OANDA credentials) to seed the approved-set and
+   candle cache before the first Hermes run.
+4. **Discord webhook or bot token** — a Discord channel where the watchlist
+   will be posted.
+5. **Anthropic API key** — for Hermes' Claude calls (news-risk + narration).
+
+### Credentials and secrets (INV-08)
+
+All secrets live in Hermes' `.env` file (never committed to git):
+
+```
+# Hermes .env — never commit this file
+ANTHROPIC_API_KEY=sk-ant-...
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+# (or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID for bot approach)
+
+# Fathom-side (if Hermes calls fathom scan live — not --dry-run)
+OANDA_API_KEY=...
+OANDA_ACCOUNT_ID=...
+OANDA_ENV=practice
+```
+
+Hermes passes these to its tool calls via environment injection — never as
+CLI arguments and never logged.
+
+### Registering the job in Hermes
+
+1. Copy this file (`hermes_integration/jobs/daily.md`) into your Hermes jobs
+   directory (or reference it directly, per your Hermes deployment).
+
+2. Register the `fathom` CLI as a Hermes tool with the following tool
+   definition. **Grant access to `scan`, `watchlist`, and `chart` only:**
+
+   ```yaml
+   tools:
+     fathom_scan:
+       command: fathom scan
+       description: "Refresh candles, rank approved strategies, emit Candidate[] JSON."
+       allowed_args: ["--instruments", "--timeframes", "--db-path", "--history-years", "--dry-run"]
+
+     fathom_watchlist:
+       command: fathom watchlist
+       description: "Re-read the latest persisted watchlist as Candidate[] JSON."
+       allowed_args: ["--db-path"]
+
+     fathom_chart:
+       command: fathom chart
+       description: "Render a chart PNG for one instrument; print its path to stdout."
+       allowed_args: ["instrument", "--timeframe", "--db-path", "--out-dir", "--history-years"]
+   ```
+
+   **Do NOT register `fathom backtest` as a Hermes tool** (it's a one-off
+   operator command, not part of the daily pipeline). **Never register any
+   order, execute, or risk tool** — `execution/orders.py` and any
+   order-placement or risk-sizing API must not be registered as Hermes tools
+   (INV-01). Do not grant Hermes execute or order tool access.
+
+3. Register the Claude prompt paths in Hermes' tool config:
+   - News-risk prompt: `hermes_integration/prompts/news_risk.md`
+   - Narration prompt: `hermes_integration/prompts/narration.md`
+
+4. Register the Discord delivery gateway with the `DISCORD_WEBHOOK_URL` (or
+   bot token + channel ID) from `.env`.
+
+5. Register the cron schedule. Example (22:00 UTC, weekdays):
+   ```
+   0 22 * * 1-5
+   ```
+
+### Wiring the response parsers
+
+Hermes calls Claude and receives the raw JSON/text response. It must pass
+those responses through Fathom's parsers before acting on them:
+
+- **News-risk:** call `parse_news_risk(raw)` from
+  `hermes_integration/news_risk.py`. Never bypass this parser or treat a raw
+  Claude string as a trusted verdict.
+- **Narration:** call `should_use_fallback(claude_response)` from
+  `hermes_integration/narration.py`. If True, call `fallback_narration(candidate)`.
+
+Both modules are importable from the installed `fathom` package; Hermes can
+call them as Python library calls or via a small wrapper script. No `anthropic`
+SDK import is needed in Fathom (D-P2-3).
+
+### Verifying the setup (dry-run)
+
+Before the first live run, perform a dry-run to confirm the tool chain works:
+
+```bash
+# 1. Confirm fathom scan (dry-run, against cached data) works and emits JSON.
+fathom scan --dry-run
+
+# 2. Confirm fathom watchlist re-reads the persisted output.
+fathom watchlist
+
+# 3. Confirm fathom chart works for one instrument in the watchlist.
+fathom chart EUR_USD --timeframe H1
+```
+
+Check that step 1 emits valid `Candidate[]` JSON (or the empty-watchlist
+message), step 2 re-reads it, and step 3 emits a PNG path.
+
+### Acceptance gate (T-08)
+
+Live acceptance requires a human operator to:
+
+1. Configure a real Hermes instance with the above setup.
+2. Confirm the watchlist lands coherently in Discord on **≥5 consecutive
+   weekday runs** (charts + Claude rationale + news flags present; empty days
+   post "no candidates"; a `skip` verdict vetoes; no secret token in output).
+3. Record the results in `docs/phases/phase-2-results.md`.
+
+This is a manual, human-admin gate (D-P2-5) — it cannot be automated.

--- a/tests/test_hermes_job.py
+++ b/tests/test_hermes_job.py
@@ -1,0 +1,456 @@
+"""Lint tests for hermes_integration/jobs/daily.md (P2-T-06).
+
+Verifies the artefact's structural requirements without invoking Hermes,
+Claude, Discord, or any live service. Pure file-content assertions.
+
+Invariants checked:
+    INV-01: job references only allowed tools (scan / watchlist / chart);
+            no execute / order / risk tool references.
+    INV-02: skip→veto / reduce_size→flag / proceed→keep mapping present;
+            malformed-Claude safe path specified.
+    INV-10: empty-watchlist safe path specified ("no candidates").
+    INV-08: operator runbook present (credentials section); no hardcoded secrets.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate the artefact
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_JOB_PATH = _REPO_ROOT / "hermes_integration" / "jobs" / "daily.md"
+
+
+@pytest.fixture(scope="module")
+def job_text() -> str:
+    """Return the full text of daily.md."""
+    assert _JOB_PATH.exists(), (
+        f"hermes_integration/jobs/daily.md not found at {_JOB_PATH}. "
+        "The artefact must be created before running this test."
+    )
+    return _JOB_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. File existence
+# ---------------------------------------------------------------------------
+
+
+def test_daily_md_exists() -> None:
+    """daily.md must exist in hermes_integration/jobs/."""
+    assert _JOB_PATH.exists(), f"Missing: {_JOB_PATH}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Ordered steps: scan → news-risk → chart → narration → deliver
+# ---------------------------------------------------------------------------
+
+
+class TestOrderedSteps:
+    """The five pipeline steps must appear in document order.
+
+    We anchor on the numbered Step headings (e.g. "### Step 1", "Step 2 —")
+    rather than on first-occurrence of a keyword, so that introductory prose
+    that mentions all five terms doesn't confuse the ordering check.
+    """
+
+    def _step_position(self, text: str, step_num: int) -> int:
+        """Return the character offset of the numbered step heading (section header only).
+
+        Matches "### Step N" or "## Step N" heading lines, not inline references
+        to a step number (e.g. "go to Step 5" in body text).
+        """
+        # Require the step to appear at the start of a line after '#' heading markers.
+        pattern = rf"^#+\s+Step\s+{step_num}\b"
+        m = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+        assert m is not None, f"Step {step_num} section heading not found in daily.md"
+        return m.start()
+
+    def _section_text(self, text: str, step_num: int) -> str:
+        """Return the text of one numbered step section (heading-anchored)."""
+        start = self._step_position(text, step_num)
+        # Find the next step heading (anchored) or a horizontal rule
+        next_match = re.search(
+            rf"^#+\s+Step\s+{step_num + 1}\b|^---",
+            text[start + 1 :],
+            re.IGNORECASE | re.MULTILINE,
+        )
+        end = start + 1 + next_match.start() if next_match else len(text)
+        return text[start:end]
+
+    def test_scan_step_present(self, job_text: str) -> None:
+        assert re.search(r"fathom scan", job_text), "scan step missing"
+
+    def test_news_risk_step_present(self, job_text: str) -> None:
+        # Step 2 heading must mention news-risk
+        step2 = self._section_text(job_text, 2)
+        assert re.search(r"news.?risk", step2, re.IGNORECASE), (
+            "news-risk content missing from Step 2"
+        )
+
+    def test_chart_step_present(self, job_text: str) -> None:
+        assert re.search(r"fathom chart", job_text), "chart step missing"
+
+    def test_narration_step_present(self, job_text: str) -> None:
+        assert re.search(r"narration", job_text, re.IGNORECASE), "narration step missing"
+
+    def test_deliver_step_present(self, job_text: str) -> None:
+        assert re.search(r"deliver|discord", job_text, re.IGNORECASE), (
+            "delivery step (Discord) missing"
+        )
+
+    def test_steps_in_order(self, job_text: str) -> None:
+        """Step 1 (scan) < Step 2 (news-risk) < Step 3 (chart) < Step 4 (narration)
+        < Step 5 (deliver) — using the numbered step headings as anchors."""
+        pos_step1 = self._step_position(job_text, 1)
+        pos_step2 = self._step_position(job_text, 2)
+        pos_step3 = self._step_position(job_text, 3)
+        pos_step4 = self._step_position(job_text, 4)
+        pos_step5 = self._step_position(job_text, 5)
+
+        assert pos_step1 < pos_step2, "Step 1 (scan) must precede Step 2 (news-risk)"
+        assert pos_step2 < pos_step3, "Step 2 (news-risk) must precede Step 3 (chart)"
+        assert pos_step3 < pos_step4, "Step 3 (chart) must precede Step 4 (narration)"
+        assert pos_step4 < pos_step5, "Step 4 (narration) must precede Step 5 (deliver)"
+
+    def test_step1_is_scan(self, job_text: str) -> None:
+        step1 = self._section_text(job_text, 1)
+        assert re.search(r"fathom scan", step1), "Step 1 must contain 'fathom scan'"
+
+    def test_step2_is_news_risk(self, job_text: str) -> None:
+        step2 = self._section_text(job_text, 2)
+        assert re.search(r"news.?risk", step2, re.IGNORECASE), (
+            "Step 2 must be the news-risk assessment step"
+        )
+
+    def test_step3_is_chart(self, job_text: str) -> None:
+        step3 = self._section_text(job_text, 3)
+        assert re.search(r"fathom chart", step3), "Step 3 must contain 'fathom chart'"
+
+    def test_step4_is_narration(self, job_text: str) -> None:
+        step4 = self._section_text(job_text, 4)
+        assert re.search(r"narration", step4, re.IGNORECASE), (
+            "Step 4 must be the narration step"
+        )
+
+    def test_step5_is_deliver(self, job_text: str) -> None:
+        step5 = self._section_text(job_text, 5)
+        assert re.search(r"deliver|discord", step5, re.IGNORECASE), (
+            "Step 5 must be the delivery step"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Allowed tools — scan / watchlist / chart present (INV-01)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedTools:
+    def test_scan_referenced(self, job_text: str) -> None:
+        assert "scan" in job_text, "daily.md must reference fathom scan"
+
+    def test_watchlist_referenced(self, job_text: str) -> None:
+        assert "watchlist" in job_text, "daily.md must reference fathom watchlist"
+
+    def test_chart_referenced(self, job_text: str) -> None:
+        assert "chart" in job_text, "daily.md must reference fathom chart"
+
+
+# ---------------------------------------------------------------------------
+# 4. Forbidden tool references (INV-01) — no execute / orders / risk as tools
+# ---------------------------------------------------------------------------
+
+
+class TestForbiddenTools:
+    """INV-01: execution/order tools must not be callable from Hermes.
+
+    We grep for the specific patterns that would indicate Hermes has been
+    granted order-placement authority. We do NOT ban the words in general
+    (e.g. the runbook legitimately mentions 'orders.py' to say it is
+    off-limits) — we ban them appearing as Hermes *tool* registrations or
+    as callable CLI commands.
+
+    Strategy: look for positive tool-granting phrases around these keywords.
+    Also assert that no fathom subcommand named 'execute', 'order', or 'risk'
+    is registered as a tool.
+    """
+
+    def test_no_fathom_execute_tool(self, job_text: str) -> None:
+        """fathom execute must not appear as a registered/callable tool."""
+        # Allow 'fathom execute' only if it is inside a note that it is forbidden.
+        # Simplest: the phrase 'fathom execute' must not appear at all — the CLI
+        # has no such subcommand; if it appears it's a spec error.
+        assert not re.search(r"\bfathom execute\b", job_text), (
+            "INV-01 violation: 'fathom execute' must not appear in daily.md"
+        )
+
+    def test_no_fathom_orders_tool(self, job_text: str) -> None:
+        """fathom orders must not appear as a registered/callable tool."""
+        assert not re.search(r"\bfathom orders\b", job_text), (
+            "INV-01 violation: 'fathom orders' must not appear in daily.md"
+        )
+
+    def test_no_fathom_risk_tool(self, job_text: str) -> None:
+        """fathom risk must not appear as a registered/callable tool."""
+        assert not re.search(r"\bfathom risk\b", job_text), (
+            "INV-01 violation: 'fathom risk' must not appear in daily.md"
+        )
+
+    def test_no_execute_in_allowed_tools_table(self, job_text: str) -> None:
+        """The allowed-tools table must not list 'execute' as an allowed tool."""
+        # Find the allowed-tools section and assert 'execute' is not in it.
+        # The table heading is "Allowed Fathom CLI tools".
+        m = re.search(
+            r"Allowed Fathom CLI tools.*?(?=\n#|\Z)",
+            job_text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if m:
+            section = m.group(0)
+            assert "execute" not in section.lower(), (
+                "INV-01 violation: 'execute' listed in allowed-tools section"
+            )
+
+    def test_no_order_in_allowed_tools_table(self, job_text: str) -> None:
+        """The allowed-tools table must not list 'order' as an allowed entry."""
+        m = re.search(
+            r"Allowed Fathom CLI tools.*?(?=\n#|\Z)",
+            job_text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if m:
+            section = m.group(0)
+            # 'order' in a tool-listing context — not in an exclusion note
+            # We look for 'fathom_order' or '| order' table cell patterns
+            assert not re.search(r"fathom_order|\|\s*order\b", section, re.IGNORECASE), (
+                "INV-01 violation: order tool listed in allowed-tools section"
+            )
+
+    def test_hermes_never_places_orders_stated(self, job_text: str) -> None:
+        """The doc must explicitly state Hermes never places orders (INV-01)."""
+        assert re.search(
+            r"hermes.{0,40}(never|not|no).{0,40}(order|trade|place|execute)",
+            job_text,
+            re.IGNORECASE,
+        ), (
+            "INV-01 boundary statement missing: "
+            "document must state Hermes never places orders"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. News-risk verdict mapping: skip→veto / reduce_size→flag / proceed→keep
+# ---------------------------------------------------------------------------
+
+
+class TestNewsRiskMapping:
+    def test_skip_veto_mapping(self, job_text: str) -> None:
+        assert re.search(r"skip.{0,80}veto|veto.{0,80}skip", job_text, re.IGNORECASE), (
+            "skip→veto mapping missing from daily.md"
+        )
+
+    def test_reduce_size_flag_mapping(self, job_text: str) -> None:
+        assert re.search(
+            r"reduce_size.{0,80}flag|flag.{0,80}reduce_size",
+            job_text,
+            re.IGNORECASE,
+        ), "reduce_size→flag mapping missing from daily.md"
+
+    def test_proceed_keep_mapping(self, job_text: str) -> None:
+        assert re.search(
+            r"proceed.{0,80}keep|keep.{0,80}proceed",
+            job_text,
+            re.IGNORECASE,
+        ), "proceed→keep mapping missing from daily.md"
+
+    def test_all_three_verdicts_in_table(self, job_text: str) -> None:
+        """All three verdict values must be mentioned."""
+        for verdict in ("skip", "reduce_size", "proceed"):
+            assert verdict in job_text, f"verdict '{verdict}' not in daily.md"
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty-watchlist safe path (INV-10)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyWatchlist:
+    def test_empty_watchlist_path_specified(self, job_text: str) -> None:
+        assert re.search(
+            r"empty.{0,80}watchlist|no candidates",
+            job_text,
+            re.IGNORECASE,
+        ), "Empty-watchlist safe path missing from daily.md"
+
+    def test_no_candidates_today_message(self, job_text: str) -> None:
+        assert re.search(r"no candidates today", job_text, re.IGNORECASE), (
+            "daily.md must specify 'no candidates today' message for empty watchlist"
+        )
+
+    def test_empty_watchlist_exits_zero(self, job_text: str) -> None:
+        assert re.search(r"exit 0", job_text, re.IGNORECASE), (
+            "daily.md must specify exit 0 for empty watchlist (INV-10)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Malformed-Claude safe path (INV-02)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedClaudeSafePath:
+    def test_malformed_claude_path_specified(self, job_text: str) -> None:
+        assert re.search(
+            r"malformed|unavailable|parse.{0,30}fail",
+            job_text,
+            re.IGNORECASE,
+        ), "Malformed-Claude safe path missing from daily.md"
+
+    def test_inv02_safe_default_skip_stated(self, job_text: str) -> None:
+        """doc must state that malformed Claude response defaults to skip."""
+        assert re.search(
+            r"(malformed|unavailable|parse).{0,120}skip",
+            job_text,
+            re.IGNORECASE,
+        ), (
+            "INV-02 safe default (malformed→skip) not stated in daily.md"
+        )
+
+    def test_narration_fallback_path_specified(self, job_text: str) -> None:
+        """Narration fallback (not a veto) must be specified."""
+        assert re.search(
+            r"fallback_narration|fallback narration",
+            job_text,
+            re.IGNORECASE,
+        ), "fallback_narration safe path missing from daily.md"
+
+    def test_narration_failure_keeps_candidate(self, job_text: str) -> None:
+        """Narration failure must keep the candidate (NOT INV-02 veto)."""
+        assert re.search(
+            r"narration.{0,120}(keep|kept|always kept|candidate.{0,40}kept)",
+            job_text,
+            re.IGNORECASE,
+        ), (
+            "daily.md must state that narration failure keeps the candidate "
+            "(narration is cosmetic — not an INV-02 veto)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Operator runbook section present (INV-08)
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorRunbook:
+    def test_runbook_section_present(self, job_text: str) -> None:
+        assert re.search(r"operator runbook", job_text, re.IGNORECASE), (
+            "Operator runbook section missing from daily.md"
+        )
+
+    def test_runbook_register_job_instruction(self, job_text: str) -> None:
+        assert re.search(
+            r"register.{0,60}(job|hermes)|hermes.{0,60}register",
+            job_text,
+            re.IGNORECASE,
+        ), "Runbook must explain how to register the job in Hermes"
+
+    def test_runbook_fathom_cli_as_tool(self, job_text: str) -> None:
+        assert re.search(
+            r"(fathom.{0,20}(cli|tool)|tool.{0,20}fathom)",
+            job_text,
+            re.IGNORECASE,
+        ), "Runbook must explain how to point Hermes at the fathom CLI as a tool"
+
+    def test_runbook_discord_gateway(self, job_text: str) -> None:
+        assert re.search(r"discord", job_text, re.IGNORECASE), (
+            "Runbook must mention Discord gateway connection"
+        )
+
+    def test_runbook_anthropic_key(self, job_text: str) -> None:
+        assert re.search(r"anthropic.{0,30}key|ANTHROPIC_API_KEY", job_text), (
+            "Runbook must mention Anthropic key configuration"
+        )
+
+    def test_secrets_in_env_not_committed(self, job_text: str) -> None:
+        """Runbook must state secrets go in .env and are never committed (INV-08)."""
+        assert re.search(
+            r"\.env.{0,80}(never commit|not commit|gitignore)|"
+            r"(never commit|not commit).{0,80}\.env",
+            job_text,
+            re.IGNORECASE,
+        ), (
+            "INV-08: runbook must state credentials live in .env and are never committed"
+        )
+
+    def test_no_hardcoded_secrets_in_file(self, job_text: str) -> None:
+        """The file must contain no hardcoded secret values (INV-08)."""
+        # Reject patterns like sk-ant-<20+ chars>, Bearer <token>, etc.
+        # Allow the placeholder 'sk-ant-...' used as an example.
+        assert not re.search(r"sk-ant-[A-Za-z0-9_-]{20,}", job_text), (
+            "INV-08 violation: hardcoded Anthropic API key in daily.md"
+        )
+        assert not re.search(r"Bearer [A-Za-z0-9._-]{20,}", job_text), (
+            "INV-08 violation: hardcoded bearer token in daily.md"
+        )
+
+    def test_inv01_boundary_in_runbook(self, job_text: str) -> None:
+        """The runbook must explicitly state that order/execute tools must not
+        be registered (INV-01).
+
+        Matches a sentence that combines:
+          - a prohibition word (never / not / must not / do not)
+          - an order/execute/risk keyword
+          - a tool/register/grant keyword
+        in any order within a 120-character window.
+        """
+        runbook_match = re.search(
+            r"operator runbook.*",
+            job_text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert runbook_match is not None, "Operator runbook section not found"
+        runbook_section = runbook_match.group(0)
+        assert re.search(
+            # Pattern A: prohibition → order/execute/risk → tool/register/grant
+            r"(never|not|do not|must not).{0,80}(order|execute|risk).{0,80}(tool|register|grant)|"
+            # Pattern B: order/execute/risk → tool/register/grant → prohibition
+            r"(order|execute|risk).{0,80}(tool|register|grant).{0,80}(never|not|must not)|"
+            # Pattern C: "never register any order/execute/risk tool"
+            r"never register.{0,40}(order|execute|risk).{0,40}tool|"
+            # Pattern D: "do not grant … execute or order tool"
+            r"(do not|must not) grant.{0,60}(execute|order|risk)",
+            runbook_section,
+            re.IGNORECASE,
+        ), (
+            "INV-01: runbook must explicitly state order/execute tools must not be registered"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. scan stdout is the primary source (not fathom watchlist)
+# ---------------------------------------------------------------------------
+
+
+class TestScanStdoutSource:
+    def test_scan_stdout_is_primary(self, job_text: str) -> None:
+        assert re.search(r"stdout", job_text, re.IGNORECASE), (
+            "daily.md must state that fathom scan's stdout is the primary watchlist source"
+        )
+
+    def test_watchlist_not_primary_source(self, job_text: str) -> None:
+        """The doc must clarify fathom watchlist is not the primary source."""
+        assert re.search(
+            r"(not|do not|NOT).{0,30}(fathom watchlist|watchlist.{0,20}primary)|"
+            r"(persisted.?read|re.?read)",
+            job_text,
+            re.IGNORECASE,
+        ), (
+            "daily.md must clarify fathom watchlist is the persisted-read accessor, "
+            "not the primary daily source"
+        )


### PR DESCRIPTION
Closes #58.

## Summary

- Adds `hermes_integration/jobs/daily.md` — the plain-English Hermes daily job definition:
  5-step ordered pipeline (scan → news-risk → chart → narration → deliver to Discord);
  skip→veto / reduce_size→flag / proceed→keep verdict mapping; empty-watchlist and
  malformed-Claude safe paths; operator runbook for registering the job in Hermes,
  wiring the CLI as a tool (scan/watchlist/chart **only** — INV-01), and connecting the
  Discord gateway + Anthropic key via `.env` (INV-08).
- Adds `tests/test_hermes_job.py` — 42 lint assertions on the artefact: step-heading order,
  allowed tool presence, forbidden tool grep (execute/orders/risk — INV-01), verdict
  mapping, empty-watchlist path, narration fallback path, and operator runbook presence.

## Verification results

```
pytest tests/test_hermes_job.py -v   →  42 passed, exit 0
pytest -q                             → 667 passed, exit 0
mypy tests/test_hermes_job.py        →  Success: no issues found in 1 source file, exit 0
mypy hermes_integration/             →  Success: no issues found in 3 source files, exit 0
```

Pre-existing mypy errors in `test_news_risk.py`, `test_ranker.py`, `test_charts.py`
(87 errors) are from prior tasks — not introduced here.

## INV-01 confirmation

`daily.md` references only `fathom scan`, `fathom watchlist`, and `fathom chart`.
`fathom execute`, `fathom orders`, and `fathom risk` do not appear in the file.
The runbook explicitly states: "Never register any order, execute, or risk tool".

## T-08 (live Discord acceptance)

Blocked on human operator — requires a configured Hermes instance + Discord channel
+ Anthropic key. Manual gate; not automated.