### PR TITLE
fix(tests): restore `mypy .` strict-clean across full suite

### DIFF
--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -18,6 +18,7 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -190,9 +191,11 @@ def test_long_level_axhlines_ordered(tmp_path: Path) -> None:
 
         # Collect the y-values of all horizontal lines drawn by axhline.
         hline_ys = sorted(
-            line.get_ydata()[0]
+            float(np.asarray(line.get_ydata(), dtype=float)[0])
             for line in ax.get_lines()
-            if len(line.get_xdata()) == 2 and line.get_xdata()[0] == 0.0 and line.get_xdata()[1] == 1.0
+            if np.asarray(line.get_xdata(), dtype=float).shape == (2,)
+            and float(np.asarray(line.get_xdata(), dtype=float)[0]) == 0.0
+            and float(np.asarray(line.get_xdata(), dtype=float)[1]) == 1.0
         )
         assert len(hline_ys) == 3, f"Expected 3 axhlines, got {len(hline_ys)}: {hline_ys}"
         stop_y, entry_y, target_y = hline_ys
@@ -238,9 +241,11 @@ def test_short_level_axhlines_ordered(tmp_path: Path) -> None:
         ax.axhline(target, **_TARGET_STYLE) # type: ignore[arg-type]
 
         hline_ys = sorted(
-            line.get_ydata()[0]
+            float(np.asarray(line.get_ydata(), dtype=float)[0])
             for line in ax.get_lines()
-            if len(line.get_xdata()) == 2 and line.get_xdata()[0] == 0.0 and line.get_xdata()[1] == 1.0
+            if np.asarray(line.get_xdata(), dtype=float).shape == (2,)
+            and float(np.asarray(line.get_xdata(), dtype=float)[0]) == 0.0
+            and float(np.asarray(line.get_xdata(), dtype=float)[1]) == 1.0
         )
         assert len(hline_ys) == 3, f"Expected 3 axhlines, got {len(hline_ys)}: {hline_ys}"
         target_y, entry_y, stop_y = hline_ys

--- a/tests/test_hermes_job.py
+++ b/tests/test_hermes_job.py
@@ -211,11 +211,11 @@ class TestForbiddenTools:
             job_text,
             re.IGNORECASE | re.DOTALL,
         )
-        if m:
-            section = m.group(0)
-            assert "execute" not in section.lower(), (
-                "INV-01 violation: 'execute' listed in allowed-tools section"
-            )
+        assert m is not None, "allowed-tools section not found in daily.md"
+        section = m.group(0)
+        assert "execute" not in section.lower(), (
+            "INV-01 violation: 'execute' listed in allowed-tools section"
+        )
 
     def test_no_order_in_allowed_tools_table(self, job_text: str) -> None:
         """The allowed-tools table must not list 'order' as an allowed entry."""
@@ -224,13 +224,13 @@ class TestForbiddenTools:
             job_text,
             re.IGNORECASE | re.DOTALL,
         )
-        if m:
-            section = m.group(0)
-            # 'order' in a tool-listing context — not in an exclusion note
-            # We look for 'fathom_order' or '| order' table cell patterns
-            assert not re.search(r"fathom_order|\|\s*order\b", section, re.IGNORECASE), (
-                "INV-01 violation: order tool listed in allowed-tools section"
-            )
+        assert m is not None, "allowed-tools section not found in daily.md"
+        section = m.group(0)
+        # 'order' in a tool-listing context — not in an exclusion note
+        # We look for 'fathom_order' or '| order' table cell patterns
+        assert not re.search(r"fathom_order|\|\s*order\b", section, re.IGNORECASE), (
+            "INV-01 violation: order tool listed in allowed-tools section"
+        )
 
     def test_hermes_never_places_orders_stated(self, job_text: str) -> None:
         """The doc must explicitly state Hermes never places orders (INV-01)."""

--- a/tests/test_news_risk.py
+++ b/tests/test_news_risk.py
@@ -85,33 +85,33 @@ class TestNewsRiskVerdictModel:
 
     def test_all_event_risk_values(self) -> None:
         for risk in ("high", "medium", "low"):
-            v = NewsRiskVerdict(event_risk=risk, reason="ok", suggest_action="proceed")  # type: ignore[arg-type]
+            v = NewsRiskVerdict(event_risk=risk, reason="ok", suggest_action="proceed")
             assert v.event_risk == risk
 
     def test_all_suggest_action_values(self) -> None:
         for action in ("proceed", "reduce_size", "skip"):
-            v = NewsRiskVerdict(event_risk="low", reason="ok", suggest_action=action)  # type: ignore[arg-type]
+            v = NewsRiskVerdict(event_risk="low", reason="ok", suggest_action=action)
             assert v.suggest_action == action
 
     def test_rejects_bad_event_risk_catastrophic(self) -> None:
         with pytest.raises(ValidationError):
-            NewsRiskVerdict(event_risk="catastrophic", reason="x", suggest_action="skip")  # type: ignore[arg-type]
+            NewsRiskVerdict(event_risk="catastrophic", reason="x", suggest_action="skip")
 
     def test_rejects_bad_event_risk_critical(self) -> None:
         with pytest.raises(ValidationError):
-            NewsRiskVerdict(event_risk="critical", reason="x", suggest_action="skip")  # type: ignore[arg-type]
+            NewsRiskVerdict(event_risk="critical", reason="x", suggest_action="skip")
 
     def test_rejects_bad_event_risk_none(self) -> None:
         with pytest.raises(ValidationError):
-            NewsRiskVerdict(event_risk=None, reason="x", suggest_action="skip")  # type: ignore[arg-type]
+            NewsRiskVerdict(event_risk=None, reason="x", suggest_action="skip")
 
     def test_rejects_bad_suggest_action_trade(self) -> None:
         with pytest.raises(ValidationError):
-            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="trade")  # type: ignore[arg-type]
+            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="trade")
 
     def test_rejects_bad_suggest_action_allow(self) -> None:
         with pytest.raises(ValidationError):
-            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="allow")  # type: ignore[arg-type]
+            NewsRiskVerdict(event_risk="low", reason="x", suggest_action="allow")
 
     def test_rejects_missing_event_risk(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Callable, Optional
 
 import pandas as pd
 import pytest
@@ -31,6 +31,10 @@ from signals.ranker import (
     NEWS_WINDOW_MEDIUM,
     Candidate,
     Ranker,
+    SessionCheck,
+    SpreadCheck,
+    _default_session_ok,
+    _default_spread_ok,
 )
 from strategies.base import Direction, Signal, Strategy
 
@@ -177,7 +181,7 @@ class StubStrategy(Strategy):
 
 def make_builder(
     spec: dict[tuple[str, str, str], tuple[Direction, float]],
-):
+) -> Callable[[str, str, str], Strategy]:
     """Builder factory: maps (strategy_name, instrument, timeframe) → StubStrategy.
 
     ``spec`` value is ``(direction, quality_score)``.  A combo absent from the
@@ -205,20 +209,16 @@ def make_ranker(
     builder_spec: dict[tuple[str, str, str], tuple[Direction, float]],
     *,
     calendar: Optional[FakeCalendar] = None,
-    spread_ok=None,
-    session_ok=None,
+    spread_ok: Optional[SpreadCheck] = None,
+    session_ok: Optional[SessionCheck] = None,
     empty_candles: bool = False,
 ) -> Ranker:
-    kwargs = {}
-    if spread_ok is not None:
-        kwargs["spread_ok"] = spread_ok
-    if session_ok is not None:
-        kwargs["session_ok"] = session_ok
     return Ranker(
         store=FakeStore(approved, empty_candles=empty_candles),
-        calendar=calendar or FakeCalendar({}),
+        calendar=calendar or FakeCalendar({}),  # type: ignore[arg-type]
         strategy_builder=make_builder(builder_spec),
-        **kwargs,
+        spread_ok=spread_ok if spread_ok is not None else _default_spread_ok,
+        session_ok=session_ok if session_ok is not None else _default_session_ok,
     )
 
 
@@ -227,7 +227,9 @@ def make_ranker(
 # ---------------------------------------------------------------------------
 
 
-def test_empty_approved_set_returns_empty_and_logs(caplog):
+def test_empty_approved_set_returns_empty_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     ranker = make_ranker([], {})
     with caplog.at_level(logging.INFO, logger="signals.ranker"):
         result = ranker.rank(NOW)
@@ -235,7 +237,7 @@ def test_empty_approved_set_returns_empty_and_logs(caplog):
     assert any("Approved-set is empty" in r.message for r in caplog.records)
 
 
-def test_rank_requires_utc_aware_now():
+def test_rank_requires_utc_aware_now() -> None:
     ranker = make_ranker([], {})
     with pytest.raises(ValueError, match="UTC-aware"):
         ranker.rank(datetime(2026, 5, 28, 12, 0, 0))  # naive
@@ -246,7 +248,7 @@ def test_rank_requires_utc_aware_now():
 # ---------------------------------------------------------------------------
 
 
-def test_only_approved_combos_emit():
+def test_only_approved_combos_emit() -> None:
     # Approved: macrossover EUR_USD H1. Builder is asked only for approved
     # combos; an un-approved combo is never built (so never emits).
     approved = [_row("macrossover_eur_usd_h1", "EUR_USD", "H1", 1.0)]
@@ -259,7 +261,7 @@ def test_only_approved_combos_emit():
     assert result[0].strategy_name == "macrossover_eur_usd_h1"
 
 
-def test_gate_join_uses_granularity_dimension():
+def test_gate_join_uses_granularity_dimension() -> None:
     """The DB row's ``granularity`` is matched to ``Signal.timeframe``.
 
     The approved row uses ``granularity='H4'``; the stub emits a signal whose
@@ -276,14 +278,14 @@ def test_gate_join_uses_granularity_dimension():
     assert result[0].direction == "SHORT"
 
 
-def test_flat_signal_produces_no_candidate():
+def test_flat_signal_produces_no_candidate() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.FLAT, 0.5)}
     ranker = make_ranker(approved, spec)
     assert ranker.rank(NOW) == []
 
 
-def test_empty_candles_skips_combo():
+def test_empty_candles_skips_combo() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     ranker = make_ranker(approved, spec, empty_candles=True)
@@ -295,7 +297,7 @@ def test_empty_candles_skips_combo():
 # ---------------------------------------------------------------------------
 
 
-def test_high_impact_news_drops_candidate():
+def test_high_impact_news_drops_candidate() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     cal = FakeCalendar({"USD": Impact.high})  # quote leg has high-impact event
@@ -303,7 +305,7 @@ def test_high_impact_news_drops_candidate():
     assert ranker.rank(NOW) == []
 
 
-def test_medium_impact_news_sets_flag_but_keeps():
+def test_medium_impact_news_sets_flag_but_keeps() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     cal = FakeCalendar({"EUR": Impact.medium})
@@ -313,7 +315,7 @@ def test_medium_impact_news_sets_flag_but_keeps():
     assert result[0].news_flag is True
 
 
-def test_low_or_no_news_clears_flag():
+def test_low_or_no_news_clears_flag() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     cal_low = FakeCalendar({"EUR": Impact.low})
@@ -322,7 +324,7 @@ def test_low_or_no_news_clears_flag():
     assert make_ranker(approved, spec, calendar=cal_none).rank(NOW)[0].news_flag is False
 
 
-def test_news_windows_are_the_documented_lengths():
+def test_news_windows_are_the_documented_lengths() -> None:
     assert NEWS_WINDOW_HIGH == timedelta(hours=4)
     assert NEWS_WINDOW_MEDIUM == timedelta(hours=1)
 
@@ -332,21 +334,21 @@ def test_news_windows_are_the_documented_lengths():
 # ---------------------------------------------------------------------------
 
 
-def test_spread_fail_drops_candidate():
+def test_spread_fail_drops_candidate() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     ranker = make_ranker(approved, spec, spread_ok=lambda i, t, n: False)
     assert ranker.rank(NOW) == []
 
 
-def test_session_fail_drops_candidate():
+def test_session_fail_drops_candidate() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     ranker = make_ranker(approved, spec, session_ok=lambda i, t, n: False)
     assert ranker.rank(NOW) == []
 
 
-def test_passing_filters_set_flags_true():
+def test_passing_filters_set_flags_true() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     c = make_ranker(approved, spec).rank(NOW)[0]
@@ -358,7 +360,7 @@ def test_passing_filters_set_flags_true():
 # ---------------------------------------------------------------------------
 
 
-def test_opposite_direction_same_instrument_timeframe_suppresses_both():
+def test_opposite_direction_same_instrument_timeframe_suppresses_both() -> None:
     approved = [
         _row("long_strat", "EUR_USD", "H1", 1.0),
         _row("short_strat", "EUR_USD", "H1", 2.0),
@@ -371,7 +373,7 @@ def test_opposite_direction_same_instrument_timeframe_suppresses_both():
     assert ranker.rank(NOW) == []
 
 
-def test_same_direction_same_group_not_suppressed():
+def test_same_direction_same_group_not_suppressed() -> None:
     approved = [
         _row("a", "EUR_USD", "H1", 1.0),
         _row("b", "EUR_USD", "H1", 2.0),
@@ -384,7 +386,7 @@ def test_same_direction_same_group_not_suppressed():
     assert len(result) == 2
 
 
-def test_opposite_direction_different_timeframe_ranked_independently():
+def test_opposite_direction_different_timeframe_ranked_independently() -> None:
     approved = [
         _row("a", "EUR_USD", "H1", 1.0),
         _row("b", "EUR_USD", "H4", 2.0),
@@ -403,7 +405,7 @@ def test_opposite_direction_different_timeframe_ranked_independently():
 # ---------------------------------------------------------------------------
 
 
-def test_rank_primary_by_oos_sharpe_descending():
+def test_rank_primary_by_oos_sharpe_descending() -> None:
     approved = [
         _row("low", "EUR_USD", "H1", 0.5),
         _row("high", "GBP_USD", "H1", 2.0),
@@ -419,7 +421,7 @@ def test_rank_primary_by_oos_sharpe_descending():
     assert [c.rank for c in result] == [1, 2, 3]
 
 
-def test_quality_score_breaks_sharpe_ties():
+def test_quality_score_breaks_sharpe_ties() -> None:
     approved = [
         _row("a", "EUR_USD", "H1", 1.0),
         _row("b", "GBP_USD", "H1", 1.0),
@@ -435,7 +437,7 @@ def test_quality_score_breaks_sharpe_ties():
     assert [c.rank for c in result] == [1, 2]
 
 
-def test_final_tiebreak_is_stable_and_deterministic():
+def test_final_tiebreak_is_stable_and_deterministic() -> None:
     # Identical sharpe AND quality → deterministic by (instrument, strategy_name).
     approved = [
         _row("z_strat", "GBP_USD", "H1", 1.0),
@@ -473,11 +475,11 @@ EXPECTED_FIELDS = [
 ]
 
 
-def test_candidate_field_names_and_order_match_inv13():
+def test_candidate_field_names_and_order_match_inv13() -> None:
     assert list(Candidate.model_fields.keys()) == EXPECTED_FIELDS
 
 
-def test_candidate_field_types_match_inv13():
+def test_candidate_field_types_match_inv13() -> None:
     ann = {name: f.annotation for name, f in Candidate.model_fields.items()}
     assert ann["instrument"] is str
     assert ann["timeframe"] is str
@@ -495,7 +497,7 @@ def test_candidate_field_types_match_inv13():
     assert ann["generated_at"] is str
 
 
-def test_candidate_serialisation_round_trip():
+def test_candidate_serialisation_round_trip() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.25)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.7)}
     candidate = make_ranker(approved, spec).rank(NOW)[0]
@@ -517,7 +519,7 @@ def test_candidate_serialisation_round_trip():
     assert payload["direction"] in ("LONG", "SHORT")
 
 
-def test_generated_at_carries_signal_bar_close_time():
+def test_generated_at_carries_signal_bar_close_time() -> None:
     approved = [_row("s1", "EUR_USD", "H1", 1.0)]
     spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
     c = make_ranker(approved, spec).rank(NOW)[0]


### PR DESCRIPTION
## Summary

Phase 2 reviewers ran **scoped** mypy (per-task paths) during orchestration, so strict type-debt accumulated in the test layer unnoticed. A full `mypy .` reported **87 errors** across `test_charts`, `test_ranker`, and `test_news_risk`. This restores `mypy .` to 0 errors with the full suite green.

## Changes

- **test_news_risk** — drop 7 unused `# type: ignore[arg-type]`.
- **test_ranker** — annotate `make_builder`/`make_ranker` returns + params; type `spread_ok`/`session_ok` as `Optional[SpreadCheck]`/`Optional[SessionCheck]` and pass them explicitly (the `**dict[str, object]` unpack was what mypy rejected); annotate `caplog`; targeted ignore for the `FakeCalendar` → `_CalendarLike` structural-mock arg-type.
- **test_charts** — `np.asarray(..., dtype=float)` for matplotlib line-data extraction (the loose `get_xdata`/`get_ydata` union resists `float()`/indexing).
- **test_hermes_job** — harden two `if m:` guards to `assert m is not None` so the INV-01 allowed-tools checks can't silently pass when the section regex misses.

## Verification

- `mypy .` → **Success: no issues found in 56 source files**
- `pytest` → **667 passed**

> Note: the 9 `test_poc_runner` integration failures seen mid-work were a **stale editable install** (the `.pth` finder pointed at a removed orchestration worktree, so the subprocess couldn't import `backtest`). Fixed by `pip install -e .` from the canonical root — environment only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)