### PR TITLE
docs(phase-3): draft 9 feature specs (risk · execution · monitoring)

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -50,14 +50,24 @@ One row per feature. Scannable in a single read — the cross-feature-consistenc
 | cli-commands | `fathom scan \| watchlist \| chart` (Hermes tools; the Hermes boundary) | [cli-commands.md](cli-commands.md) | ready |
 | hermes-job-definitions | plain-English daily Hermes job → Discord (configured not coded; capstone, INV-01) | [hermes-job-definitions.md](hermes-job-definitions.md) | ready |
 
-## Later — execution, monitoring, panel (Phase 3+)
+## Phase 3 — risk, execution & monitoring, demo only (specs drafted; cross-spec audit pending)
+
+Maps to product-spec Phase 4. The phase where Fathom gains order authority — kept on the deterministic side of INV-01 (operator-run `fathom execute`, never a Hermes tool). See [phase-3.md](../phases/phase-3.md).
+
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| order-model-and-brackets | frozen `Order`/`Fill`/`Position` models + `build_bracket` (INV-04); prerequisite hub | [order-model-and-brackets.md](order-model-and-brackets.md) | draft |
+| position-sizing | units from stop distance + 0.25% equity cap; rejects on no valid stop (INV-05/11) | [position-sizing.md](position-sizing.md) | draft |
+| risk-limits-kill-switch | exposure + correlation caps + daily-loss kill switch (UTC-day reset) | [risk-limits-kill-switch.md](risk-limits-kill-switch.md) | draft |
+| pretrade-check | in-process Claude veto; pydantic verdict; malformed→abort (INV-02); stubbable adapter | [pretrade-check.md](pretrade-check.md) | draft |
+| order-placement | atomic bracket submit to v20 practice; client-id idempotency; retries; slippage capture (INV-04/07/09) | [order-placement.md](order-placement.md) | draft |
+| reconciliation | broker-vs-db; broker is source of truth; startup + periodic | [reconciliation.md](reconciliation.md) | draft |
+| deviation-monitor | always-on adverse-path/slippage/vol/feed-health detection on open positions | [deviation-monitor.md](deviation-monitor.md) | draft |
+| monitor-alerts | format + deliver `DeviationEvent` to Discord via Hermes gateway; durable deviation log | [monitor-alerts.md](monitor-alerts.md) | draft |
+| execution-cli | `fathom execute <candidate>` operator join (the INV-01 enforcement point); `positions`/`reconcile` helpers | [execution-cli.md](execution-cli.md) | draft |
+
+## Later — admin panel & hardening (impl-Phase 4+)
 
 | Feature | Summary | Status |
 |---|---|---|
-| pretrade-check | deterministic pre-trade Claude sanity check (INV-02) | planned |
-| position-sizing | lot size from stop distance + 0.25% cap (INV-05) | planned |
-| risk-limits | exposure, correlation caps, daily kill switch | planned |
-| execution-engine | OANDA orders, brackets (INV-04), idempotency, retries | planned |
-| reconciliation | broker-vs-DB state reconciliation | planned |
-| deviation-monitor | always-on adverse-path/slippage/feed-health alerts | planned |
-| admin-panel | Streamlit + Lightweight Charts dashboard | planned |
+| admin-panel | Streamlit + Lightweight Charts dashboard (charts, blotter, equity, watchlist, deviation log) | planned |

--- a/docs/features/deviation-monitor.md
+++ b/docs/features/deviation-monitor.md
@@ -1,0 +1,108 @@
+# Feature: deviation-monitor
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The always-on Python service that watches open positions against reality and raises
+an alert when they diverge from plan: adverse price path, slippage on stop/target
+fills, volatility spikes, and feed-health loss (the stream dropped). It holds the
+live price stream (Phase 1B) and reads open positions from the store, evaluating
+each on every tick/bar. On the most severe triggers it *may* take a configurable
+response (default **alert-only** on demo). This is the "operational risk is real
+risk" feature — a crashed feed or an unnoticed adverse move costs money independent
+of strategy quality.
+
+## User-facing behaviour
+
+Backend module `monitoring/watcher.py` + entrypoint `scripts/run_monitor.py`:
+
+- `Watcher(stream, store, alerter, config)` with a `run()` loop: consume ticks,
+  refresh open positions (periodically via [[reconciliation]]), and evaluate
+  deviation rules per position.
+- **Rules:** adverse excursion past a configurable fraction of stop distance;
+  realized slippage beyond a threshold; volatility spike (ATR/range expansion);
+  feed-health (no tick within the heartbeat window → stale-feed alert).
+- On a trigger → emit a `DeviationEvent` to the alerter ([[monitor-alerts]]).
+- **Severe-response policy:** `alert_only` (default) | `auto_flatten` |
+  `tighten_stop`, behind a default-off config flag. On demo the default is
+  alert-only; auto-responses are opt-in.
+- `scripts/run_monitor.py` is the long-lived entrypoint (the always-on process on
+  the private server).
+
+## Acceptance criteria
+
+- [ ] Adverse excursion past the configured fraction of stop distance on an open position → exactly one `DeviationEvent` (debounced; not re-fired every tick). Verified with a synthetic tick sequence.
+- [ ] A stop/target fill whose slippage exceeds the threshold → a slippage `DeviationEvent`.
+- [ ] A volatility spike (range/ATR expansion past threshold) → a vol `DeviationEvent`.
+- [ ] No tick within the heartbeat window → a feed-health `DeviationEvent` (stale feed) — reusing the Phase 1B stream's gap/heartbeat detection.
+- [ ] Default config is `alert_only`: no position is flattened/modified unless the auto-response flag is explicitly enabled (verified — demo safety).
+- [ ] The loop is resilient: a transient stream drop triggers the stream's reconnect/backoff (Phase 1B) and a feed-health alert, not a crash.
+- [ ] Events carry UTC timestamps (INV-03); the loop reads positions via the store/reconcile, never places opening orders (INV-01 — it only observes, and at most flattens an existing position when explicitly configured).
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant ST as data/stream.py (live ticks)
+    participant W as monitoring/watcher.py
+    participant S as store (open positions)
+    participant A as monitor-alerts
+
+    loop always-on
+        ST->>W: tick
+        W->>S: open positions (refreshed via reconcile)
+        W->>W: evaluate rules (adverse / slippage / vol / feed-health)
+        alt deviation
+            W->>A: DeviationEvent
+        end
+        alt no tick within heartbeat
+            W->>A: feed-health DeviationEvent (stale feed)
+        end
+    end
+```
+
+## Component design
+
+`monitoring/watcher.py` reuses Phase 1B `data/stream.py` (heartbeat, reconnect,
+gap detection) for the feed and its health signal. Deviation rules are pure
+predicates over `(position, recent_prices, config)` so each is unit-testable with
+synthetic series; the `run()` loop wires them to the live stream. Debounce/state
+per position prevents alert storms. The severe-response is a strategy object,
+default `AlertOnly`. → sonnet (rules are table-driven; the risky parts — feed
+handling — are inherited from shipped Phase 1B code).
+
+## Non-goals
+
+- No alert delivery formatting/transport — that is [[monitor-alerts]].
+- No opening trades — observe-only (plus optional flatten of an *existing* position when explicitly enabled). INV-01 holds: the monitor never opens a position.
+- No reconciliation logic — it consumes [[reconciliation]] output for fresh positions.
+
+## Touches
+
+- [INV-01] — observes/at-most-closes; never opens an order; not a Hermes tool.
+- [INV-03] — UTC event timestamps.
+- [INV-09] — uses the shared stream (only `oanda_client.py` reads `env`).
+
+## Depends on
+
+- `data/stream.py` (Phase 1B, on `main`), [[order-model-and-brackets]] (`Position`), [[reconciliation]] (fresh positions + `day_pl`), [[monitor-alerts]] (delivery), `strategies/_indicators.py::atr` (vol rule).
+
+## Approach
+
+`monitoring/watcher.py` + `scripts/run_monitor.py`. Pure rule predicates first
+(full synthetic-series tests), then the always-on loop on top of the Phase 1B
+stream. Auto-response defaults off.
+
+## Open questions
+
+- Severe-response default — **alert-only on demo** (proposed); `auto_flatten`/`tighten_stop` behind a default-off flag.
+- Rule thresholds (adverse fraction, slippage, vol-expansion, heartbeat seconds) — propose defaults; confirm at audit.
+- Evaluation cadence: per-tick vs per-bar. Propose per-tick for adverse/feed-health, per-bar for vol.
+
+## Out of scope
+
+- Alert transport ([[monitor-alerts]]), the panel deviation-log UI (impl-Phase 4).

--- a/docs/features/execution-cli.md
+++ b/docs/features/execution-cli.md
@@ -1,0 +1,124 @@
+# Feature: execution-cli
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The operator entrypoint that joins the whole Phase 3 gate: `fathom execute
+<candidate>` takes an approved watchlist candidate and runs it through pre-trade
+check → sizing → limits → order placement, reporting the outcome. This is the
+**human, deterministic approval act** that turns a suggestion into a trade —
+and the canonical INV-01 enforcement point: it is a CLI command an operator runs,
+**never registered as a Hermes tool**. Optional read-only helpers (`fathom
+positions`, `fathom reconcile`) let the operator inspect state.
+
+## User-facing behaviour
+
+Extends `cli.py` (the single Phase 3 writer of this file):
+
+```
+fathom execute <candidate-ref> [--db-path PATH] [--dry-run] [--yes]
+```
+
+1. Load the named candidate from the **persisted watchlist** (INV-13); error if it
+   isn't on the current watchlist (no executing arbitrary input).
+2. Fetch current equity (OANDA v20 account summary).
+3. **Pre-trade check** ([[pretrade-check]]) → `block` aborts (exit non-zero, reason printed).
+4. **Sizing** ([[position-sizing]]) → reject (size 0) aborts with the reason.
+5. **Limits / kill switch** ([[risk-limits-kill-switch]]) → reject aborts with the reason.
+6. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
+7. `--dry-run` runs steps 1–5 and prints what *would* be submitted without placing
+   an order (safe rehearsal). `--yes` skips an interactive confirm.
+
+Read-only helpers: `fathom positions` (print open `Position[]` JSON), `fathom
+reconcile` (run [[reconciliation]] once, print the report).
+
+## Acceptance criteria
+
+- [ ] `fathom execute` only accepts a candidate present on the persisted watchlist; an unknown ref errors without side effects (no executing off-watchlist input).
+- [ ] The gate order is exactly pretrade-check → sizing → limits → submit; **any** stage's rejection aborts with a clear reason and a non-zero exit, and no order is placed.
+- [ ] `--dry-run` performs checks 1–5 and prints the would-be order **without** any v20 submission (verified — no order endpoint called).
+- [ ] A successful run prints the `Fill` (fill price, units, slippage, trade id) and persists state; re-running the same execute is idempotent (no double-fill, via [[order-placement]]).
+- [ ] When the kill switch is active, `fathom execute` refuses and reports the kill-switch status.
+- [ ] `fathom execute` / `positions` / `reconcile` are **not** referenced by any Hermes job; the Phase 2 `daily.md` allow-list (`scan`/`watchlist`/`chart`) is unchanged (INV-01). A test asserts no execution command appears in `hermes_integration/`.
+- [ ] Existing `scan`/`watchlist`/`chart`/`backtest` commands remain unbroken; no live HTTP in unit tests (mocked); practice endpoint only (INV-07).
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    actor OP as Operator
+    participant CLI as fathom execute
+    participant PT as pretrade-check
+    participant RK as sizing + limits
+    participant EX as order-placement
+    participant B as OANDA v20 (practice)
+
+    OP->>CLI: fathom execute <candidate>
+    CLI->>CLI: load candidate from watchlist (INV-13)
+    CLI->>PT: pretrade_check
+    PT-->>CLI: proceed | block
+    alt block
+        CLI-->>OP: abort (reason), exit ≠ 0
+    else proceed
+        CLI->>RK: size + check limits
+        alt rejected
+            RK-->>CLI: reason
+            CLI-->>OP: abort (reason), exit ≠ 0
+        else allowed
+            CLI->>EX: submit_order (bracketed, idempotent)
+            EX->>B: market + SL + TP
+            B-->>EX: fill
+            EX-->>CLI: Fill
+            CLI-->>OP: Fill (price, units, slippage)
+        end
+    end
+```
+
+## Component design
+
+Extends `cli.py` with the `execute`/`positions`/`reconcile` subparsers, reusing the
+Phase 1/2 runner scaffolding (`--db-path`, `--dry-run`, UTC logging). It is the
+**only** Phase 3 task that edits `cli.py` (single-writer, like Phase 2's T-07). The
+command is pure orchestration — all logic lives in the risk/execution modules; the
+CLI wires them and handles exit codes + operator output. → sonnet.
+
+## Non-goals
+
+- No new risk/execution logic — orchestration only.
+- No Hermes wiring — by design this is never a Hermes tool (INV-01).
+- No scheduling — execution is operator-initiated, not cron.
+
+## Touches
+
+- [INV-01] — the enforcement point: execution is operator CLI, never a Hermes tool.
+- [INV-07] — practice endpoint only.
+- [INV-13] — executes only persisted `Candidate`s.
+- [INV-03] — UTC logging.
+
+## Depends on
+
+- [[pretrade-check]], [[position-sizing]], [[risk-limits-kill-switch]], [[order-placement]], [[reconciliation]] — all Phase 3; the persisted watchlist (Phase 2, on `main`).
+
+## Approach
+
+Drafted last (the join). Wire the gate, add `--dry-run` as the safe default
+rehearsal, and assert the INV-01 boundary with a test scanning `hermes_integration/`
+for any execution-command reference.
+
+## Open questions
+
+- Candidate ref format: `rank`, `instrument`, or a composite id from the watchlist
+  row? Propose composite `instrument:timeframe:strategy_name` (unambiguous on a
+  watchlist).
+- One candidate per invocation (proposed) vs a batch `--all`. Propose single; the
+  book cap is enforced by limits regardless.
+- Interactive confirm default: require `--yes` for a real submit, or confirm prompt?
+  Propose a confirm prompt unless `--yes` (demo safety).
+
+## Out of scope
+
+- The risk/execution/monitor internals (their own specs); the panel (impl-Phase 4).

--- a/docs/features/monitor-alerts.md
+++ b/docs/features/monitor-alerts.md
@@ -1,0 +1,78 @@
+# Feature: monitor-alerts
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The delivery layer for the deviation monitor: turn a `DeviationEvent` into a
+concise, human-readable alert and post it to the **same Discord channel** as the
+daily watchlist, via Hermes' Discord gateway. Alerts ride the existing Hermes
+gateway (delivery only — this is outbound notification, not order authority, so
+INV-01 is untouched). Delivery is best-effort with retry; an event is always
+persisted to the store's deviation log regardless of delivery success.
+
+## User-facing behaviour
+
+Backend module `monitoring/alerts.py`:
+
+- `Alerter(gateway, store)` with `send(event: DeviationEvent) -> None`.
+- Formats a one-line alert: `⚠️ <instrument> <type> | <detail> | <UTC time>`
+  (e.g. `⚠️ EUR_USD adverse | −0.6×stop excursion | 2026-05-29T15:10:00Z`).
+- Persists the event to the store `deviation_log` table first (durable), then posts
+  to Discord via the Hermes gateway.
+- Delivery failure → retry per gateway policy; the persisted log is the durable
+  record for the panel (impl-Phase 4) and post-hoc review.
+- Debounce/severity is decided upstream in [[deviation-monitor]]; the alerter
+  formats and ships.
+
+## Acceptance criteria
+
+- [ ] Each `DeviationEvent` is persisted to `deviation_log` **before** the delivery attempt (durable even if Discord is down). Verified.
+- [ ] The formatted alert is one line, includes instrument, deviation type, a short detail, and a UTC RFC-3339 timestamp (INV-03); no secret appears (INV-08).
+- [ ] Delivery goes through the Hermes Discord gateway to the configured channel; a delivery failure is retried and does not raise into the monitor loop (a down Discord never crashes the watcher).
+- [ ] Alerts are outbound-only — the module exposes no order/execution capability and is not registered as a Hermes tool (INV-01).
+- [ ] A duplicate event id is not double-logged (idempotent persistence).
+
+## Component design
+
+`monitoring/alerts.py` takes an injectable `gateway` (the Hermes Discord webhook /
+gateway client) and the store. Formatting is a pure function over `DeviationEvent`
+(unit-testable); persistence-then-deliver ordering guarantees the durable record.
+Mirrors Phase 2's "delivery is best-effort, the store is the durable truth"
+posture. → sonnet.
+
+## Non-goals
+
+- No rule evaluation / debounce — that is [[deviation-monitor]].
+- No watchlist delivery — that is the Phase 2 Hermes job (this is the monitor's alert channel, same destination).
+
+## Touches
+
+- [INV-01] — outbound delivery only; never order authority; not a Hermes tool.
+- [INV-03] — UTC timestamps on alerts + log rows.
+- [INV-08] — no secrets in alert text or logs.
+
+## Depends on
+
+- [[deviation-monitor]] (`DeviationEvent`), the Hermes Discord gateway (config), `data/store.py` (`deviation_log` table — this spec owns it).
+
+## Approach
+
+`monitoring/alerts.py`. Pure formatter + persist-then-deliver wrapper with retry.
+Inject the gateway for testing (no live Discord in tests). The live webhook is
+exercised at the acceptance gate alongside the watcher.
+
+## Open questions
+
+- Gateway interface: reuse the same Discord webhook the Phase 2 watchlist uses, or a
+  dedicated alerts webhook? Propose **same channel** (per the design — watchlist +
+  alerts together), one webhook.
+- Rate-limit/coalesce repeated alerts for the same position — propose a short
+  cooldown window; debounce primarily lives in [[deviation-monitor]].
+
+## Out of scope
+
+- Rule logic ([[deviation-monitor]]), the panel deviation-log view (impl-Phase 4).

--- a/docs/features/order-model-and-brackets.md
+++ b/docs/features/order-model-and-brackets.md
@@ -1,0 +1,96 @@
+# Feature: order-model-and-brackets
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The frozen, in-process data contract for everything execution touches: the
+`Order`, `Fill`, and `Position` pydantic models plus the pure function that turns
+an approved `Candidate` + a sized unit count into a **bracket** order spec (entry +
+stop-loss + take-profit). This is the Phase 3 prerequisite hub — `position-sizing`,
+`order-placement`, `reconciliation`, and the monitor all build against these
+shapes. It is the execution-side analogue of what `Candidate` (INV-13) is to the
+watchlist. No I/O, no OANDA calls — models and bracket maths only.
+
+## User-facing behaviour
+
+Backend module `execution/models.py` (models) + a `build_bracket()` pure function.
+Not a CLI surface; consumed by other Phase 3 modules.
+
+- `Order` — an intent to open a position: `client_order_id` (idempotency key),
+  `instrument`, `direction`, `units` (signed: +long/−short), `entry_type`
+  (`market`), `stop_loss_price`, `take_profit_price`, `candidate_ref` (the
+  originating `Candidate` identity), `created_at` (UTC).
+- `Fill` — the broker's confirmation: `client_order_id`, `broker_trade_id`,
+  `fill_price`, `units_filled`, `slippage` (fill vs `Candidate.entry_ref`),
+  `filled_at` (UTC), `status` (`filled`|`partial`|`rejected`).
+- `Position` — current open state: `broker_trade_id`, `instrument`, `units`,
+  `entry_price`, `stop_loss_price`, `take_profit_price`, `opened_at`,
+  `unrealized_pl`, `candidate_ref`.
+- `build_bracket(candidate, units, *, precision) -> Order` — converts the
+  `Candidate`'s **price-distance** stop/target into **absolute** bracket prices for
+  the order's direction, rounded to the instrument's price precision.
+
+## Acceptance criteria
+
+- [ ] `build_bracket` produces a stop **and** a take-profit price for every order — there is no code path that yields a stop-less or target-less `Order` (INV-04). A candidate with a non-positive `stop_distance` raises (rejected upstream, never sized naked).
+- [ ] Bracket prices are computed by direction: LONG → `stop = entry − stop_distance`, `target = entry + target_distance`; SHORT → mirrored. Verified against worked examples for both directions.
+- [ ] Prices are rounded to the instrument's price precision (from `InstrumentMeta`); a round-trip test pins the rounding for a 5-dp (EUR_USD) and a 3-dp (USD_JPY) instrument.
+- [ ] `units` sign encodes direction (LONG > 0, SHORT < 0); a zero-unit order is invalid (validator rejects).
+- [ ] All datetime fields are UTC-aware RFC 3339 (INV-03); naive datetimes are rejected by validators.
+- [ ] The three models serialise/deserialise round-trip losslessly (a JSON round-trip test pins the shape — this is a frozen contract).
+- [ ] `client_order_id` is a required, non-empty string on every `Order` (idempotency precondition for `order-placement`).
+
+## Component design
+
+`execution/models.py` holds the three pydantic v2 models with strict validators
+(positive prices, signed non-zero units, UTC-aware timestamps), mirroring the
+`Signal`/`Candidate` validator style. `build_bracket()` is a pure function (no
+broker, no clock beyond the passed `created_at`) so it is exhaustively
+unit-testable with hypothesis (property: stop and target always straddle entry on
+the correct sides; rounding never moves a stop to the wrong side of entry).
+
+**Frozen-contract intent.** Like `Candidate` (INV-13), these field names/types/shape
+are the stable execution wire contract within Fathom. A promotion to a new
+invariant is proposed at the Phase 3 cross-spec audit; until then, treat changes as
+breaking and reviewable.
+
+## Non-goals
+
+- No OANDA submission, no network, no retries — that is [[order-placement]].
+- No sizing (units are an input here) — that is [[position-sizing]].
+- No persistence — the store schema lives with [[order-placement]]/[[reconciliation]].
+
+## Touches
+
+- [INV-04] — the bracket is constructed here; no order shape lacks SL+TP.
+- [INV-03] — UTC timestamps on all models.
+- [INV-11] — consumes the ATR-derived `stop_distance`/`target_distance` unchanged.
+- [INV-13] — reads the frozen `Candidate`; never mutates it.
+
+## Depends on
+
+- `signals/ranker.py::Candidate` (shipped, INV-13), `data` `InstrumentMeta` (price precision) — both on `main`.
+
+## Approach
+
+New `execution/` package. Models first, then `build_bracket`. Property-based tests
+for the bracket maths. No other Phase 3 module is drafted against an unfrozen
+contract — this spec ships and its round-trip test passes before the execution
+fan-out begins.
+
+## Open questions
+
+- Entry type: market-only for Phase 3, or also limit/stop-entry? Propose
+  **market-only** (the watchlist `entry_ref` is a reference, fills at market);
+  revisit if slippage capture shows it matters.
+- Does `Position` carry realized P&L too, or only unrealized? Propose unrealized
+  here; realized P&L is a reconciliation/store concern.
+
+## Out of scope
+
+- Sizing ([[position-sizing]]), submission ([[order-placement]]), reconciliation
+  ([[reconciliation]]), monitoring ([[deviation-monitor]]).

--- a/docs/features/order-placement.md
+++ b/docs/features/order-placement.md
@@ -1,0 +1,116 @@
+# Feature: order-placement
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The execution engine: submit a sized, bracketed `Order` to the OANDA v20 **practice**
+account, atomically with its stop-loss and take-profit, idempotently (a retry never
+double-fills), capturing the actual fill price and slippage, and persisting the
+`Fill`/`Position` to the store. This is the module that actually places trades —
+the most safety-critical code in Fathom. It is invoked only by the deterministic
+path (`fathom execute`), never by Hermes (INV-01).
+
+## User-facing behaviour
+
+Backend module `execution/orders.py`. `submit_order(order, *, client, store) -> Fill`:
+
+1. **Idempotency:** attach the `Order.client_order_id` as the v20 client extension;
+   before submitting, check the store/broker for an existing fill with that id → if
+   present, return it (no second submission).
+2. **Atomic bracket:** submit a market order with `stopLossOnFill` +
+   `takeProfitOnFill` in one v20 request (INV-04) — never an entry followed by a
+   separate, skippable bracket call.
+3. **Retries:** on transient network/5xx error, retry with backoff, reusing the
+   same `client_order_id` so a retry is a no-op if the first attempt actually landed.
+4. **Capture:** read the fill price + units; compute `slippage` vs
+   `Candidate.entry_ref`; build the `Fill` and `Position`; persist both to the store
+   `fills`/`positions`/`orders` tables.
+5. On `rejected`/partial, record the actual status; never synthesise a fill.
+
+## Acceptance criteria
+
+- [ ] Every submission includes both `stopLossOnFill` and `takeProfitOnFill` in the same request; there is no path that opens a position without a bracket (INV-04). Verified against a mocked v20 (`responses`).
+- [ ] Re-submitting the same `client_order_id` does not create a second broker order — the existing fill is returned (idempotency). Verified by a duplicate-submit test.
+- [ ] A transient error then success results in exactly **one** filled position (retry reuses the id; the duplicate is deduped). Verified with a mocked transient failure.
+- [ ] `slippage` = actual fill price − `Candidate.entry_ref` (signed by direction), recorded on the `Fill`.
+- [ ] A broker rejection is recorded as `status="rejected"` with no `Position` created; a partial fill records `units_filled < units` and `status="partial"`.
+- [ ] `Fill`/`Position`/`Order` persist to the store; all timestamps UTC RFC 3339 (INV-03).
+- [ ] Only the **practice** endpoint is used; the live token is never referenced (INV-07); only `oanda_client.py` reads the `env` switch (INV-09).
+- [ ] No secret appears in logs or persisted rows (INV-08).
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant G as fathom execute (gate)
+    participant O as execution/orders.py
+    participant B as OANDA v20 (practice)
+    participant S as store
+
+    G->>O: submit_order(order)
+    O->>S: existing fill for client_order_id?
+    alt already filled
+        S-->>O: Fill
+        O-->>G: Fill (idempotent no-op)
+    else new
+        O->>B: market + stopLossOnFill + takeProfitOnFill (client_order_id)
+        alt transient error
+            B-->>O: 5xx / network
+            O->>B: retry (same client_order_id)
+        end
+        B-->>O: fill (price, units, trade id)
+        O->>S: persist Order, Fill, Position
+        O-->>G: Fill
+    end
+```
+
+## Component design
+
+`execution/orders.py` uses `oandapyV20` order endpoints via the existing
+`oanda_client.py` (extended with order + account-summary endpoints; still the only
+reader of `env`). The store gains `orders`/`fills`/`positions` tables (this spec
+owns the migration). Idempotency is enforced two ways: the v20 client-order-id
+client extension *and* a pre-submit store check — belt and suspenders against
+double-fills. Unit tests mock v20 with `responses`; no live HTTP in tests. → opus.
+
+## Non-goals
+
+- No sizing/limits — the `order` arrives sized and gated.
+- No reconciliation loop — startup/periodic reconcile is [[reconciliation]] (this spec persists fills; that spec audits them vs the broker).
+- No monitoring — [[deviation-monitor]] reads the persisted positions.
+
+## Touches
+
+- [INV-04] — atomic bracket submission; no naked positions.
+- [INV-07] — practice endpoint only.
+- [INV-08] — no secrets logged/persisted.
+- [INV-09] — single code path; only `oanda_client.py` reads `env`.
+- [INV-03] — UTC timestamps on all persisted rows.
+
+## Depends on
+
+- [[order-model-and-brackets]] (the `Order`/`Fill`/`Position` contract), [[position-sizing]] + [[risk-limits-kill-switch]] (produce the gated, sized order), `data/oanda_client.py` (extended), `data/store.py` (new tables).
+
+## Approach
+
+`execution/orders.py`. Implement idempotency + atomic bracket first (the
+double-fill / naked-position risks), then retries and slippage capture. Mock v20
+throughout; the live practice submission is exercised at the acceptance gate.
+
+## Open questions
+
+- **Idempotency key scheme** — propose `client_order_id` = hash of
+  `(instrument, strategy_name, timeframe, generated_at, execution_date)` so a retry
+  of the same approval dedups but a genuine re-approval next day is distinct. Pin here.
+- Store schema migration ownership — this spec owns `orders`/`fills`/`positions`;
+  reconciliation reads them.
+- v20 stop/target as absolute price vs distance — propose absolute price (from
+  [[order-model-and-brackets]]), instrument precision applied.
+
+## Out of scope
+
+- Reconciliation ([[reconciliation]]), monitoring ([[deviation-monitor]]), the CLI join ([[execution-cli]]).

--- a/docs/features/position-sizing.md
+++ b/docs/features/position-sizing.md
@@ -1,0 +1,79 @@
+# Feature: position-sizing
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The deterministic function that turns an approved `Candidate` and the current
+account equity into a **unit count**, such that the loss if the stop is hit is at
+most **0.25% of equity** (INV-05). Size is *derived* from the stop distance and the
+risk budget — never a fixed lot. This is the first gate that can reject a trade
+(an uncomputable size → no order, never a naked or oversized one).
+
+## User-facing behaviour
+
+Backend module `risk/sizing.py`. `size_position(candidate, equity, *, instrument_meta, risk_fraction=0.0025) -> SizingResult`:
+
+1. Compute the per-unit risk = `stop_distance` converted to account-currency value
+   per unit (via `InstrumentMeta` pip value / quote conversion).
+2. `risk_budget = equity × risk_fraction` (0.25% default).
+3. `units = floor(risk_budget / per_unit_risk)`, signed by direction.
+4. Clamp to the instrument's min/max trade size; **reject** (return a
+   `SizingResult` with `units=0` and a reason) if the budget cannot fund even the
+   minimum size, or if `stop_distance ≤ 0`.
+
+`SizingResult` carries `units`, `risk_amount` (actual money at risk), `reason`
+(when rejected). The execution CLI surfaces the reason on rejection.
+
+## Acceptance criteria
+
+- [ ] For a worked example (known equity, stop distance, pip value), `units` is the largest size whose stop-loss equals ≤ 0.25% of equity — verified by hand-computed fixtures for EUR_USD (quote=USD) and USD_JPY (quote=JPY, conversion required).
+- [ ] The realized risk (`units × per_unit_risk`) never exceeds `equity × risk_fraction` — property-tested across random equity/stop combinations (INV-05).
+- [ ] `stop_distance ≤ 0` → reject (`units=0`, reason set); never sizes naked (INV-04/11 boundary).
+- [ ] A budget too small for the instrument minimum → reject with a clear reason; never rounds up to the minimum.
+- [ ] `risk_fraction` is a parameter defaulting to `0.0025`; it is read from config, and the default cap cannot be exceeded silently.
+- [ ] Quote-currency conversion is correct for non-USD-quote pairs (uses current rate from the candle store / account summary); a JPY-quote fixture pins it.
+- [ ] Pure and deterministic — no network, no clock; equity and rates are inputs.
+
+## Component design
+
+`risk/sizing.py` is a pure function over `(Candidate, equity, InstrumentMeta,
+rate)`. The pip/quote-conversion maths is the subtle part: per-unit risk in account
+currency = `stop_distance × units_per_price_move × quote_to_account_rate`. Account
+currency assumed = USD on the demo account (configurable). The 0.25% cap is the
+single most safety-critical line in the module → opus, heavy property tests.
+
+## Non-goals
+
+- No exposure/correlation/daily-loss logic — that is [[risk-limits-kill-switch]].
+- No order construction — emits a unit count consumed by [[order-model-and-brackets]]/[[order-placement]].
+- No equity fetch — equity is an input (the CLI/orchestrator fetches it once).
+
+## Touches
+
+- [INV-05] — owns the 0.25% cap; the enforcement point for per-trade risk.
+- [INV-11] — consumes the ATR-derived stop that makes sizing symmetric across strategies.
+- [INV-04] — a trade with no valid stop is rejected here, before any order exists.
+
+## Depends on
+
+- [[order-model-and-brackets]] (for `SizingResult`/types alignment), `Candidate` (INV-13), `InstrumentMeta` — `Candidate`/meta on `main`.
+
+## Approach
+
+`risk/` package. Implement the account-currency risk conversion with explicit
+`InstrumentMeta` inputs; property-test the cap invariant with hypothesis. The
+account-currency assumption (USD) is config-driven, not hard-coded.
+
+## Open questions
+
+- Account currency: assume USD (demo account) for Phase 3, config-driven? Propose yes.
+- Rate source for quote conversion: latest cached candle close vs account-summary
+  margin rate. Propose latest cached mid; confirm in spec.
+
+## Out of scope
+
+- Book-level limits ([[risk-limits-kill-switch]]), submission ([[order-placement]]).

--- a/docs/features/pretrade-check.md
+++ b/docs/features/pretrade-check.md
@@ -1,0 +1,103 @@
+# Feature: pretrade-check
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The final structured Claude veto, run in-process immediately before order
+submission. Given an approved `Candidate`, it asks Claude for a `{decision, reason}`
+verdict; a `block` (or any malformed/unavailable response) **aborts the trade**.
+This is the second Claude boundary in Fathom (the first is Phase 2's Hermes-side
+news-risk), and the **first in-process `anthropic` SDK call**. Per INV-02 it is a
+hard structured boundary that fails safe to abort — it can only subtract a trade,
+never authorise one.
+
+## User-facing behaviour
+
+Backend module `hermes_integration/pretrade_check.py`:
+
+- `PretradeVerdict` (pydantic) — `{decision: "proceed"|"block", reason: str}`.
+- `parse_pretrade_verdict(raw: str) -> PretradeVerdict` — the INV-02 boundary: any
+  parse/validation/enum failure or empty input → `decision="block"` (safe default),
+  logs at WARNING, **never raises**, **never returns `proceed`** on a failure path.
+- `pretrade_check(candidate, *, client=None) -> PretradeVerdict` — builds the prompt
+  from `prompts/pretrade.md`, calls Claude via an injectable `client` adapter, and
+  routes the raw response through `parse_pretrade_verdict`. With `client=None` and no
+  key configured, it returns the safe-default `block` (so the gate is testable and
+  safe offline). The live `anthropic` call lives behind the adapter.
+
+The execution CLI treats `proceed` as the only value that lets the trade continue.
+
+## Acceptance criteria
+
+- [ ] `parse_pretrade_verdict` returns `block` on: invalid JSON, missing field, out-of-enum `decision`, empty/whitespace input, wrong JSON type — exercised per case; it never raises and never returns `proceed` on failure (INV-02).
+- [ ] A valid `{"decision":"proceed","reason":"..."}` parses to `proceed`; a valid `block` parses to `block`.
+- [ ] `pretrade_check` with an injected stub client returning a fixed payload routes through the parser and returns the corresponding verdict (offline-testable, no key).
+- [ ] With no client and no `ANTHROPIC_API_KEY`, `pretrade_check` returns the safe default `block` (fails safe; does not crash the gate).
+- [ ] The live adapter, when a key is present, calls the `anthropic` SDK and returns a typed model; no secret is logged (INV-08).
+- [ ] No order, execution, or risk function is importable/callable from this module — it returns a verdict only.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant CLI as fathom execute
+    participant PT as pretrade_check
+    participant CL as Anthropic API (Claude)
+    participant P as parse_pretrade_verdict
+
+    CLI->>PT: pretrade_check(candidate)
+    PT->>CL: structured prompt (via adapter)
+    alt response received
+        CL-->>PT: raw text/JSON
+        PT->>P: parse_pretrade_verdict(raw)
+        P-->>PT: proceed | block (block on any failure)
+    else unavailable / error / no key
+        PT->>P: parse_pretrade_verdict("")
+        P-->>PT: block (safe default)
+    end
+    PT-->>CLI: PretradeVerdict
+    Note over CLI: proceed → continue to sizing; block → abort
+```
+
+## Component design
+
+Mirrors Phase 2's `news_risk.py` structure (parser as the safe boundary; model with
+`extra="forbid"`; `_safe_default()` factory) so the two Claude boundaries are
+consistent and reviewable side-by-side. The `anthropic` SDK import is isolated in a
+thin adapter (`_LiveClient`) injected into `pretrade_check`; tests inject a stub.
+Adds the `anthropic` dependency (coordinator-branch edit to `pyproject.toml` +
+`CLAUDE.md` before this task — like Phase 2's matplotlib edit).
+
+## Non-goals
+
+- No sizing/limits/orders — verdict only; the CLI enforces the abort.
+- No Hermes involvement — this is the deterministic in-process path, distinct from the Hermes-side news-risk (INV-01).
+
+## Touches
+
+- [INV-02] — structured JSON, validated, malformed → safe default (abort).
+- [INV-08] — no key/secret logged; key from `.env`.
+
+## Depends on
+
+- `Candidate` (INV-13), `anthropic` SDK (new dep, coordinator edit). Prompt template `hermes_integration/prompts/pretrade.md` (this spec adds it).
+
+## Approach
+
+`hermes_integration/pretrade_check.py` + `prompts/pretrade.md`. Build the parser
+and stub-client path first (full offline test coverage), then the live adapter. The
+real `ANTHROPIC_API_KEY` is wired only at the Phase 3 acceptance gate.
+
+## Open questions
+
+- Model + token budget for the call — propose a small, fast Claude model; confirm.
+- Does the prompt receive the chart, or text-only candidate facts? Propose
+  text-only for Phase 3 (cheaper, deterministic); revisit.
+
+## Out of scope
+
+- The deterministic risk gate ([[position-sizing]], [[risk-limits-kill-switch]]), submission ([[order-placement]]).

--- a/docs/features/reconciliation.md
+++ b/docs/features/reconciliation.md
@@ -1,0 +1,84 @@
+# Feature: reconciliation
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The truth-keeper: on startup and periodically, fetch the broker's view of open
+trades and the account summary, and reconcile them against Fathom's `positions`
+table. **The broker is the source of truth** — local state is corrected to match,
+and any drift (a position we think is open but the broker closed, a fill we missed,
+an unexpected broker position) is logged and surfaced. This is what makes a crashed
+process or a missed fill recoverable rather than silently wrong.
+
+## User-facing behaviour
+
+Backend module `execution/reconcile.py`. `reconcile(*, client, store, now) -> ReconcileReport`:
+
+1. Fetch open trades + account summary (equity, realized day P&L) from OANDA v20.
+2. Diff against the store `positions`:
+   - **broker-only** position (we missed a fill / restarted) → adopt it into the store.
+   - **store-only** position (we think open, broker closed it — stop/target hit) →
+     mark it closed in the store, record the realized P&L.
+   - **matched** → refresh `unrealized_pl`, stop/target, units.
+3. Update `start_of_day_equity` / `day_pl` used by the kill switch.
+4. Return a `ReconcileReport` (`adopted`, `closed`, `matched`, `drift_flags`).
+
+Invoked at monitor startup and every N minutes; also callable via a read-only
+`fathom reconcile` operator command (optional, in [[execution-cli]]).
+
+## Acceptance criteria
+
+- [ ] A broker-open position absent from the store is **adopted** (inserted) — the broker wins. Verified against a mocked v20 open-trades response.
+- [ ] A store-open position the broker has closed is **marked closed** with realized P&L recorded; the kill-switch `day_pl` reflects it. Verified.
+- [ ] A matched position has its `unrealized_pl`/stop/target refreshed from the broker.
+- [ ] `start_of_day_equity` and `day_pl` are updated from the account summary so the kill switch reads true figures.
+- [ ] Drift (counts/ids that don't line up) is recorded in `drift_flags` and logged at WARNING — never silently dropped.
+- [ ] Reconciliation is idempotent: running it twice with no broker change is a no-op (no duplicate adoptions).
+- [ ] Practice endpoint only (INV-07); UTC timestamps (INV-03); no secrets logged (INV-08).
+
+## Component design
+
+`execution/reconcile.py` reads broker state via `oanda_client.py` (open-trades +
+account-summary endpoints) and the store `positions`/`fills`. The diff is a pure
+function over `(broker_state, store_state)` returning a set of corrective actions,
+so it is unit-testable without a broker; a thin wrapper applies the actions and
+fetches state. "Broker is truth" is the one-line rule that resolves every conflict.
+→ opus (a reconciliation bug corrupts the very state the kill switch trusts).
+
+## Non-goals
+
+- No order submission — corrective adoption inserts/updates store rows, it does not place trades.
+- No alerting on drift beyond logging + the report — alert routing is [[monitor-alerts]] / [[deviation-monitor]].
+
+## Touches
+
+- [INV-07] — practice endpoint only.
+- [INV-03] — UTC timestamps.
+- [INV-08] — no secrets logged.
+- [INV-05] — supplies the true `day_pl`/equity the kill switch depends on.
+
+## Depends on
+
+- [[order-model-and-brackets]], [[order-placement]] (store `positions`/`fills` schema), `data/oanda_client.py` (open-trades + account-summary endpoints).
+
+## Approach
+
+`execution/reconcile.py`. Pure diff function + apply wrapper. Mock v20 for tests.
+Run on monitor startup and on a timer; expose a read-only operator command.
+
+## Open questions
+
+- **Cadence** — propose **startup + every 5 minutes**; operator-configurable.
+- Adoption policy for an *unexpected* broker position (one Fathom never placed):
+  adopt-and-flag, or alert-only? Propose adopt-and-flag (broker is truth) + a loud
+  drift alert.
+- Source of truth for realized day P&L: account summary vs summing closed trades.
+  Propose account summary.
+
+## Out of scope
+
+- Submission ([[order-placement]]), monitoring/alerts ([[deviation-monitor]], [[monitor-alerts]]).

--- a/docs/features/risk-limits-kill-switch.md
+++ b/docs/features/risk-limits-kill-switch.md
@@ -1,0 +1,81 @@
+# Feature: risk-limits-kill-switch
+
+**Status.** draft
+**Phase.** Phase 3
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The book-level deterministic gate that decides whether a freshly-sized order is
+*allowed onto the book* right now. It enforces exposure caps (max concurrent
+trades, max total risk on the book), correlation-aware shared exposure (correlated
+pairs count as one bet), and a **daily-loss kill switch** that halts all new
+entries once the day's cumulative realized loss crosses a threshold. Like sizing,
+it can only subtract: every check is a potential reject, never a green light.
+
+## User-facing behaviour
+
+Backend module `risk/limits.py`. `check_limits(order, *, open_positions, day_pl, equity, config) -> LimitDecision`:
+
+1. **Daily-loss kill switch:** if `day_pl ≤ −(daily_loss_cap × start_of_day_equity)`
+   → **reject all** new entries (`kill_switch_active=True`), until UTC-midnight reset.
+2. **Max concurrent:** if `len(open_positions) ≥ max_concurrent` → reject.
+3. **Book risk:** if `current_book_risk + order_risk > max_book_risk` → reject.
+4. **Correlation cap:** group the prospective + open positions by correlation
+   bucket; if adding this order pushes a bucket's shared exposure past
+   `max_per_correlation_group` → reject.
+
+`LimitDecision` carries `allowed: bool`, `reason`, and `kill_switch_active`. A
+read-only `kill_switch_status()` lets the CLI/monitor report state.
+
+## Acceptance criteria
+
+- [ ] Daily cumulative loss at/over the cap → every subsequent `check_limits` returns `allowed=False, kill_switch_active=True` until the UTC-day boundary; a fixture pins the reset at 00:00 UTC (INV-03).
+- [ ] `len(open_positions) == max_concurrent` → next order rejected; one fewer → allowed.
+- [ ] Book risk that would exceed `max_book_risk` → rejected; the sum is computed from each position's stop-distance risk, not notional.
+- [ ] Two correlated instruments (per the correlation source) count as shared exposure; a third correlated entry past `max_per_correlation_group` is rejected while an uncorrelated entry is allowed.
+- [ ] Every reject carries a human-readable `reason`; `kill_switch_status()` reports active/inactive + the triggering figure without side effects.
+- [ ] Pure/deterministic — open positions, day P&L, equity, and config are inputs (no DB/network/clock beyond an injected `now`).
+- [ ] Default config values are explicit and documented (daily_loss_cap, max_concurrent, max_book_risk, correlation thresholds).
+
+## Component design
+
+`risk/limits.py` is a pure decision function over injected state. The correlation
+source reuses Phase 2's `portfolio.py` correlation grouping where possible (shared
+helper) so the watchlist and the book speak the same correlation language. The
+kill switch reads `day_pl` (realized, from the store) and `start_of_day_equity`;
+the UTC-day boundary is computed from the injected `now`.
+
+## Non-goals
+
+- No sizing (units arrive sized) — [[position-sizing]].
+- No P&L computation — `day_pl` is supplied by the store/reconciliation.
+- No auto-flatten — halting *new* entries only; position-level responses live in [[deviation-monitor]].
+
+## Touches
+
+- [INV-05] — book-level extension of the per-trade cap; the daily-loss backstop.
+- [INV-03] — UTC-day boundary for the kill-switch reset.
+
+## Depends on
+
+- [[position-sizing]] (order risk), [[order-model-and-brackets]], `signals/portfolio.py` correlation helper (Phase 2, on `main`), store `day_pl`/positions (from [[order-placement]]/[[reconciliation]]).
+
+## Approach
+
+`risk/limits.py`. Reuse the Phase 2 correlation grouping. Inject all state for
+testability. Config defaults proposed below; confirm at cross-spec audit.
+
+## Open questions
+
+- **Daily-loss cap value** — propose **1.0% of start-of-day equity** (≈4 max-loss
+  trades). Operator-overridable in config.
+- Kill-switch reset — propose **UTC midnight** (INV-03-consistent) vs broker-day.
+- `max_concurrent` / `max_book_risk` / correlation thresholds — propose defaults
+  (e.g. 5 concurrent, 1.0% book risk, 2 per correlation group); confirm.
+- Correlation source: reuse Phase 2's static/rolling correlation? Propose the same source as `portfolio.py`.
+
+## Out of scope
+
+- Monitoring responses ([[deviation-monitor]]), submission ([[order-placement]]).


### PR DESCRIPTION
## Summary

Layer-4 feature specs for **impl-Phase 3** (= product-spec Phase 4 — risk, execution & monitoring, demo only), per the approved kickoff plan. Status **draft** — the cross-spec audit promotes to `ready`.

### Specs (drafting order = dependency order)
1. **order-model-and-brackets** — frozen `Order`/`Fill`/`Position` models + `build_bracket` (INV-04). Prerequisite hub, à la `Candidate`/INV-13.
2. **position-sizing** — stop-derived units + 0.25% equity cap; rejects on no valid stop (INV-05/11).
3. **risk-limits-kill-switch** — exposure + correlation caps + daily-loss kill switch (UTC-day reset).
4. **pretrade-check** — in-process Claude veto; pydantic verdict; malformed→**abort** (INV-02); stubbable adapter (adds `anthropic` dep).
5. **order-placement** — atomic bracket submit to v20 **practice**; client-id idempotency; retries; slippage capture (INV-04/07/09).
6. **reconciliation** — broker-vs-db; broker is source of truth; startup + periodic.
7. **deviation-monitor** — always-on adverse/slippage/vol/feed-health rules on open positions.
8. **monitor-alerts** — `DeviationEvent` → Discord via Hermes gateway; durable deviation log.
9. **execution-cli** — `fathom execute <candidate>` operator join (the **INV-01 enforcement point**); `positions`/`reconcile` helpers.

Each carries acceptance criteria, component design, touches, deps, proposed defaults for the phase-3 open questions, and sequence diagrams where 3+ actors / async coordination warrant them (pretrade-check, order-placement, deviation-monitor, execution-cli). `INDEX.md` Phase 3 section replaces the old planned stub.

### Invariant-promotion candidates flagged for the audit
Order/Fill/Position as a frozen contract; client-order-id idempotency; "broker is source of truth."

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)