### PR TITLE
docs(phase-3): cross-spec audit + fixes; promote INV-14/15/16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 | [`docs/PLAYBOOK.md`](docs/PLAYBOOK.md) | **Start here.** Phase status (what's done / what's next) + the reproducible build method: kickoff prompt, half-cycle layers, runbook flow, orchestration pattern, copy-paste prompts |
 | [`docs/product-spec.md`](docs/product-spec.md) | Scope, confirmed decisions, build phases, honest caveats |
 | [`docs/architecture-overview.md`](docs/architecture-overview.md) | Container diagram, key boundaries, data flows, repo layout, stack |
-| [`docs/invariants.md`](docs/invariants.md) | 13 non-negotiable rules (execution boundary, JSON+safe-defaults, UTC, brackets, 0.25% cap, approved-set gate, frozen `Candidate` contract, …) |
+| [`docs/invariants.md`](docs/invariants.md) | 16 non-negotiable rules (execution boundary, JSON+safe-defaults, UTC, brackets, 0.25% cap, approved-set gate, frozen `Candidate` + `Order`/`Fill`/`Position` contracts, client-order-id idempotency, broker-is-truth, …) |
 | [`docs/features/INDEX.md`](docs/features/INDEX.md) | One-line summary per feature area with phase and status |
 | [`docs/forex-algo-trading-plan.md`](docs/forex-algo-trading-plan.md) | Original design narrative (full rationale and deep-dives) |
 

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -12,12 +12,15 @@ Single Python repo (not a monorepo) — "areas" are package directories.
 | `data` | `data/oanda_client.py`, `data/candles.py`, `data/store.py`, `data/stream.py`, `data/calendar.py` | OANDA access, candle fetch/cache, storage, live stream, calendar | partial (PoC: client+candles+store) |
 | `strategies` | `strategies/base.py`, `strategies/_indicators.py`, `strategies/trend.py`, `strategies/mean_reversion.py`, `strategies/momentum.py`, `strategies/breakout.py` | strategy interface + shared indicators (`atr()`) + implementations | partial (PoC: base + trend/MACrossover) |
 | `backtest` | `backtest/engine.py`, `backtest/costs.py`, `backtest/walkforward.py`, `backtest/metrics.py` | event-driven engine, cost model, walk-forward, metrics | shipped (PoC); `costs.py` extended in Phase 1 |
-| `signals` | `signals/ranker.py`, `signals/portfolio.py`, `signals/charts.py` | ranker (score/filter/dedup/conflict), portfolio correlation+exposure caps, chart PNG rendering | Phase 2 (not started) |
-| `hermes_integration` | `hermes_integration/news_risk.py`, `hermes_integration/narration.py`, `hermes_integration/prompts/`, `hermes_integration/jobs/` | Claude response models+validators (INV-02), prompt templates, plain-English Hermes job (configured, not coded) | Phase 2 (not started) |
-| `cli` | `cli.py` | `fathom backtest` (Phase 1), `scan\|watchlist\|chart` (Phase 2) | new in Phase 1 |
-| `scripts` | `scripts/poc_run.py` | one-off runners | shipped (PoC) |
+| `signals` | `signals/ranker.py`, `signals/portfolio.py`, `signals/charts.py`, `signals/correlation.py` | ranker, portfolio caps, chart PNG; `correlation.py` = shared Pearson primitive **extracted from `portfolio.py` in Phase 3** | shipped (Phase 2); `correlation.py` new in Phase 3 |
+| `hermes_integration` | `hermes_integration/news_risk.py`, `narration.py`, `pretrade_check.py`, `prompts/`, `jobs/` | Claude response models+validators (INV-02); `pretrade_check.py` = in-process pre-trade veto (Phase 3) | shipped (Phase 2); `pretrade_check.py` new in Phase 3 |
+| `risk` | `risk/sizing.py`, `risk/limits.py` | stop-derived sizing (INV-05), exposure/correlation caps + daily-loss kill switch | Phase 3 |
+| `execution` | `execution/models.py`, `execution/orders.py`, `execution/reconcile.py` | frozen Order/Fill/Position (INV-14), bracket submit + idempotency (INV-04/15), broker reconciliation (INV-16) | Phase 3 |
+| `monitoring` | `monitoring/watcher.py`, `monitoring/alerts.py` | always-on deviation detection; `DiscordWebhookClient` alert delivery | Phase 3 |
+| `cli` | `cli.py` | `fathom backtest` (P1), `scan\|watchlist\|chart` (P2), `execute\|positions\|reconcile` (P3) | new in Phase 1 |
+| `scripts` | `scripts/poc_run.py`, `scripts/run_monitor.py` | one-off runners; `run_monitor.py` = always-on monitor entrypoint (Phase 3) | shipped (PoC); monitor new in Phase 3 |
 | `tests` | `tests/`, `tests/integration/` | test suites (per-area files) | shipped (PoC) |
-| _future_ | `risk/`, `execution/`, `monitoring/`, `panel/` | Phase 3+ | not started |
+| _future_ | `panel/` | Phase 4+ (admin panel) | not started |
 
 ## Shared / coordinator-owned files
 
@@ -62,3 +65,18 @@ Edits to these go through the **coordinator branch** or are **serialized** — n
 | `hermes-job-definitions` | `hermes_integration/jobs/daily.md` (config, not code) | capstone — depends on cli + both Claude specs; runs last. Its live Discord acceptance is a **manual/human-admin** task (D-P2-5). |
 
 **Safe-parallel set for Phase 2 (after `signal-ranker` locks the `Candidate` shape):** `{portfolio-limits (portfolio.py)}`, `{chart-generation (charts.py)}`, `{news-risk-assessment (hermes_integration/news_risk.py)}`, `{watchlist-narration (hermes_integration/narration.py)}` run concurrently — distinct files. `cli-commands (cli.py)` is the join (after ranker+portfolio+charts); `hermes-job-definitions` is the capstone (config + manual acceptance). `matplotlib` dep via coordinator.
+
+## Phase 3 dispatch implications (pre-resolved collisions)
+
+| Collision | Files | Resolution |
+|---|---|---|
+| **Coordinator pre-step: extract correlation primitive** | `signals/portfolio.py` (shipped) → new `signals/correlation.py` | DRIFT-09. Touches a **shipped, tested** file → **coordinator-serialized**, before `risk-limits`. Move `_pearson_corr` + returns loaders out; `portfolio.py` imports them back (behaviour-preserving; re-run Phase 2 portfolio tests). |
+| **Coordinator pre-step: `anthropic` dep** | `pyproject.toml` + `CLAUDE.md` | `pretrade-check` needs it → coordinator edit before that task (mirrors Phase 2 matplotlib). |
+| `order-model-and-brackets` defines Order/Fill/Position (INV-14) | `execution/models.py` | **load-bearing prerequisite** — sizing, order-placement, reconcile, monitor build against it. Lock + round-trip test first; do not fan out until it passes. |
+| `order-placement` owns the store migration | `execution/orders.py` + `data/store.py` (orders/fills/positions tables) | **ONLY Phase 3 task that migrates those tables.** `reconciliation` adds `account_state`; `monitor-alerts` adds `deviation_log` — distinct tables, no collision. `data/store.py` edits serialized across these 3 (declare table ownership; coordinator watches). |
+| `data/oanda_client.py` gains order + account-summary endpoints | `data/oanda_client.py` (shipped) | order-placement + reconciliation both need new endpoints → **serialized** (or one adds both, the other imports). Still the only reader of `env` (INV-09). |
+| `cli-commands` → `execution-cli` | `cli.py` (shared with P1/P2) | **ONLY Phase 3 task that edits `cli.py`** — the join. Depends on pretrade-check + sizing + limits + orders + reconcile. |
+| `pretrade-check` | `hermes_integration/pretrade_check.py` + `prompts/pretrade.md` | distinct files → parallel-safe with the risk/execution tasks once `Candidate` (shipped) is the only input. |
+| monitor pair | `monitoring/watcher.py` (+ `scripts/run_monitor.py`) vs `monitoring/alerts.py` | distinct files → parallel-safe; `watcher` defines `DeviationEvent`, `alerts` consumes it (sequence watcher→alerts logically). |
+
+**Drafting/dispatch order for Phase 3:** coordinator pre-steps (`signals/correlation.py` extract, `anthropic` dep) → `order-model-and-brackets` (lock) → `{position-sizing, risk-limits-kill-switch, pretrade-check}` ∥ → `{order-placement, reconciliation}` (serialize `store.py`/`oanda_client.py` edits) → `{deviation-monitor, monitor-alerts}` ∥ → `execution-cli` (join). `data/store.py` and `data/oanda_client.py` are shipped files touched by multiple Phase 3 tasks → **serialize, don't parallelize** those edits.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -50,21 +50,21 @@ One row per feature. Scannable in a single read — the cross-feature-consistenc
 | cli-commands | `fathom scan \| watchlist \| chart` (Hermes tools; the Hermes boundary) | [cli-commands.md](cli-commands.md) | ready |
 | hermes-job-definitions | plain-English daily Hermes job → Discord (configured not coded; capstone, INV-01) | [hermes-job-definitions.md](hermes-job-definitions.md) | ready |
 
-## Phase 3 — risk, execution & monitoring, demo only (specs drafted; cross-spec audit pending)
+## Phase 3 — risk, execution & monitoring, demo only (specs ready; cross-spec audit passed 2026-05-29)
 
 Maps to product-spec Phase 4. The phase where Fathom gains order authority — kept on the deterministic side of INV-01 (operator-run `fathom execute`, never a Hermes tool). See [phase-3.md](../phases/phase-3.md).
 
 | Feature | Summary | Spec file | Status |
 |---|---|---|---|
-| order-model-and-brackets | frozen `Order`/`Fill`/`Position` models + `build_bracket` (INV-04); prerequisite hub | [order-model-and-brackets.md](order-model-and-brackets.md) | draft |
-| position-sizing | units from stop distance + 0.25% equity cap; rejects on no valid stop (INV-05/11) | [position-sizing.md](position-sizing.md) | draft |
-| risk-limits-kill-switch | exposure + correlation caps + daily-loss kill switch (UTC-day reset) | [risk-limits-kill-switch.md](risk-limits-kill-switch.md) | draft |
-| pretrade-check | in-process Claude veto; pydantic verdict; malformed→abort (INV-02); stubbable adapter | [pretrade-check.md](pretrade-check.md) | draft |
-| order-placement | atomic bracket submit to v20 practice; client-id idempotency; retries; slippage capture (INV-04/07/09) | [order-placement.md](order-placement.md) | draft |
-| reconciliation | broker-vs-db; broker is source of truth; startup + periodic | [reconciliation.md](reconciliation.md) | draft |
-| deviation-monitor | always-on adverse-path/slippage/vol/feed-health detection on open positions | [deviation-monitor.md](deviation-monitor.md) | draft |
-| monitor-alerts | format + deliver `DeviationEvent` to Discord via Hermes gateway; durable deviation log | [monitor-alerts.md](monitor-alerts.md) | draft |
-| execution-cli | `fathom execute <candidate>` operator join (the INV-01 enforcement point); `positions`/`reconcile` helpers | [execution-cli.md](execution-cli.md) | draft |
+| order-model-and-brackets | frozen `Order`/`Fill`/`Position` models + `build_bracket` (INV-04); prerequisite hub | [order-model-and-brackets.md](order-model-and-brackets.md) | ready |
+| position-sizing | units from stop distance + 0.25% equity cap; rejects on no valid stop (INV-05/11) | [position-sizing.md](position-sizing.md) | ready |
+| risk-limits-kill-switch | exposure + correlation caps + daily-loss kill switch (UTC-day reset) | [risk-limits-kill-switch.md](risk-limits-kill-switch.md) | ready |
+| pretrade-check | in-process Claude veto; pydantic verdict; malformed→abort (INV-02); stubbable adapter | [pretrade-check.md](pretrade-check.md) | ready |
+| order-placement | atomic bracket submit to v20 practice; client-id idempotency; retries; slippage capture (INV-04/07/09) | [order-placement.md](order-placement.md) | ready |
+| reconciliation | broker-vs-db; broker is source of truth; startup + periodic | [reconciliation.md](reconciliation.md) | ready |
+| deviation-monitor | always-on adverse-path/slippage/vol/feed-health detection on open positions | [deviation-monitor.md](deviation-monitor.md) | ready |
+| monitor-alerts | format + deliver `DeviationEvent` to Discord via Hermes gateway; durable deviation log | [monitor-alerts.md](monitor-alerts.md) | ready |
+| execution-cli | `fathom execute <candidate>` operator join (the INV-01 enforcement point); `positions`/`reconcile` helpers | [execution-cli.md](execution-cli.md) | ready |
 
 ## Later — admin panel & hardening (impl-Phase 4+)
 

--- a/docs/features/deviation-monitor.md
+++ b/docs/features/deviation-monitor.md
@@ -1,6 +1,6 @@
 # Feature: deviation-monitor
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -27,9 +27,22 @@ Backend module `monitoring/watcher.py` + entrypoint `scripts/run_monitor.py`:
   realized slippage beyond a threshold; volatility spike (ATR/range expansion);
   feed-health (no tick within the heartbeat window → stale-feed alert).
 - On a trigger → emit a `DeviationEvent` to the alerter ([[monitor-alerts]]).
-- **Severe-response policy:** `alert_only` (default) | `auto_flatten` |
-  `tighten_stop`, behind a default-off config flag. On demo the default is
-  alert-only; auto-responses are opt-in.
+- **Severe-response policy (AMBIGUOUS-01 resolution):** `alert_only` (default) |
+  `auto_flatten` | `tighten_stop`, behind a default-off config flag. On demo the
+  default is **alert-only**. Any auto-response is **delegated to a deterministic
+  `execution/` function** (close/modify of an *existing* position via
+  `execution/orders.py`) — the watcher never calls the v20 order API inline, and
+  this path is **not** Hermes-reachable. INV-01 holds: the monitor may at most
+  close/modify an existing position when explicitly configured; it never *opens*
+  one.
+
+**`DeviationEvent` (pydantic — this spec, the producer, defines it):**
+`event_id` (str, stable per (position, rule, debounce-window) so re-persistence is
+idempotent), `instrument` (str), `deviation_type`
+(`Literal["adverse","slippage","vol","feed_health"]`), `detail` (str — short
+human-readable figure), `broker_trade_id` (str | None — None for feed-health),
+`severity` (`Literal["info","warn","severe"]`), `created_at` (UTC RFC-3339,
+INV-03). [[monitor-alerts]] consumes this exact shape.
 - `scripts/run_monitor.py` is the long-lived entrypoint (the always-on process on
   the private server).
 
@@ -78,7 +91,7 @@ handling — are inherited from shipped Phase 1B code).
 ## Non-goals
 
 - No alert delivery formatting/transport — that is [[monitor-alerts]].
-- No opening trades — observe-only (plus optional flatten of an *existing* position when explicitly enabled). INV-01 holds: the monitor never opens a position.
+- No opening trades — observe-only (plus optional flatten/modify of an *existing* position when explicitly enabled, delegated to `execution/orders.py`). INV-01 holds: the monitor never opens a position and is never a Hermes tool.
 - No reconciliation logic — it consumes [[reconciliation]] output for fresh positions.
 
 ## Touches

--- a/docs/features/execution-cli.md
+++ b/docs/features/execution-cli.md
@@ -1,6 +1,6 @@
 # Feature: execution-cli
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -23,12 +23,19 @@ Extends `cli.py` (the single Phase 3 writer of this file):
 fathom execute <candidate-ref> [--db-path PATH] [--dry-run] [--yes]
 ```
 
-1. Load the named candidate from the **persisted watchlist** (INV-13); error if it
-   isn't on the current watchlist (no executing arbitrary input).
-2. Fetch current equity (OANDA v20 account summary).
+1. Load the named candidate from the **latest persisted watchlist** via
+   `load_watchlist()` (INV-13). The `<candidate-ref>` is
+   `instrument:timeframe:strategy_name` (DRIFT-04) — unique within one watchlist
+   run; error if it isn't on the latest watchlist (no executing arbitrary input).
+   The full `Candidate` row (incl. `generated_at`) is loaded so the
+   `client_order_id` (INV-15) is reconstructible.
+2. **Fresh reconcile** ([[reconciliation]]): fetch account summary + broker open
+   trades and refresh the `account_state` (`day_pl`, `start_of_day_equity`) and
+   `positions` *before* the limits check (AMBIGUOUS-03 — `fathom execute` is
+   operator-initiated and infrequent, so it must not trust a stale `day_pl`).
 3. **Pre-trade check** ([[pretrade-check]]) → `block` aborts (exit non-zero, reason printed).
-4. **Sizing** ([[position-sizing]]) → reject (size 0) aborts with the reason.
-5. **Limits / kill switch** ([[risk-limits-kill-switch]]) → reject aborts with the reason.
+4. **Sizing** ([[position-sizing]], using the freshly-fetched equity) → reject (size 0) aborts with the reason.
+5. **Limits / kill switch** ([[risk-limits-kill-switch]], reading the fresh `account_state`) → reject aborts with the reason.
 6. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
 7. `--dry-run` runs steps 1–5 and prints what *would* be submitted without placing
    an order (safe rehearsal). `--yes` skips an interactive confirm.
@@ -111,13 +118,16 @@ for any execution-command reference.
 
 ## Open questions
 
-- Candidate ref format: `rank`, `instrument`, or a composite id from the watchlist
-  row? Propose composite `instrument:timeframe:strategy_name` (unambiguous on a
-  watchlist).
 - One candidate per invocation (proposed) vs a batch `--all`. Propose single; the
   book cap is enforced by limits regardless.
 - Interactive confirm default: require `--yes` for a real submit, or confirm prompt?
   Propose a confirm prompt unless `--yes` (demo safety).
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-04 — `<candidate-ref>` =
+`instrument:timeframe:strategy_name`, resolved against the latest watchlist run
+(`load_watchlist(run_timestamp=None)`); the full row is loaded for the
+`client_order_id` derivation. AMBIGUOUS-03 — `fathom execute` triggers a fresh
+reconcile before the limits check so the kill switch reads a current `day_pl`.
 
 ## Out of scope
 

--- a/docs/features/monitor-alerts.md
+++ b/docs/features/monitor-alerts.md
@@ -1,6 +1,6 @@
 # Feature: monitor-alerts
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -9,40 +9,52 @@
 
 The delivery layer for the deviation monitor: turn a `DeviationEvent` into a
 concise, human-readable alert and post it to the **same Discord channel** as the
-daily watchlist, via Hermes' Discord gateway. Alerts ride the existing Hermes
-gateway (delivery only — this is outbound notification, not order authority, so
-INV-01 is untouched). Delivery is best-effort with retry; an event is always
-persisted to the store's deviation log regardless of delivery success.
+daily watchlist. **Delivery mechanism (DRIFT-06 resolution):** the always-on
+monitor is a standalone Python process (`scripts/run_monitor.py`), **not** a
+Hermes job — there is no Python-callable "Hermes gateway." It therefore posts
+directly via a small `DiscordWebhookClient` that POSTs to `DISCORD_WEBHOOK_URL`
+(the same webhook the Phase 2 watchlist channel uses, from `.env` — INV-08). This
+is outbound notification only, not order authority, so INV-01 is untouched and no
+Hermes job is involved. Delivery is best-effort with retry; an event is always
+persisted to the `deviation_log` table first, regardless of delivery success.
 
 ## User-facing behaviour
 
 Backend module `monitoring/alerts.py`:
 
-- `Alerter(gateway, store)` with `send(event: DeviationEvent) -> None`.
+- `Alerter(webhook_client, store)` with `send(event: DeviationEvent) -> None`.
 - Formats a one-line alert: `⚠️ <instrument> <type> | <detail> | <UTC time>`
   (e.g. `⚠️ EUR_USD adverse | −0.6×stop excursion | 2026-05-29T15:10:00Z`).
-- Persists the event to the store `deviation_log` table first (durable), then posts
-  to Discord via the Hermes gateway.
-- Delivery failure → retry per gateway policy; the persisted log is the durable
-  record for the panel (impl-Phase 4) and post-hoc review.
+- Persists the event to the `deviation_log` table first (durable), then POSTs to
+  `DISCORD_WEBHOOK_URL` via the `DiscordWebhookClient`.
+- Delivery failure → retry with backoff; the persisted log is the durable record
+  for the panel (impl-Phase 4) and post-hoc review.
 - Debounce/severity is decided upstream in [[deviation-monitor]]; the alerter
   formats and ships.
+
+**`deviation_log` table (this spec owns the migration):**
+`event_id` (PK, text), `instrument`, `deviation_type` (text enum:
+`adverse`|`slippage`|`vol`|`feed_health`), `detail` (text), `broker_trade_id`
+(nullable — feed-health events have no position), `severity` (text), `created_at`
+(UTC RFC-3339), `delivered` (bool, set true after a successful POST). `event_id` is
+unique → re-persisting the same event is a no-op (idempotent).
 
 ## Acceptance criteria
 
 - [ ] Each `DeviationEvent` is persisted to `deviation_log` **before** the delivery attempt (durable even if Discord is down). Verified.
 - [ ] The formatted alert is one line, includes instrument, deviation type, a short detail, and a UTC RFC-3339 timestamp (INV-03); no secret appears (INV-08).
-- [ ] Delivery goes through the Hermes Discord gateway to the configured channel; a delivery failure is retried and does not raise into the monitor loop (a down Discord never crashes the watcher).
+- [ ] Delivery POSTs to `DISCORD_WEBHOOK_URL` (the shared watchlist channel); a delivery failure is retried with backoff and does not raise into the monitor loop (a down Discord never crashes the watcher).
 - [ ] Alerts are outbound-only — the module exposes no order/execution capability and is not registered as a Hermes tool (INV-01).
 - [ ] A duplicate event id is not double-logged (idempotent persistence).
 
 ## Component design
 
-`monitoring/alerts.py` takes an injectable `gateway` (the Hermes Discord webhook /
-gateway client) and the store. Formatting is a pure function over `DeviationEvent`
-(unit-testable); persistence-then-deliver ordering guarantees the durable record.
-Mirrors Phase 2's "delivery is best-effort, the store is the durable truth"
-posture. → sonnet.
+`monitoring/alerts.py` takes an injectable `DiscordWebhookClient` (a thin `httpx`
+POST wrapper around `DISCORD_WEBHOOK_URL`) and the store. Formatting is a pure
+function over `DeviationEvent` (unit-testable); persistence-then-deliver ordering
+guarantees the durable record. Mirrors Phase 2's "delivery is best-effort, the
+store is the durable truth" posture. Tests inject a stub client (no live HTTP).
+→ sonnet.
 
 ## Non-goals
 
@@ -57,21 +69,24 @@ posture. → sonnet.
 
 ## Depends on
 
-- [[deviation-monitor]] (`DeviationEvent`), the Hermes Discord gateway (config), `data/store.py` (`deviation_log` table — this spec owns it).
+- [[deviation-monitor]] (`DeviationEvent`), `DISCORD_WEBHOOK_URL` (`.env`, the shared watchlist webhook), `httpx` (shipped dep), `data/store.py` (`deviation_log` table — this spec owns it).
 
 ## Approach
 
 `monitoring/alerts.py`. Pure formatter + persist-then-deliver wrapper with retry.
-Inject the gateway for testing (no live Discord in tests). The live webhook is
+Inject a stub webhook client for testing (no live Discord in tests). The live webhook is
 exercised at the acceptance gate alongside the watcher.
 
 ## Open questions
 
-- Gateway interface: reuse the same Discord webhook the Phase 2 watchlist uses, or a
-  dedicated alerts webhook? Propose **same channel** (per the design — watchlist +
-  alerts together), one webhook.
 - Rate-limit/coalesce repeated alerts for the same position — propose a short
   cooldown window; debounce primarily lives in [[deviation-monitor]].
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-06 — the monitor is a
+standalone Python process, not a Hermes job; it posts directly to the shared
+`DISCORD_WEBHOOK_URL` via `DiscordWebhookClient` (one webhook, same channel as the
+watchlist). DRIFT-08 — `DeviationEvent` is defined in [[deviation-monitor]]; the
+`deviation_log` columns are pinned above.
 
 ## Out of scope
 

--- a/docs/features/order-model-and-brackets.md
+++ b/docs/features/order-model-and-brackets.md
@@ -1,6 +1,6 @@
 # Feature: order-model-and-brackets
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -20,19 +20,37 @@ watchlist. No I/O, no OANDA calls — models and bracket maths only.
 Backend module `execution/models.py` (models) + a `build_bracket()` pure function.
 Not a CLI surface; consumed by other Phase 3 modules.
 
-- `Order` — an intent to open a position: `client_order_id` (idempotency key),
-  `instrument`, `direction`, `units` (signed: +long/−short), `entry_type`
-  (`market`), `stop_loss_price`, `take_profit_price`, `candidate_ref` (the
-  originating `Candidate` identity), `created_at` (UTC).
+- `Order` — an intent to open a position: `client_order_id` (idempotency key,
+  derived — see below), `instrument`, `direction`, `units` (signed: +long/−short),
+  `entry_type` (`market`), `stop_loss_price`, `take_profit_price`, `candidate_ref`
+  (the originating `Candidate` identity — see below), `created_at` (UTC).
 - `Fill` — the broker's confirmation: `client_order_id`, `broker_trade_id`,
-  `fill_price`, `units_filled`, `slippage` (fill vs `Candidate.entry_ref`),
+  `fill_price`, `units_filled` (signed), `slippage` (signed — see convention),
   `filled_at` (UTC), `status` (`filled`|`partial`|`rejected`).
-- `Position` — current open state: `broker_trade_id`, `instrument`, `units`,
-  `entry_price`, `stop_loss_price`, `take_profit_price`, `opened_at`,
-  `unrealized_pl`, `candidate_ref`.
-- `build_bracket(candidate, units, *, precision) -> Order` — converts the
-  `Candidate`'s **price-distance** stop/target into **absolute** bracket prices for
-  the order's direction, rounded to the instrument's price precision.
+- `Position` — current open state: `broker_trade_id`, `instrument`, `units`
+  (signed), `entry_price`, `stop_loss_price`, `take_profit_price`, `opened_at`,
+  `unrealized_pl`, `closed_at` (nullable), `realized_pl` (nullable until close),
+  `candidate_ref`. (Persisted column list is pinned in [[order-placement]].)
+- `build_bracket(candidate, units, *, execution_date, precision) -> Order` —
+  converts the `Candidate`'s **price-distance** stop/target into **absolute**
+  bracket prices for the order's direction, rounded to `precision`, and computes the
+  `client_order_id`. `precision` is bound to `InstrumentMeta.display_precision`
+  (DRIFT-07).
+
+**`client_order_id` derivation (DRIFT-03 / INV-15).** `build_bracket` computes
+`client_order_id = sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date}").hexdigest()[:32]`
+from the `Candidate` fields + the injected `execution_date`. The same formula is
+stated in [[order-placement]] and [[execution-cli]].
+
+**`candidate_ref` (DRIFT-04).** A string `f"{instrument}:{timeframe}:{strategy_name}"`
+— the same value `fathom execute` ([[execution-cli]]) accepts as its argument and
+resolves against the latest persisted watchlist. It is provenance, distinct from the
+`client_order_id` (which additionally folds in `generated_at` + `execution_date`).
+
+**Sign convention (AMBIGUOUS-05).** `units`/`units_filled` are signed to match
+OANDA v20 (long > 0, short < 0). `slippage` is signed so **positive = adverse**
+(worse than `Candidate.entry_ref`) regardless of direction. Pinned by the AC worked
+examples.
 
 ## Acceptance criteria
 
@@ -70,6 +88,8 @@ breaking and reviewable.
 - [INV-03] — UTC timestamps on all models.
 - [INV-11] — consumes the ATR-derived `stop_distance`/`target_distance` unchanged.
 - [INV-13] — reads the frozen `Candidate`; never mutates it.
+- [INV-14] — these models **are** the frozen execution contract (this spec defines it).
+- [INV-15] — computes the deterministic `client_order_id`.
 
 ## Depends on
 
@@ -87,8 +107,12 @@ fan-out begins.
 - Entry type: market-only for Phase 3, or also limit/stop-entry? Propose
   **market-only** (the watchlist `entry_ref` is a reference, fills at market);
   revisit if slippage capture shows it matters.
-- Does `Position` carry realized P&L too, or only unrealized? Propose unrealized
-  here; realized P&L is a reconciliation/store concern.
+
+**Resolved at cross-spec audit (2026-05-29):** `Position` carries both
+`unrealized_pl` and `realized_pl` (the latter written by [[reconciliation]] on
+close); `precision` binds to `InstrumentMeta.display_precision` (DRIFT-07);
+`client_order_id`/`candidate_ref`/sign conventions pinned above; models promoted to
+**INV-14**.
 
 ## Out of scope
 

--- a/docs/features/order-placement.md
+++ b/docs/features/order-placement.md
@@ -1,6 +1,6 @@
 # Feature: order-placement
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -72,10 +72,29 @@ sequenceDiagram
 
 `execution/orders.py` uses `oandapyV20` order endpoints via the existing
 `oanda_client.py` (extended with order + account-summary endpoints; still the only
-reader of `env`). The store gains `orders`/`fills`/`positions` tables (this spec
-owns the migration). Idempotency is enforced two ways: the v20 client-order-id
+reader of `env`). The store gains `orders`/`fills`/`positions` tables (**this spec
+owns the migration**). Idempotency is enforced two ways: the v20 client-order-id
 client extension *and* a pre-submit store check — belt and suspenders against
 double-fills. Unit tests mock v20 with `responses`; no live HTTP in tests. → opus.
+
+**Idempotency key (DRIFT-03 — pinned, INV-15).** `client_order_id =
+sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date}").hexdigest()[:32]`,
+computed by `build_bracket()` in [[order-model-and-brackets]] from the `Candidate`
+fields plus an injected `execution_date` (UTC date of the `fathom execute` run).
+The same approved candidate retried the same day dedups; a genuine re-approval the
+next day yields a distinct id. `order-model`, this spec, and [[execution-cli]] all
+state this one formula.
+
+**Store schema (DRIFT-01/02 — pinned). `orders`:** `client_order_id` (PK),
+`instrument`, `direction`, `units`, `stop_loss_price`, `take_profit_price`,
+`candidate_ref`, `created_at`, `status`. **`fills`:** `client_order_id` (FK),
+`broker_trade_id`, `fill_price`, `units_filled`, `slippage`, `status`
+(`filled`|`partial`|`rejected`), `filled_at`. **`positions`:** `broker_trade_id`
+(PK), `instrument`, `units`, `entry_price`, `stop_loss_price`,
+`take_profit_price`, `candidate_ref`, `opened_at`, `unrealized_pl`, `closed_at`
+(nullable), **`realized_pl`** (nullable until close — written by
+[[reconciliation]] when the broker reports the trade closed; summed into the
+kill-switch `day_pl`). All timestamps UTC RFC-3339 (INV-03).
 
 ## Non-goals
 
@@ -103,13 +122,13 @@ throughout; the live practice submission is exercised at the acceptance gate.
 
 ## Open questions
 
-- **Idempotency key scheme** — propose `client_order_id` = hash of
-  `(instrument, strategy_name, timeframe, generated_at, execution_date)` so a retry
-  of the same approval dedups but a genuine re-approval next day is distinct. Pin here.
-- Store schema migration ownership — this spec owns `orders`/`fills`/`positions`;
-  reconciliation reads them.
-- v20 stop/target as absolute price vs distance — propose absolute price (from
+- v20 stop/target as absolute price vs distance — **resolved:** absolute price (from
   [[order-model-and-brackets]]), instrument precision applied.
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-03 idempotency key pinned
+(above, INV-15); DRIFT-01/02 store schema columns pinned (above) incl. `realized_pl`;
+schema-migration ownership = this spec (reconciliation reads/writes `realized_pl`,
+monitor-alerts owns `deviation_log`).
 
 ## Out of scope
 

--- a/docs/features/position-sizing.md
+++ b/docs/features/position-sizing.md
@@ -1,6 +1,6 @@
 # Feature: position-sizing
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -17,13 +17,19 @@ risk budget — never a fixed lot. This is the first gate that can reject a trad
 
 Backend module `risk/sizing.py`. `size_position(candidate, equity, *, instrument_meta, risk_fraction=0.0025) -> SizingResult`:
 
-1. Compute the per-unit risk = `stop_distance` converted to account-currency value
-   per unit (via `InstrumentMeta` pip value / quote conversion).
+1. Compute the per-unit risk in account currency (DRIFT-07): for a base/quote pair,
+   the loss-per-unit if the stop is hit is `stop_distance × quote_to_account_rate`
+   (price units × the quote→account-currency rate). For a quote==account pair the
+   rate is 1; for a non-account-quote pair (e.g. USD_JPY with a USD account) apply
+   the conversion rate. **There is no `InstrumentMeta.pip_value` field — per-unit
+   risk is derived from `stop_distance` (a price distance) and the quote rate; only
+   `pip_location` is used, and only to validate price precision.**
 2. `risk_budget = equity × risk_fraction` (0.25% default).
 3. `units = floor(risk_budget / per_unit_risk)`, signed by direction.
-4. Clamp to the instrument's min/max trade size; **reject** (return a
-   `SizingResult` with `units=0` and a reason) if the budget cannot fund even the
-   minimum size, or if `stop_distance ≤ 0`.
+4. **Reject** (return a `SizingResult` with `units=0` and a reason) if the budget
+   cannot fund the instrument's `InstrumentMeta.min_trade_size`, or if
+   `stop_distance ≤ 0`. (No max-trade-size clamp — OANDA's `InstrumentMeta` exposes
+   no per-instrument max; the book-level cap is enforced by [[risk-limits-kill-switch]].)
 
 `SizingResult` carries `units`, `risk_amount` (actual money at risk), `reason`
 (when rejected). The execution CLI surfaces the reason on rejection.
@@ -33,7 +39,7 @@ Backend module `risk/sizing.py`. `size_position(candidate, equity, *, instrument
 - [ ] For a worked example (known equity, stop distance, pip value), `units` is the largest size whose stop-loss equals ≤ 0.25% of equity — verified by hand-computed fixtures for EUR_USD (quote=USD) and USD_JPY (quote=JPY, conversion required).
 - [ ] The realized risk (`units × per_unit_risk`) never exceeds `equity × risk_fraction` — property-tested across random equity/stop combinations (INV-05).
 - [ ] `stop_distance ≤ 0` → reject (`units=0`, reason set); never sizes naked (INV-04/11 boundary).
-- [ ] A budget too small for the instrument minimum → reject with a clear reason; never rounds up to the minimum.
+- [ ] A budget too small for `InstrumentMeta.min_trade_size` → reject with a clear reason; never rounds up to the minimum. (No max-size clamp.)
 - [ ] `risk_fraction` is a parameter defaulting to `0.0025`; it is read from config, and the default cap cannot be exceeded silently.
 - [ ] Quote-currency conversion is correct for non-USD-quote pairs (uses current rate from the candle store / account summary); a JPY-quote fixture pins it.
 - [ ] Pure and deterministic — no network, no clock; equity and rates are inputs.
@@ -71,8 +77,13 @@ account-currency assumption (USD) is config-driven, not hard-coded.
 ## Open questions
 
 - Account currency: assume USD (demo account) for Phase 3, config-driven? Propose yes.
-- Rate source for quote conversion: latest cached candle close vs account-summary
-  margin rate. Propose latest cached mid; confirm in spec.
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-07 — per-unit risk derives from
+`stop_distance × quote_to_account_rate` (no `pip_value` field); the max-size clamp
+is dropped (no source). AMBIGUOUS-02 — the quote→account **rate source is the latest
+cached candle mid** for the conversion pair; `equity` is the live account-summary
+value fetched once by [[execution-cli]]. The freshness mismatch (cached rate vs live
+equity) is accepted — it perturbs the 0.25% cap by less than intraday rate drift.
 
 ## Out of scope
 

--- a/docs/features/pretrade-check.md
+++ b/docs/features/pretrade-check.md
@@ -1,6 +1,6 @@
 # Feature: pretrade-check
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29

--- a/docs/features/reconciliation.md
+++ b/docs/features/reconciliation.md
@@ -1,6 +1,6 @@
 # Feature: reconciliation
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -24,7 +24,14 @@ Backend module `execution/reconcile.py`. `reconcile(*, client, store, now) -> Re
    - **store-only** position (we think open, broker closed it — stop/target hit) →
      mark it closed in the store, record the realized P&L.
    - **matched** → refresh `unrealized_pl`, stop/target, units.
-3. Update `start_of_day_equity` / `day_pl` used by the kill switch.
+3. Update the persisted `account_state` row used by the kill switch (DRIFT-02/05):
+   - `day_pl` ← the **account-summary's realized day P&L** (the broker's figure —
+     authoritative per INV-16; the store column is a cached mirror, not an
+     independent sum-of-closed-trades).
+   - `start_of_day_equity` ← snapshotted **once, on the first reconcile after the
+     UTC-day boundary** (00:00 UTC, INV-03-consistent with the kill-switch reset).
+     A mid-day process restart re-reads the persisted snapshot — it does **not**
+     re-snapshot (so the kill-switch threshold is stable across restarts).
 4. Return a `ReconcileReport` (`adopted`, `closed`, `matched`, `drift_flags`).
 
 Invoked at monitor startup and every N minutes; also callable via a read-only
@@ -33,7 +40,8 @@ Invoked at monitor startup and every N minutes; also callable via a read-only
 ## Acceptance criteria
 
 - [ ] A broker-open position absent from the store is **adopted** (inserted) — the broker wins. Verified against a mocked v20 open-trades response.
-- [ ] A store-open position the broker has closed is **marked closed** with realized P&L recorded; the kill-switch `day_pl` reflects it. Verified.
+- [ ] A store-open position the broker has closed is **marked closed** with `realized_pl` written to the `positions` row; the `account_state.day_pl` (from account-summary) reflects the day's loss. Verified.
+- [ ] `start_of_day_equity` is snapshotted once per UTC day (first reconcile after 00:00 UTC) and is stable across a mid-day restart (re-read, not re-snapshotted). Verified with a fixture crossing the day boundary.
 - [ ] A matched position has its `unrealized_pl`/stop/target refreshed from the broker.
 - [ ] `start_of_day_equity` and `day_pl` are updated from the account summary so the kill switch reads true figures.
 - [ ] Drift (counts/ids that don't line up) is recorded in `drift_flags` and logged at WARNING — never silently dropped.
@@ -76,8 +84,14 @@ Run on monitor startup and on a timer; expose a read-only operator command.
 - Adoption policy for an *unexpected* broker position (one Fathom never placed):
   adopt-and-flag, or alert-only? Propose adopt-and-flag (broker is truth) + a loud
   drift alert.
-- Source of truth for realized day P&L: account summary vs summing closed trades.
-  Propose account summary.
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-05 — realized `day_pl` source
+is the **account-summary** figure (broker-truth, INV-16); the store column mirrors
+it. Caveat noted: the broker's day boundary may differ from UTC-midnight (which the
+kill switch uses for reset) — `account_state` records both the broker figure and the
+UTC-day `start_of_day_equity` so the kill switch reasons in UTC. DRIFT-02 — the
+`account_state` table (`start_of_day_equity`, `day_pl`, `as_of` UTC) is owned by
+this spec's migration; restart re-reads, never re-snapshots.
 
 ## Out of scope
 

--- a/docs/features/risk-limits-kill-switch.md
+++ b/docs/features/risk-limits-kill-switch.md
@@ -1,6 +1,6 @@
 # Feature: risk-limits-kill-switch
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 3
 **Owner.** saambaby
 **Last updated.** 2026-05-29
@@ -41,11 +41,19 @@ read-only `kill_switch_status()` lets the CLI/monitor report state.
 
 ## Component design
 
-`risk/limits.py` is a pure decision function over injected state. The correlation
-source reuses Phase 2's `portfolio.py` correlation grouping where possible (shared
-helper) so the watchlist and the book speak the same correlation language. The
-kill switch reads `day_pl` (realized, from the store) and `start_of_day_equity`;
-the UTC-day boundary is computed from the injected `now`.
+`risk/limits.py` is a pure decision function over injected state. **Correlation
+source (DRIFT-09 resolution):** shipped `signals/portfolio.py` inlines its
+correlation logic inside `PortfolioLimiter.apply()` (a private `_pearson_corr` +
+returns loaders, doing *pairwise admission-time dropping* — not bucket grouping).
+There is no reusable grouping helper today. Resolution: a **prerequisite
+coordinator task extracts `_pearson_corr` + the returns loaders
+(`_mid_returns`/`_load_returns`/`_split_currencies`) into `signals/correlation.py`**
+(a refactor of the shipped, tested `portfolio.py` — coordinator-serialized, flagged
+in code-map), so the watchlist and the book share one correlation primitive.
+`risk/limits.py` then builds its *bucket-grouping* (shared-exposure-per-bucket) on
+that primitive — a different shape than portfolio's per-currency cap, kept distinct.
+The kill switch reads `day_pl` and `start_of_day_equity` from the `account_state`
+row ([[reconciliation]]); the UTC-day boundary is computed from the injected `now`.
 
 ## Non-goals
 
@@ -60,12 +68,12 @@ the UTC-day boundary is computed from the injected `now`.
 
 ## Depends on
 
-- [[position-sizing]] (order risk), [[order-model-and-brackets]], `signals/portfolio.py` correlation helper (Phase 2, on `main`), store `day_pl`/positions (from [[order-placement]]/[[reconciliation]]).
+- [[position-sizing]] (order risk), [[order-model-and-brackets]], the extracted `signals/correlation.py` primitive (prerequisite coordinator task — see Component design), `account_state` + `positions` (from [[reconciliation]]/[[order-placement]]).
 
 ## Approach
 
-`risk/limits.py`. Reuse the Phase 2 correlation grouping. Inject all state for
-testability. Config defaults proposed below; confirm at cross-spec audit.
+`risk/limits.py`. Build bucket-grouping on the extracted `signals/correlation.py`
+primitive (see Component design). Inject all state for testability.
 
 ## Open questions
 
@@ -74,7 +82,12 @@ testability. Config defaults proposed below; confirm at cross-spec audit.
 - Kill-switch reset — propose **UTC midnight** (INV-03-consistent) vs broker-day.
 - `max_concurrent` / `max_book_risk` / correlation thresholds — propose defaults
   (e.g. 5 concurrent, 1.0% book risk, 2 per correlation group); confirm.
-- Correlation source: reuse Phase 2's static/rolling correlation? Propose the same source as `portfolio.py`.
+
+**Resolved at cross-spec audit (2026-05-29):** DRIFT-09 — extract the correlation
+primitive to `signals/correlation.py` (coordinator task touching shipped
+`portfolio.py`), build bucket-grouping on it here; `max_per_correlation_group` is a
+distinct concept from portfolio's `max_per_currency`. DRIFT-02 — `day_pl` /
+`start_of_day_equity` come from the `account_state` row, not an ad-hoc store read.
 
 ## Out of scope
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -132,3 +132,33 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 **Reason:** `Candidate` is consumed by `portfolio.py`, `charts.py`, `cli.py`, `narration.py`, and the Hermes daily job. Once shipped, a silent field rename ripples across all of them and breaks the Discord watchlist. Freezing the contract (as INV-11 freezes the `Signal` stop/target derivation) makes the dependency explicit and reviewable. Note: `timeframe` is the same dimension the approved-set/DB calls `granularity`; the INV-10 gate join is `signal.timeframe == approved_set.granularity`.
 
 **Enforcement:** The field table lives in `docs/features/signal-ranker.md`; `cli-commands`, `chart-generation`, and `watchlist-narration` reference it rather than re-listing fields. A serialisation round-trip test pins the JSON shape. Reviewer checks any `Candidate` field change against this invariant.
+
+---
+
+## INV-14 · The `Order`/`Fill`/`Position` Models Are the Frozen Execution Contract
+
+**Rule:** `execution/models.py`'s `Order`, `Fill`, and `Position` pydantic models are the stable in-process execution contract. Their field names (snake_case), types, and flat shape are frozen once `order-model-and-brackets` ships. `position-sizing`, `order-placement`, `reconciliation`, the deviation monitor, and the alerter all build against this exact shape. A change to field names/types/shape is a breaking change across the execution path and must be treated as an amendment to this invariant.
+
+**Reason:** like `Candidate` (INV-13), these models are consumed by many modules; a silent rename ripples across sizing, placement, reconciliation, and monitoring. Freezing them makes the dependency explicit and reviewable. This is the execution-side analogue of INV-13.
+
+**Enforcement:** a serialisation round-trip test pins each model's JSON shape; the field tables live in `docs/features/order-model-and-brackets.md` (and the persisted column lists in `order-placement.md`), and consumers reference them rather than re-listing fields. Reviewer checks any field change against this invariant.
+
+---
+
+## INV-15 · Every Order Carries a Deterministic Client-Order-ID; Retries Never Double-Fill
+
+**Rule:** every `Order` submitted to OANDA carries a `client_order_id` deterministically derived from `(instrument, strategy_name, timeframe, generated_at, execution_date)`. Submission is idempotent: re-submitting the same `client_order_id` (a network retry, or an operator re-run of `fathom execute`) must return the existing fill, never create a second broker order.
+
+**Reason:** a network retry or an operator re-run must not open a duplicate position. A double-fill costs real money and corrupts the book the kill switch and monitor trust. Idempotency is a first-class safety feature, not an afterthought.
+
+**Enforcement:** `build_bracket()` computes the id; `execution/orders.py` checks the store and attaches the v20 client-extension id before every submit (belt-and-suspenders). A duplicate-submit test asserts exactly one filled position.
+
+---
+
+## INV-16 · The Broker Is the Source of Truth for Positions and Realized P&L
+
+**Rule:** on any disagreement between Fathom's local `positions`/`account_state` and the OANDA account (open trades, account summary), the broker wins: local state is corrected to match. A broker-only position is adopted; a locally-open position the broker has closed is marked closed with its realized P&L; the realized day P&L and equity the kill switch reads are sourced from the broker account summary.
+
+**Reason:** a crashed process or a missed fill must be recoverable, not silently wrong — the kill switch (INV-05 daily cap) and the deviation monitor both trust this state. Operational risk is real risk; reconciliation is a first-class feature.
+
+**Enforcement:** `execution/reconcile.py` applies broker-wins on startup and every N minutes; drift is logged at WARNING, never silently dropped. The kill switch reads `day_pl`/`start_of_day_equity` from the reconciled `account_state` row.

--- a/docs/phases/phase-3-spec-audit-2026-05-29.md
+++ b/docs/phases/phase-3-spec-audit-2026-05-29.md
@@ -1,0 +1,72 @@
+# Fathom Phase 3 — Cross-Spec Audit (2026-05-29)
+
+Run per `runbook-cross-spec-audit` by a fresh, independent, read-only auditor (no
+prior session context). Fixes applied afterward by the lead — each finding
+annotated with its resolution. Audit + fixes landed together in one PR.
+
+## Scope
+
+The 9 Phase 3 specs (`order-model-and-brackets`, `position-sizing`,
+`risk-limits-kill-switch`, `pretrade-check`, `order-placement`, `reconciliation`,
+`deviation-monitor`, `monitor-alerts`, `execution-cli`), cross-checked against
+`invariants.md`, `phase-3.md`, `code-map.md`, `INDEX.md`, and the shipped contracts
+(`Candidate`/INV-13, `Signal`, `data/oanda_client.py::InstrumentMeta`,
+`data/store.py`, `hermes_integration/news_risk.py`, `signals/portfolio.py`).
+
+## Summary
+
+18 shared concepts · 7 consistent · **6 blocking drift** · 3 non-blocking drift ·
+5 ambiguities · 3 invariant-promotion candidates (all promoted). All blocking items
+were bounded spec edits (missing model columns, a phantom `InstrumentMeta.pip_value`,
+a non-existent "Hermes gateway" code object, an unproduced `start_of_day_equity`),
+not structural rework. All fixed below; corpus is now taskgraph-ready.
+
+## Drift findings & resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| DRIFT-01 | blocking | Realized P&L named by reconciliation/risk-limits but no model/column carries it; `order-model` punted it | **Fixed** — `order-placement` pins `positions.realized_pl` (+ full `orders`/`fills`/`positions` column lists); `order-model` `Position` now lists `realized_pl`; reconciliation writes it, risk-limits sums it into `day_pl` |
+| DRIFT-02 | blocking | `start_of_day_equity` consumed by the kill switch, produced by nothing; account-summary returns *current* equity, not day-open | **Fixed** — reconciliation owns an `account_state` row (`start_of_day_equity`, `day_pl`, `as_of`) snapshotted once on the first reconcile after 00:00 UTC; restart re-reads, never re-snapshots; risk-limits reads it |
+| DRIFT-03 | blocking | `client_order_id` scheme stated 3 ways (phase-3 vs order-placement vs "non-empty string"); producer undefined | **Fixed** — one formula pinned in `order-placement`/`order-model`/`execution-cli`: `sha256(instrument:strategy_name:timeframe:generated_at:execution_date)[:32]`, computed in `build_bracket`. Promoted to **INV-15** |
+| DRIFT-04 | blocking | `Order.candidate_ref` (provenance) conflated with the `fathom execute` ref (lookup key); CLI ref omitted `generated_at` needed for the id | **Fixed** — `candidate_ref` = `instrument:timeframe:strategy_name` (provenance), distinct from `client_order_id`; CLI loads the full `Candidate` row (incl. `generated_at`) by that ref from the latest watchlist |
+| DRIFT-05 | blocking | Realized `day_pl` source stated two ways (account-summary vs sum-of-closed-trades) | **Fixed** — account-summary is authoritative (broker-truth, INV-16); store column mirrors it; broker-day-vs-UTC-day caveat documented in reconciliation |
+| DRIFT-06 | blocking | `monitor-alerts` assumes an injectable "Hermes Discord gateway" that does not exist; the monitor is a Python process, not a Hermes job | **Fixed** — replaced with a `DiscordWebhookClient` POSTing to `DISCORD_WEBHOOK_URL` (shared watchlist channel, INV-08) directly from the standalone monitor; phase-3 diagram + execution-boundary updated; no Hermes job involved (INV-01 untouched) |
+| DRIFT-07 | blocking | `position-sizing`/`order-model` use `InstrumentMeta.pip_value` + max-trade-size — neither exists on the shipped model | **Fixed** — per-unit risk = `stop_distance × quote_to_account_rate` (uses `pip_location`, no `pip_value` field); max-size clamp dropped (no source; book cap covers it); `build_bracket` `precision` bound to `display_precision` |
+| DRIFT-08 | non-blocking | `DeviationEvent` referenced by two specs, defined by neither; `deviation_log` columns unspecified | **Fixed** — `DeviationEvent` pydantic defined in `deviation-monitor` (producer); `deviation_log` column list pinned in `monitor-alerts` (migration owner) |
+| DRIFT-09 | non-blocking | `risk-limits` "reuses `portfolio.py` correlation grouping" — no reusable grouping helper exists (logic inlined in `PortfolioLimiter.apply`) | **Fixed** — prerequisite coordinator task extracts the correlation primitive to `signals/correlation.py` (touches shipped `portfolio.py` → coordinator-serialized, flagged in code-map); risk-limits builds bucket-grouping on it; `max_per_correlation_group` ≠ portfolio's `max_per_currency` |
+
+## Ambiguity findings & resolutions
+
+| ID | Finding | Resolution |
+|---|---|---|
+| AMBIGUOUS-01 | Monitor auto-flatten vs INV-01 — which module performs the close; does it cross into the execution engine? | **Fixed (lead ruling)** — any auto-response is delegated to a deterministic `execution/` function, default-off on demo, never Hermes-reachable. "Deterministic close/modify of an *existing* position is permitted; opening is not." Stated in deviation-monitor + phase-3 boundary |
+| AMBIGUOUS-02 | Equity (live) vs quote-conversion rate (cached) freshness mismatch in sizing | **Fixed** — rate source = latest cached candle mid; equity = live account-summary; the sub-rate-drift perturbation of the 0.25% cap is accepted and documented |
+| AMBIGUOUS-03 | `fathom execute` may check the kill switch against a stale `day_pl` | **Fixed** — `execute` triggers a fresh reconcile before the limits check |
+| AMBIGUOUS-04 | `fathom execute` ref resolvability against the watchlist | **Fixed** — resolves against the latest watchlist run (`load_watchlist(run_timestamp=None)`); stated in execution-cli |
+| AMBIGUOUS-05 | `units`/`slippage` sign conventions loosely specified | **Fixed** — `units` signed to match v20 (long>0/short<0); `slippage` signed so positive = adverse; pinned by order-model AC worked examples |
+
+## Invariant promotions (all promoted)
+
+- **INV-14** — `Order`/`Fill`/`Position` are the frozen execution contract (execution-side analogue of INV-13).
+- **INV-15** — deterministic `client_order_id`; retries never double-fill (depends on DRIFT-03 being pinned — done).
+- **INV-16** — the broker is the source of truth for positions and realized P&L.
+
+Added to `docs/invariants.md`; `order-model-and-brackets` §Touches references INV-14/15; phase-3 active-invariants list updated.
+
+## Consistent (no action)
+
+Gate ordering (pretrade→size→limits→submit) identical across execution-cli/phase-3;
+store-table ownership unambiguous (order-placement owns orders/fills/positions +
+account_state; monitor-alerts owns deviation_log); `anthropic` coordinator-edit
+sequencing mirrors Phase 2's matplotlib pattern; safe-default posture (`block`)
+consistent with INV-02; practice-endpoint-only (INV-07/09); reconcile cadence
+(startup + 5 min); UTC-day kill-switch reset.
+
+## Action plan — status
+
+All 6 blocking + 3 non-blocking drifts and all 5 ambiguities **Fixed** in this PR;
+3 invariants promoted. One **prerequisite coordinator task** surfaced for the
+taskgraph: extract `signals/correlation.py` from the shipped `portfolio.py` (before
+`risk-limits-kill-switch`).
+
+**Verdict after fixes:** spec corpus coherent; **ready for taskgraph generation.**

--- a/docs/phases/phase-3.md
+++ b/docs/phases/phase-3.md
@@ -47,7 +47,7 @@ deferred to impl-Phase 5.
 - [ ] `execution/reconcile.py` fetches the broker's open trades on startup and periodically, reconciles against the DB, and treats **the broker as the source of truth**.
 - [ ] `hermes_integration/pretrade_check.py` makes a final structured Claude veto immediately before submission; malformed/unavailable → **safe default = abort** (INV-02). Offline-testable; live key wired at acceptance.
 - [ ] `monitoring/watcher.py` runs always-on against the live stream: detects adverse path, slippage, volatility spikes, and feed-health loss on open positions; severe-response policy is configurable (default alert-only on demo).
-- [ ] `monitoring/alerts.py` delivers deviation alerts to the **same Discord channel** as the watchlist, via Hermes' Discord gateway.
+- [ ] `monitoring/alerts.py` delivers deviation alerts to the **same Discord channel** as the watchlist, via a direct `DiscordWebhookClient` (`DISCORD_WEBHOOK_URL`) — the monitor is a standalone process, not a Hermes job (DRIFT-06).
 - [ ] `scripts/run_monitor.py` is the always-on monitor entrypoint.
 - [ ] `fathom execute <candidate>` runs the full deterministic gate (pretrade-check → sizing → limits → order) for an operator-approved candidate; it is **not** a Hermes tool.
 - [ ] The full demo loop runs end-to-end: approve → sized bracketed demo order placed through the gate → fill recorded → monitor tracks it → deviation alerts fire — over a sustained demo period.
@@ -65,7 +65,7 @@ Adds to Phase 2: `hermes_integration/pretrade_check.py`, the `risk/` module, the
 graph TD
     subgraph ext["External"]
         OANDA["OANDA v20 API\nREST orders + HTTP stream\n(practice endpoint only)"]
-        HERMES_GW["Hermes Discord gateway\n(alert delivery only)"]
+        WEBHOOK["Discord webhook\nDISCORD_WEBHOOK_URL\n(shared watchlist channel)"]
         DISCORD["Discord\nwatchlist + deviation alerts"]
         CLAUDE_PT["Anthropic API\nClaude — pre-trade veto\n(in-process SDK, INV-02)"]
     end
@@ -101,7 +101,7 @@ graph TD
 
         subgraph monitor_layer["Monitoring (always-on)"]
             WATCHER["monitoring/watcher.py\nadverse path · slippage\nvol spike · feed health"]
-            ALERTS["monitoring/alerts.py\nDiscord via Hermes gateway"]
+            ALERTS["monitoring/alerts.py\nDiscordWebhookClient (direct POST)"]
             RUNMON["scripts/run_monitor.py\nentrypoint"]
         end
     end
@@ -121,8 +121,8 @@ graph TD
     STREAM -->|"live ticks"| WATCHER
     STORE -->|"open positions"| WATCHER
     WATCHER --> ALERTS
-    ALERTS -->|"alert"| HERMES_GW
-    HERMES_GW --> DISCORD
+    ALERTS -->|"POST (httpx)"| WEBHOOK
+    WEBHOOK --> DISCORD
     RUNMON --> WATCHER
     CLIENT --> OANDA
 ```
@@ -142,7 +142,7 @@ equity-curve / blotter / deviation-log UI, and any live-endpoint wiring (INV-07)
 | `risk/limits.py` | Exposure caps (max concurrent, max book risk), correlation-aware shared exposure, daily-loss kill switch (halt + alert). |
 | `hermes_integration/pretrade_check.py` | Final pre-submission Claude veto; pydantic verdict + parser; INV-02 safe-default = **abort**; live `anthropic` call behind a stubbable adapter. |
 | `monitoring/watcher.py` | Always-on deviation detection on open positions: adverse path, slippage, vol spike, feed-health loss; configurable severe-response (default alert-only). |
-| `monitoring/alerts.py` | Deviation-alert delivery to Discord via Hermes' gateway (same channel as the watchlist). |
+| `monitoring/alerts.py` | Deviation-alert delivery to Discord via a direct `DiscordWebhookClient` (`DISCORD_WEBHOOK_URL`, same channel as the watchlist); owns the `deviation_log` table. |
 | `scripts/run_monitor.py` | Entrypoint for the always-on monitor process. |
 | `cli.py` (extend) | `fathom execute <candidate>` operator command (the deterministic gate join); optionally `fathom positions` / `fathom reconcile` read-only operator helpers. **Single-writer task** (only one Phase 3 task edits `cli.py`). |
 | `data/store.py` (extend) | `orders`, `fills`, `positions` tables (state for execution + reconciliation + monitoring). |
@@ -167,8 +167,13 @@ of the wall:
 - **The pre-trade Claude check can only *subtract*.** It can veto (abort) a trade;
   it can never cause one. Malformed/unavailable → abort (INV-02). It is the finer
   veto on top of the deterministic gate, not a green light.
-- **Alerts go *out* through Hermes' gateway** — that is delivery, not order
-  authority, and is allowed.
+- **Alerts go *out* via a direct Discord webhook** (`DISCORD_WEBHOOK_URL`) from the
+  standalone monitor process — that is outbound delivery, not order authority, and
+  is not mediated by a Hermes job (DRIFT-06 resolution).
+- **The monitor may close/modify an *existing* position when explicitly configured**
+  (default-off on demo), delegated to a deterministic `execution/` function — it
+  never *opens* a position and is never a Hermes tool. "Deterministic close/modify of
+  an open position is permitted; opening is not" (AMBIGUOUS-01 ruling).
 
 ---
 
@@ -208,11 +213,14 @@ of the wall:
 - **INV-09** — demo and live share one code path; only `oanda_client.py` reads `env`.
 - **INV-11** — sizing consumes the ATR-derived stop; symmetric across strategies.
 - **INV-13** — execution consumes the frozen `Candidate` contract unchanged.
+- **INV-14** — the `Order`/`Fill`/`Position` models are the frozen execution contract.
+- **INV-15** — deterministic `client_order_id`; retries never double-fill.
+- **INV-16** — the broker is the source of truth for positions and realized P&L.
 
-**Invariant-promotion candidates (decide at cross-spec audit):** the
-`Order`/`Fill`/`Position` model as a frozen contract (à la INV-13 for `Candidate`);
-client-order-ID idempotency as a promoted rule; "broker is source of truth" for
-reconciliation.
+**Invariant promotions — DONE (cross-spec audit, 2026-05-29):** the three candidates
+were promoted to **INV-14** (frozen Order/Fill/Position), **INV-15** (client-order-id
+idempotency), and **INV-16** (broker is source of truth). See
+[phase-3-spec-audit-2026-05-29.md](phase-3-spec-audit-2026-05-29.md).
 
 ---
 
@@ -225,6 +233,6 @@ reconciliation.
 - [ ] Feature spec: `order-placement` (bracket submit, idempotency, retries, slippage capture)
 - [ ] Feature spec: `reconciliation` (broker-vs-db, broker = truth)
 - [ ] Feature spec: `deviation-monitor` (watcher + run_monitor entrypoint)
-- [ ] Feature spec: `monitor-alerts` (Discord via Hermes gateway)
+- [ ] Feature spec: `monitor-alerts` (Discord via direct webhook client)
 - [ ] Feature spec: `execution-cli` (`fathom execute`, the operator join)
 - [ ] Task graph for Phase 3


### PR DESCRIPTION
## Summary

Ran `runbook-cross-spec-audit` over the 9 Phase 3 specs with a **fresh, independent, read-only auditor** (no prior context — the non-negotiable rule). It found **6 blocking drifts, 3 non-blocking, 5 ambiguities, 3 invariant-promotion candidates**. All fixed here (audits report; the lead amends). Full report: `docs/phases/phase-3-spec-audit-2026-05-29.md`.

### Blocking fixes
- **DRIFT-06** *(architecture gap)* — `monitor-alerts` assumed an injectable "Hermes Discord gateway" that **doesn't exist as a code object**; the always-on monitor is a standalone Python process, not a Hermes job. Replaced with a `DiscordWebhookClient` POSTing to `DISCORD_WEBHOOK_URL` (shared watchlist channel). Diagram + boundary updated.
- **DRIFT-01/02** — pinned the `orders`/`fills`/`positions` + `account_state` column lists (incl. `realized_pl`, `start_of_day_equity`, `day_pl`), single owner, UTC-day snapshot + restart semantics.
- **DRIFT-03** — pinned the `client_order_id` formula → promoted to **INV-15**.
- **DRIFT-04** — separated `candidate_ref` (provenance) from the `fathom execute` lookup ref.
- **DRIFT-05** — `day_pl` source = account-summary (broker-truth) → **INV-16**.
- **DRIFT-07** — verified against shipped `InstrumentMeta`: no `pip_value`/`max_trade_size` exist. Rewrote per-unit risk as `stop_distance × quote_rate`; dropped the unsourced max-size clamp.

### Non-blocking + ambiguities
Defined `DeviationEvent` + `deviation_log` columns; ruled **DRIFT-09** (extract `signals/correlation.py` from the shipped `portfolio.py` — coordinator-serialized); monitor auto-flatten delegated to `execution/` and default-off (AMBIGUOUS-01); fresh reconcile before the kill-switch check (AMBIGUOUS-03); signed-units/slippage conventions (AMBIGUOUS-05).

### Invariants promoted
**INV-14** (frozen `Order`/`Fill`/`Position`), **INV-15** (client-order-id idempotency), **INV-16** (broker is source of truth). `CLAUDE.md` 13→16.

### Dispatch readiness
`code-map.md` gains the Phase 3 collision plan: two coordinator pre-steps (`signals/correlation.py` extract, `anthropic` dep), `order-model` as the locked prerequisite hub, and serialized edits to the shipped `data/store.py` + `data/oanda_client.py`. INDEX statuses → `ready`.

**Verdict:** corpus coherent; ready for taskgraph generation. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)