### PR TITLE
chore(deps): add anthropic SDK (Phase 3 C-A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyarrow>=14",
     "httpx>=0.27",
     "matplotlib>=3.7",
+    "anthropic>=0.39",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Coordinator-branch dep edit before P3-T-05 (pretrade-check). Adds `anthropic>=0.39` for the first in-process Claude call (INV-02 pre-trade veto), behind a stubbable adapter. Mirrors Phase 2's matplotlib coordinator edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)