### PR TITLE
P3-T-01: order-model-and-brackets (Order/Fill/Position + build_bracket)

### DIFF
--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,0 +1,19 @@
+"""Execution package — the Phase 3 order/fill/position contract and bracket maths.
+
+Public surface (INV-14 frozen execution contract):
+
+* :class:`~execution.models.Order` — intent to open a bracketed position.
+* :class:`~execution.models.Fill` — broker confirmation of an order.
+* :class:`~execution.models.Position` — current/closed open state.
+* :func:`~execution.models.build_bracket` — pure ``Candidate`` → ``Order`` maths.
+
+This package holds no I/O, no OANDA calls, and no clock beyond the timestamps
+passed into it.  Submission lives in ``order-placement``; sizing in
+``position-sizing``; persistence with ``order-placement``/``reconciliation``.
+"""
+
+from __future__ import annotations
+
+from execution.models import Fill, Order, Position, build_bracket
+
+__all__ = ["Fill", "Order", "Position", "build_bracket"]

--- a/execution/models.py
+++ b/execution/models.py
@@ -1,0 +1,427 @@
+"""The frozen in-process execution contract (INV-14) + the bracket-maths function.
+
+This module is the execution-side analogue of ``signals/ranker.py::Candidate``
+(INV-13): the ``Order``/``Fill``/``Position`` pydantic v2 models are the stable
+wire shapes that ``position-sizing``, ``order-placement``, ``reconciliation``,
+the deviation monitor, and the alerter all build against.  Field names
+(snake_case), types, and flat shape are **frozen** — a change is a breaking
+amendment to INV-14.
+
+The module holds models and pure maths only.  No OANDA submission, no network,
+no clock beyond the timestamps passed in (no ``datetime.now()`` anywhere).
+
+Invariants enforced here
+------------------------
+* **INV-03** — every datetime field is UTC-aware; naive datetimes are rejected
+  by validators (the ``Signal``/``Candidate`` style).
+* **INV-04** — :func:`build_bracket` produces a stop **and** a take-profit for
+  every ``Order``; there is no code path to a naked order.  A non-positive
+  ``stop_distance`` raises (rejected, never sized naked).
+* **INV-14** — these three models are the frozen execution contract.
+* **INV-15** — :func:`build_bracket` computes the deterministic
+  ``client_order_id``.
+
+Sign convention (AMBIGUOUS-05, pinned by the AC)
+------------------------------------------------
+* ``units`` / ``units_filled`` are signed to match OANDA v20: **long > 0**,
+  **short < 0**.  Zero is invalid.
+* ``slippage`` is signed so **positive = adverse** (a fill worse than the
+  candidate's ``entry_ref``) regardless of direction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+from signals.ranker import Candidate
+from strategies.base import Direction
+
+__all__ = ["EntryType", "FillStatus", "Order", "Fill", "Position", "build_bracket"]
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class EntryType(str, Enum):
+    """How an order enters the market.
+
+    Phase 3 is market-only (the watchlist ``entry_ref`` is a reference, the
+    order fills at market — see the spec's resolved open question).  The enum
+    exists so a later limit/stop-entry amendment is additive, not a breaking
+    shape change.
+    """
+
+    MARKET = "market"
+
+
+class FillStatus(str, Enum):
+    """Terminal/partial state of a broker fill."""
+
+    FILLED = "filled"
+    PARTIAL = "partial"
+    REJECTED = "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Shared validators (mirroring the Signal/Candidate validator style)
+# ---------------------------------------------------------------------------
+
+
+def _require_utc_aware(v: datetime, field: str) -> datetime:
+    """Reject a naive datetime (INV-03).  Returns ``v`` unchanged when aware."""
+    if v.tzinfo is None:
+        raise ValueError(
+            f"{field} must be UTC-aware (INV-03). "
+            "Use a UTC-aware bar/clock timestamp, never datetime.now()."
+        )
+    return v
+
+
+def _require_positive(v: float, field: str) -> float:
+    """Reject a non-positive price."""
+    if v <= 0:
+        raise ValueError(f"{field} must be > 0, got {v}")
+    return v
+
+
+def _require_signed_nonzero_units(v: int, field: str) -> int:
+    """Reject zero units; sign encodes direction (long > 0, short < 0)."""
+    if v == 0:
+        raise ValueError(
+            f"{field} must be a signed non-zero integer "
+            "(long > 0, short < 0); got 0."
+        )
+    return v
+
+
+# ---------------------------------------------------------------------------
+# Order — intent to open a bracketed position (INV-04, INV-14, INV-15)
+# ---------------------------------------------------------------------------
+
+
+class Order(BaseModel):
+    """An intent to open a bracketed position.
+
+    Frozen execution contract (INV-14).  Every ``Order`` carries both a
+    ``stop_loss_price`` and a ``take_profit_price`` (INV-04) and a non-empty
+    deterministic ``client_order_id`` (INV-15).
+
+    Fields
+    ------
+    client_order_id   : deterministic idempotency key (sha256[:32]) — INV-15.
+    instrument        : OANDA instrument identifier, e.g. ``"EUR_USD"``.
+    direction         : ``LONG`` | ``SHORT``.
+    units             : signed size (long > 0, short < 0); zero invalid.
+    entry_type        : market-only for Phase 3.
+    stop_loss_price   : absolute bracket stop price (> 0).
+    take_profit_price : absolute bracket target price (> 0).
+    candidate_ref     : provenance ``f"{instrument}:{timeframe}:{strategy_name}"``.
+    created_at        : UTC-aware order-creation time (INV-03).
+    """
+
+    client_order_id: str
+    instrument: str
+    direction: Direction
+    units: int
+    entry_type: EntryType
+    stop_loss_price: float
+    take_profit_price: float
+    candidate_ref: str
+    created_at: datetime
+
+    @field_validator("client_order_id", "instrument", "candidate_ref")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("units")
+    @classmethod
+    def _units_signed_nonzero(cls, v: int) -> int:
+        return _require_signed_nonzero_units(v, "units")
+
+    @field_validator("stop_loss_price")
+    @classmethod
+    def _stop_positive(cls, v: float) -> float:
+        return _require_positive(v, "stop_loss_price")
+
+    @field_validator("take_profit_price")
+    @classmethod
+    def _target_positive(cls, v: float) -> float:
+        return _require_positive(v, "take_profit_price")
+
+    @field_validator("created_at")
+    @classmethod
+    def _created_at_utc(cls, v: datetime) -> datetime:
+        return _require_utc_aware(v, "created_at")
+
+
+# ---------------------------------------------------------------------------
+# Fill — the broker's confirmation (INV-14)
+# ---------------------------------------------------------------------------
+
+
+class Fill(BaseModel):
+    """The broker's confirmation of an order.
+
+    Fields
+    ------
+    client_order_id : the originating order's idempotency key (INV-15 link).
+    broker_trade_id : OANDA's trade identifier for the resulting position.
+    fill_price      : the executed price (> 0).
+    units_filled    : signed filled size (long > 0, short < 0); zero invalid.
+    slippage        : signed; **positive = adverse** vs ``entry_ref`` (any dir).
+    filled_at       : UTC-aware fill time (INV-03).
+    status          : ``filled`` | ``partial`` | ``rejected``.
+    """
+
+    client_order_id: str
+    broker_trade_id: str
+    fill_price: float
+    units_filled: int
+    slippage: float
+    filled_at: datetime
+    status: FillStatus
+
+    @field_validator("client_order_id", "broker_trade_id")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("fill_price")
+    @classmethod
+    def _fill_price_positive(cls, v: float) -> float:
+        return _require_positive(v, "fill_price")
+
+    @field_validator("units_filled")
+    @classmethod
+    def _units_filled_signed_nonzero(cls, v: int) -> int:
+        return _require_signed_nonzero_units(v, "units_filled")
+
+    @field_validator("filled_at")
+    @classmethod
+    def _filled_at_utc(cls, v: datetime) -> datetime:
+        return _require_utc_aware(v, "filled_at")
+
+
+# ---------------------------------------------------------------------------
+# Position — current/closed open state (INV-14)
+# ---------------------------------------------------------------------------
+
+
+class Position(BaseModel):
+    """Current (or closed) open state of a bracketed position.
+
+    Fields
+    ------
+    broker_trade_id   : OANDA trade identifier.
+    instrument        : OANDA instrument identifier.
+    units             : signed size (long > 0, short < 0); zero invalid.
+    entry_price       : the fill/entry price (> 0).
+    stop_loss_price   : active bracket stop (> 0).
+    take_profit_price : active bracket target (> 0).
+    opened_at         : UTC-aware open time (INV-03).
+    unrealized_pl     : mark-to-market PnL while open.
+    closed_at         : UTC-aware close time, or ``None`` while open.
+    realized_pl       : realised PnL, written on close (``None`` until then).
+    candidate_ref     : provenance ``f"{instrument}:{timeframe}:{strategy_name}"``.
+    """
+
+    broker_trade_id: str
+    instrument: str
+    units: int
+    entry_price: float
+    stop_loss_price: float
+    take_profit_price: float
+    opened_at: datetime
+    unrealized_pl: float
+    closed_at: Optional[datetime] = None
+    realized_pl: Optional[float] = None
+    candidate_ref: str
+
+    @field_validator("broker_trade_id", "instrument", "candidate_ref")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("units")
+    @classmethod
+    def _units_signed_nonzero(cls, v: int) -> int:
+        return _require_signed_nonzero_units(v, "units")
+
+    @field_validator("entry_price")
+    @classmethod
+    def _entry_positive(cls, v: float) -> float:
+        return _require_positive(v, "entry_price")
+
+    @field_validator("stop_loss_price")
+    @classmethod
+    def _stop_positive(cls, v: float) -> float:
+        return _require_positive(v, "stop_loss_price")
+
+    @field_validator("take_profit_price")
+    @classmethod
+    def _target_positive(cls, v: float) -> float:
+        return _require_positive(v, "take_profit_price")
+
+    @field_validator("opened_at")
+    @classmethod
+    def _opened_at_utc(cls, v: datetime) -> datetime:
+        return _require_utc_aware(v, "opened_at")
+
+    @field_validator("closed_at")
+    @classmethod
+    def _closed_at_utc(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if v is None:
+            return None
+        return _require_utc_aware(v, "closed_at")
+
+
+# ---------------------------------------------------------------------------
+# build_bracket — pure Candidate → Order maths (INV-04, INV-15)
+# ---------------------------------------------------------------------------
+
+
+def build_bracket(
+    candidate: Candidate,
+    units: int,
+    *,
+    execution_date: datetime,
+    precision: int,
+) -> Order:
+    """Convert an approved ``Candidate`` + a signed unit count into an ``Order``.
+
+    Turns the candidate's **price-distance** stop/target into **absolute**
+    bracket prices for the order's direction, rounds them to ``precision``
+    decimal places (bound to ``InstrumentMeta.display_precision``, DRIFT-07),
+    and computes the deterministic ``client_order_id`` (INV-15).
+
+    Bracket maths (INV-04 — always a stop **and** a target)::
+
+        LONG  : stop   = entry_ref − stop_distance
+                target = entry_ref + target_distance
+        SHORT : stop   = entry_ref + stop_distance
+                target = entry_ref − target_distance
+
+    Args:
+        candidate: the frozen, approved ``Candidate`` (INV-13); read-only.
+        units: signed size — long > 0, short < 0 (from ``position-sizing``).
+        execution_date: UTC-aware order-creation time; becomes ``created_at``
+            and folds into the ``client_order_id`` (INV-15).  No internal clock.
+        precision: decimal places to round bracket prices to
+            (``InstrumentMeta.display_precision``).
+
+    Returns:
+        A fully-bracketed ``Order`` (stop + target both present, INV-04) with a
+        non-empty deterministic ``client_order_id`` (INV-15).
+
+    Raises:
+        ValueError: if ``candidate.stop_distance`` or ``target_distance`` is
+            non-positive (rejected upstream — never sized naked); if
+            ``execution_date`` is naive (INV-03); if ``units`` is zero or its
+            sign disagrees with the candidate direction; if ``candidate.direction``
+            is not ``LONG``/``SHORT``.
+    """
+    _require_utc_aware(execution_date, "execution_date")
+
+    if candidate.stop_distance <= 0:
+        raise ValueError(
+            "build_bracket: stop_distance must be > 0 (INV-04 — a candidate "
+            f"with a non-positive stop is rejected, never sized naked); got "
+            f"{candidate.stop_distance}."
+        )
+    if candidate.target_distance <= 0:
+        raise ValueError(
+            "build_bracket: target_distance must be > 0 (INV-04); got "
+            f"{candidate.target_distance}."
+        )
+
+    direction = Direction(candidate.direction)
+    if direction is Direction.LONG:
+        if units <= 0:
+            raise ValueError(
+                f"build_bracket: LONG candidate requires units > 0, got {units}."
+            )
+        stop_price = candidate.entry_ref - candidate.stop_distance
+        target_price = candidate.entry_ref + candidate.target_distance
+    elif direction is Direction.SHORT:
+        if units >= 0:
+            raise ValueError(
+                f"build_bracket: SHORT candidate requires units < 0, got {units}."
+            )
+        stop_price = candidate.entry_ref + candidate.stop_distance
+        target_price = candidate.entry_ref - candidate.target_distance
+    else:
+        raise ValueError(
+            f"build_bracket: untradeable direction {candidate.direction!r} "
+            "(expected LONG or SHORT)."
+        )
+
+    stop_price = round(stop_price, precision)
+    target_price = round(target_price, precision)
+
+    # Defence in depth: a stop distance smaller than the rounding granularity
+    # could round a bracket onto the wrong side of entry, silently producing a
+    # non-protective order.  Reject rather than emit a malformed bracket (INV-04).
+    entry_rounded = round(candidate.entry_ref, precision)
+    if direction is Direction.LONG:
+        if not (stop_price < entry_rounded < target_price):
+            raise ValueError(
+                "build_bracket: rounded LONG bracket does not straddle entry "
+                f"(stop={stop_price}, entry={entry_rounded}, target={target_price}) "
+                f"at precision {precision} — stop/target distances too small to "
+                "represent. Rejected (INV-04)."
+            )
+    else:  # SHORT
+        if not (target_price < entry_rounded < stop_price):
+            raise ValueError(
+                "build_bracket: rounded SHORT bracket does not straddle entry "
+                f"(target={target_price}, entry={entry_rounded}, stop={stop_price}) "
+                f"at precision {precision} — stop/target distances too small to "
+                "represent. Rejected (INV-04)."
+            )
+
+    client_order_id = _client_order_id(candidate, execution_date)
+    candidate_ref = (
+        f"{candidate.instrument}:{candidate.timeframe}:{candidate.strategy_name}"
+    )
+
+    return Order(
+        client_order_id=client_order_id,
+        instrument=candidate.instrument,
+        direction=direction,
+        units=units,
+        entry_type=EntryType.MARKET,
+        stop_loss_price=stop_price,
+        take_profit_price=target_price,
+        candidate_ref=candidate_ref,
+        created_at=execution_date,
+    )
+
+
+def _client_order_id(candidate: Candidate, execution_date: datetime) -> str:
+    """Deterministic idempotency key (INV-15 / DRIFT-03).
+
+    ``sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:"
+    f"{execution_date}").hexdigest()[:32]`` over the candidate fields plus the
+    injected ``execution_date``.  ``generated_at`` is already the candidate's
+    RFC-3339 string; ``execution_date`` is interpolated via the f-string as the
+    spec states.  Pure: identical inputs always yield the identical id.
+    """
+    payload = (
+        f"{candidate.instrument}:{candidate.strategy_name}:{candidate.timeframe}:"
+        f"{candidate.generated_at}:{execution_date}"
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]

--- a/tests/test_order_model.py
+++ b/tests/test_order_model.py
@@ -1,0 +1,528 @@
+"""Tests for the frozen execution contract (INV-14) and ``build_bracket``.
+
+Covers every Acceptance criterion of ``order-model-and-brackets``:
+
+* SL + TP always present, both directions, no naked path (INV-04).
+* Direction-correct bracket maths against worked examples.
+* Precision rounding pinned for 5-dp (EUR_USD) and 3-dp (USD_JPY) fixtures.
+* Signed units; zero rejected.
+* UTC validators reject naive datetimes (INV-03).
+* JSON round-trip pins the frozen shape (INV-14).
+* ``client_order_id`` determinism (INV-15).
+* Non-positive stop raises.
+* hypothesis property: stop/target straddle entry on the correct sides
+  after rounding.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from execution.models import (
+    EntryType,
+    Fill,
+    FillStatus,
+    Order,
+    Position,
+    build_bracket,
+)
+from signals.ranker import Candidate
+from strategies.base import Direction
+
+UTC = timezone.utc
+EXEC_DATE = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    *,
+    instrument: str = "EUR_USD",
+    timeframe: str = "H1",
+    strategy_name: str = "macrossover_10_50_eur_usd_h1",
+    direction: str = "LONG",
+    entry_ref: float = 1.10000,
+    stop_distance: float = 0.00200,
+    target_distance: float = 0.00300,
+    generated_at: str = "2026-05-29T11:00:00Z",
+) -> Candidate:
+    return Candidate(
+        instrument=instrument,
+        timeframe=timeframe,
+        strategy_name=strategy_name,
+        direction=direction,
+        entry_ref=entry_ref,
+        stop_distance=stop_distance,
+        target_distance=target_distance,
+        oos_sharpe_mean=1.2,
+        quality_score=0.7,
+        rank=1,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=False,
+        generated_at=generated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: SL + TP always present, both directions (INV-04)
+# ---------------------------------------------------------------------------
+
+
+def test_long_bracket_has_stop_and_target() -> None:
+    order = build_bracket(
+        _candidate(direction="LONG"), 1000, execution_date=EXEC_DATE, precision=5
+    )
+    assert order.stop_loss_price > 0
+    assert order.take_profit_price > 0
+    assert order.entry_type is EntryType.MARKET
+
+
+def test_short_bracket_has_stop_and_target() -> None:
+    order = build_bracket(
+        _candidate(direction="SHORT"), -1000, execution_date=EXEC_DATE, precision=5
+    )
+    assert order.stop_loss_price > 0
+    assert order.take_profit_price > 0
+
+
+def test_non_positive_stop_distance_raises() -> None:
+    # Candidate validator forbids stop_distance <= 0, so build a candidate that
+    # bypasses validation (model_construct) to prove build_bracket also guards.
+    bad = _candidate().model_copy(update={"stop_distance": 0.0})
+    with pytest.raises(ValueError, match="stop_distance must be > 0"):
+        build_bracket(bad, 1000, execution_date=EXEC_DATE, precision=5)
+
+
+def test_non_positive_target_distance_raises() -> None:
+    bad = _candidate().model_copy(update={"target_distance": -0.001})
+    with pytest.raises(ValueError, match="target_distance must be > 0"):
+        build_bracket(bad, 1000, execution_date=EXEC_DATE, precision=5)
+
+
+# ---------------------------------------------------------------------------
+# AC: direction-correct bracket maths (worked examples)
+# ---------------------------------------------------------------------------
+
+
+def test_long_worked_example() -> None:
+    c = _candidate(
+        direction="LONG", entry_ref=1.10000, stop_distance=0.00200, target_distance=0.00300
+    )
+    order = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    assert order.stop_loss_price == pytest.approx(1.09800)
+    assert order.take_profit_price == pytest.approx(1.10300)
+    assert order.direction is Direction.LONG
+
+
+def test_short_worked_example() -> None:
+    c = _candidate(
+        direction="SHORT", entry_ref=1.10000, stop_distance=0.00200, target_distance=0.00300
+    )
+    order = build_bracket(c, -1000, execution_date=EXEC_DATE, precision=5)
+    assert order.stop_loss_price == pytest.approx(1.10200)
+    assert order.take_profit_price == pytest.approx(1.09700)
+    assert order.direction is Direction.SHORT
+
+
+# ---------------------------------------------------------------------------
+# AC: precision rounding — 5dp (EUR_USD) and 3dp (USD_JPY)
+# ---------------------------------------------------------------------------
+
+
+def test_precision_rounding_eur_usd_5dp() -> None:
+    c = _candidate(
+        instrument="EUR_USD",
+        entry_ref=1.105555,
+        stop_distance=0.001234,
+        target_distance=0.002345,
+    )
+    order = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    assert order.stop_loss_price == round(1.105555 - 0.001234, 5)
+    assert order.take_profit_price == round(1.105555 + 0.002345, 5)
+    # Pinned literal values.
+    assert order.stop_loss_price == 1.10432
+    assert order.take_profit_price == 1.1079
+
+
+def test_precision_rounding_usd_jpy_3dp() -> None:
+    c = _candidate(
+        instrument="USD_JPY",
+        entry_ref=151.2378,
+        stop_distance=0.2512,
+        target_distance=0.3766,
+        direction="SHORT",
+    )
+    order = build_bracket(c, -1000, execution_date=EXEC_DATE, precision=3)
+    assert order.stop_loss_price == round(151.2378 + 0.2512, 3)
+    assert order.take_profit_price == round(151.2378 - 0.3766, 3)
+    assert order.stop_loss_price == 151.489
+    assert order.take_profit_price == 150.861
+
+
+# ---------------------------------------------------------------------------
+# AC: signed units; zero rejected; sign must match direction
+# ---------------------------------------------------------------------------
+
+
+def test_zero_units_rejected_by_order_validator() -> None:
+    with pytest.raises(ValidationError):
+        Order(
+            client_order_id="x" * 32,
+            instrument="EUR_USD",
+            direction=Direction.LONG,
+            units=0,
+            entry_type=EntryType.MARKET,
+            stop_loss_price=1.0,
+            take_profit_price=1.1,
+            candidate_ref="EUR_USD:H1:macrossover",
+            created_at=EXEC_DATE,
+        )
+
+
+def test_long_with_negative_units_rejected() -> None:
+    with pytest.raises(ValueError, match="LONG candidate requires units > 0"):
+        build_bracket(_candidate(direction="LONG"), -1000, execution_date=EXEC_DATE, precision=5)
+
+
+def test_short_with_positive_units_rejected() -> None:
+    with pytest.raises(ValueError, match="SHORT candidate requires units < 0"):
+        build_bracket(_candidate(direction="SHORT"), 1000, execution_date=EXEC_DATE, precision=5)
+
+
+def test_zero_units_to_build_bracket_rejected() -> None:
+    with pytest.raises(ValueError):
+        build_bracket(_candidate(direction="LONG"), 0, execution_date=EXEC_DATE, precision=5)
+
+
+# ---------------------------------------------------------------------------
+# AC: UTC validators reject naive datetimes (INV-03)
+# ---------------------------------------------------------------------------
+
+
+def test_order_naive_created_at_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Order(
+            client_order_id="x" * 32,
+            instrument="EUR_USD",
+            direction=Direction.LONG,
+            units=1000,
+            entry_type=EntryType.MARKET,
+            stop_loss_price=1.0,
+            take_profit_price=1.1,
+            candidate_ref="EUR_USD:H1:macrossover",
+            created_at=datetime(2026, 5, 29, 12, 0, 0),  # naive
+        )
+
+
+def test_fill_naive_filled_at_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Fill(
+            client_order_id="x" * 32,
+            broker_trade_id="t1",
+            fill_price=1.10,
+            units_filled=1000,
+            slippage=0.0001,
+            filled_at=datetime(2026, 5, 29, 12, 0, 0),  # naive
+            status=FillStatus.FILLED,
+        )
+
+
+def test_position_naive_opened_at_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Position(
+            broker_trade_id="t1",
+            instrument="EUR_USD",
+            units=1000,
+            entry_price=1.10,
+            stop_loss_price=1.098,
+            take_profit_price=1.103,
+            opened_at=datetime(2026, 5, 29, 12, 0, 0),  # naive
+            unrealized_pl=0.0,
+            candidate_ref="EUR_USD:H1:macrossover",
+        )
+
+
+def test_position_naive_closed_at_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Position(
+            broker_trade_id="t1",
+            instrument="EUR_USD",
+            units=1000,
+            entry_price=1.10,
+            stop_loss_price=1.098,
+            take_profit_price=1.103,
+            opened_at=EXEC_DATE,
+            unrealized_pl=0.0,
+            closed_at=datetime(2026, 5, 29, 14, 0, 0),  # naive
+            candidate_ref="EUR_USD:H1:macrossover",
+        )
+
+
+def test_build_bracket_naive_execution_date_rejected() -> None:
+    with pytest.raises(ValueError, match="execution_date must be UTC-aware"):
+        build_bracket(
+            _candidate(),
+            1000,
+            execution_date=datetime(2026, 5, 29, 12, 0, 0),
+            precision=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: positive-price validators
+# ---------------------------------------------------------------------------
+
+
+def test_negative_stop_price_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Order(
+            client_order_id="x" * 32,
+            instrument="EUR_USD",
+            direction=Direction.LONG,
+            units=1000,
+            entry_type=EntryType.MARKET,
+            stop_loss_price=-1.0,
+            take_profit_price=1.1,
+            candidate_ref="EUR_USD:H1:macrossover",
+            created_at=EXEC_DATE,
+        )
+
+
+def test_empty_client_order_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Order(
+            client_order_id="",
+            instrument="EUR_USD",
+            direction=Direction.LONG,
+            units=1000,
+            entry_type=EntryType.MARKET,
+            stop_loss_price=1.0,
+            take_profit_price=1.1,
+            candidate_ref="EUR_USD:H1:macrossover",
+            created_at=EXEC_DATE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: JSON round-trip pins the frozen shape (INV-14)
+# ---------------------------------------------------------------------------
+
+
+def test_order_json_roundtrip_pins_shape() -> None:
+    order = build_bracket(_candidate(), 1000, execution_date=EXEC_DATE, precision=5)
+    dumped = order.model_dump_json()
+    restored = Order.model_validate_json(dumped)
+    assert restored == order
+    keys = set(order.model_dump().keys())
+    assert keys == {
+        "client_order_id",
+        "instrument",
+        "direction",
+        "units",
+        "entry_type",
+        "stop_loss_price",
+        "take_profit_price",
+        "candidate_ref",
+        "created_at",
+    }
+
+
+def test_fill_json_roundtrip_pins_shape() -> None:
+    fill = Fill(
+        client_order_id="x" * 32,
+        broker_trade_id="t1",
+        fill_price=1.10,
+        units_filled=1000,
+        slippage=0.00012,
+        filled_at=EXEC_DATE,
+        status=FillStatus.FILLED,
+    )
+    restored = Fill.model_validate_json(fill.model_dump_json())
+    assert restored == fill
+    assert set(fill.model_dump().keys()) == {
+        "client_order_id",
+        "broker_trade_id",
+        "fill_price",
+        "units_filled",
+        "slippage",
+        "filled_at",
+        "status",
+    }
+
+
+def test_position_json_roundtrip_pins_shape() -> None:
+    pos = Position(
+        broker_trade_id="t1",
+        instrument="EUR_USD",
+        units=1000,
+        entry_price=1.10,
+        stop_loss_price=1.098,
+        take_profit_price=1.103,
+        opened_at=EXEC_DATE,
+        unrealized_pl=0.0,
+        closed_at=None,
+        realized_pl=None,
+        candidate_ref="EUR_USD:H1:macrossover",
+    )
+    restored = Position.model_validate_json(pos.model_dump_json())
+    assert restored == pos
+    assert set(pos.model_dump().keys()) == {
+        "broker_trade_id",
+        "instrument",
+        "units",
+        "entry_price",
+        "stop_loss_price",
+        "take_profit_price",
+        "opened_at",
+        "unrealized_pl",
+        "closed_at",
+        "realized_pl",
+        "candidate_ref",
+    }
+
+
+def test_candidate_ref_format() -> None:
+    order = build_bracket(
+        _candidate(instrument="EUR_USD", timeframe="H1", strategy_name="donchian_20"),
+        1000,
+        execution_date=EXEC_DATE,
+        precision=5,
+    )
+    assert order.candidate_ref == "EUR_USD:H1:donchian_20"
+
+
+# ---------------------------------------------------------------------------
+# AC: client_order_id determinism (INV-15)
+# ---------------------------------------------------------------------------
+
+
+def test_client_order_id_deterministic() -> None:
+    c = _candidate()
+    a = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    b = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    assert a.client_order_id == b.client_order_id
+    assert len(a.client_order_id) == 32
+    assert a.client_order_id != ""
+
+
+def test_client_order_id_changes_with_execution_date() -> None:
+    c = _candidate()
+    a = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    b = build_bracket(c, 1000, execution_date=EXEC_DATE + timedelta(days=1), precision=5)
+    assert a.client_order_id != b.client_order_id
+
+
+def test_client_order_id_changes_with_candidate_identity() -> None:
+    a = build_bracket(_candidate(instrument="EUR_USD"), 1000, execution_date=EXEC_DATE, precision=5)
+    b = build_bracket(_candidate(instrument="GBP_USD"), 1000, execution_date=EXEC_DATE, precision=5)
+    assert a.client_order_id != b.client_order_id
+
+
+def test_client_order_id_matches_formula() -> None:
+    import hashlib
+
+    c = _candidate()
+    payload = (
+        f"{c.instrument}:{c.strategy_name}:{c.timeframe}:"
+        f"{c.generated_at}:{EXEC_DATE}"
+    )
+    expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+    order = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    assert order.client_order_id == expected
+
+
+# ---------------------------------------------------------------------------
+# build_bracket does not mutate the input Candidate (INV-13 read-only)
+# ---------------------------------------------------------------------------
+
+
+def test_build_bracket_does_not_mutate_candidate() -> None:
+    c = _candidate()
+    before = c.model_dump()
+    build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
+    assert c.model_dump() == before
+
+
+# ---------------------------------------------------------------------------
+# Property: stop/target straddle entry on the correct sides after rounding
+# ---------------------------------------------------------------------------
+
+_PRECISION = st.integers(min_value=2, max_value=5)
+
+
+@st.composite
+def _entry_and_distances(draw: st.DrawFn) -> tuple[float, float, float]:
+    """Entry + (stop, target) distances that keep both bracket prices positive.
+
+    Distances stay comfortably above the coarsest rounding granularity (1e-2)
+    and strictly below entry, so the property exercises *straddling*, not the
+    separately-tested price-positivity validator (a SHORT target or a LONG stop
+    at/below zero is impossible and is rejected by the model — see
+    ``test_negative_stop_price_rejected``).
+    """
+    entry = draw(st.floats(min_value=1.0, max_value=200.0, allow_nan=False, allow_infinity=False))
+    # Both distances < entry so LONG stop (entry−stop) and SHORT target
+    # (entry−target) remain strictly positive.
+    upper = min(entry * 0.5, 5.0)
+    stop_d = draw(st.floats(min_value=0.05, max_value=upper, allow_nan=False, allow_infinity=False))
+    target_d = draw(st.floats(min_value=0.05, max_value=upper, allow_nan=False, allow_infinity=False))
+    return entry, stop_d, target_d
+
+
+@given(ed=_entry_and_distances(), precision=_PRECISION)
+def test_property_long_brackets_straddle_entry(
+    ed: tuple[float, float, float], precision: int
+) -> None:
+    entry, stop_d, target_d = ed
+    c = _candidate(direction="LONG", entry_ref=entry, stop_distance=stop_d, target_distance=target_d)
+    order = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=precision)
+    entry_rounded = round(entry, precision)
+    assert order.stop_loss_price < entry_rounded < order.take_profit_price
+
+
+@given(ed=_entry_and_distances(), precision=_PRECISION)
+def test_property_short_brackets_straddle_entry(
+    ed: tuple[float, float, float], precision: int
+) -> None:
+    entry, stop_d, target_d = ed
+    c = _candidate(direction="SHORT", entry_ref=entry, stop_distance=stop_d, target_distance=target_d)
+    order = build_bracket(c, -1000, execution_date=EXEC_DATE, precision=precision)
+    entry_rounded = round(entry, precision)
+    assert order.take_profit_price < entry_rounded < order.stop_loss_price
+
+
+@given(
+    instrument=st.sampled_from(["EUR_USD", "GBP_USD", "USD_JPY", "AUD_USD"]),
+    timeframe=st.sampled_from(["H1", "H4", "D"]),
+    strategy=st.sampled_from(["macrossover_10_50", "donchian_20", "rsi_14"]),
+)
+def test_property_client_order_id_is_32_hex(
+    instrument: str, timeframe: str, strategy: str
+) -> None:
+    direction = "SHORT" if instrument == "USD_JPY" else "LONG"
+    units = -1000 if direction == "SHORT" else 1000
+    entry = 150.0 if instrument == "USD_JPY" else 1.1
+    precision = 3 if instrument == "USD_JPY" else 5
+    stop_d = 0.5 if instrument == "USD_JPY" else 0.002
+    target_d = 0.75 if instrument == "USD_JPY" else 0.003
+    c = _candidate(
+        instrument=instrument,
+        timeframe=timeframe,
+        strategy_name=strategy,
+        direction=direction,
+        entry_ref=entry,
+        stop_distance=stop_d,
+        target_distance=target_d,
+    )
+    order = build_bracket(c, units, execution_date=EXEC_DATE, precision=precision)
+    assert len(order.client_order_id) == 32
+    assert all(ch in "0123456789abcdef" for ch in order.client_order_id)


### PR DESCRIPTION
Closes #76.

## What this builds
The frozen Phase 3 execution contract (INV-14) — the execution-side analogue of `Candidate` (INV-13) — plus the pure bracket-maths function. New `execution/` package; touches only `execution/` and `tests/test_order_model.py`.

- `execution/models.py`
  - `Order` — intent to open a bracketed market position: `client_order_id, instrument, direction, units, entry_type, stop_loss_price, take_profit_price, candidate_ref, created_at`.
  - `Fill` — broker confirmation: `client_order_id, broker_trade_id, fill_price, units_filled, slippage, filled_at, status`.
  - `Position` — open/closed state: `broker_trade_id, instrument, units, entry_price, stop_loss_price, take_profit_price, opened_at, unrealized_pl, closed_at, realized_pl, candidate_ref`.
  - `build_bracket(candidate, units, *, execution_date, precision) -> Order` — pure, no I/O, no clock beyond `execution_date`.
- `execution/__init__.py` — re-exports `Order`, `Fill`, `Position`, `build_bracket`.

## Invariant compliance
- **INV-04** — `build_bracket` always yields both a `stop_loss_price` and a `take_profit_price`. It raises on non-positive `stop_distance`/`target_distance`, and (defence in depth) on a rounded bracket that fails to straddle entry. No code path produces a naked order.
- **INV-14** — field names/types/flat shape frozen; JSON round-trip tests pin each model's shape.
- **INV-15** — `client_order_id = sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date}").hexdigest()[:32]`, deterministic for identical inputs; tests pin the formula and determinism.
- **INV-03** — all datetime fields reject naive timestamps; `build_bracket` rejects a naive `execution_date`.
- **INV-13** — `Candidate` consumed read-only (test asserts no mutation).

## Bracket maths
LONG: stop = entry − stop_distance, target = entry + target_distance. SHORT mirrored. Prices rounded to `precision` (= `InstrumentMeta.display_precision`, DRIFT-07).

## Sign convention (AMBIGUOUS-05)
`units`/`units_filled` signed (long > 0, short < 0); zero rejected. `build_bracket` rejects a sign that disagrees with the candidate direction. `slippage` signed, positive = adverse.

## Spec ambiguities resolved
- `Candidate.generated_at` is already an RFC-3339 string, so the `client_order_id` formula folds it in verbatim; `execution_date` interpolated as the spec's literal f-string states.
- `entry_type` is a single-member `EntryType.MARKET` enum (market-only per the resolved open question), additive for a future limit/stop-entry amendment.
- Added a straddle-after-rounding guard: a stop distance smaller than the rounding granularity could round a bracket onto the wrong side of entry — rejected rather than emitted (INV-04).

## Verification
- `mypy .` (strict, whole repo): 0 errors across 59 files.
- `pytest -q`: 698 passed (667 pre-existing + 31 new), exit 0.
- Tests include a hypothesis property (brackets straddle entry on the correct sides after rounding, both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)