### PR TITLE
P3-T-06: order-placement (atomic brackets + idempotency)

### DIFF
--- a/data/oanda_client.py
+++ b/data/oanda_client.py
@@ -18,6 +18,7 @@ from typing import Any, List
 import oandapyV20
 import oandapyV20.endpoints.accounts as oanda_accounts
 import oandapyV20.endpoints.instruments as oanda_instruments
+import oandapyV20.endpoints.orders as oanda_orders
 from oandapyV20.exceptions import V20Error
 from pydantic import AwareDatetime, BaseModel, field_validator
 
@@ -334,6 +335,74 @@ class OandaClient:
             for r in raw_instruments
             if r.get("type") == "CURRENCY"
         ]
+
+    # ------------------------------------------------------------------
+    # Order placement + account summary (Phase 3 — execution path)
+    # ------------------------------------------------------------------
+
+    def create_order(self, order_body: dict[str, Any]) -> dict[str, Any]:
+        """Submit one v20 order-create request and return the raw response.
+
+        This is the single broker-write entry point used by
+        ``execution/orders.py``.  The ``order_body`` is the fully-formed v20
+        ``OrderCreate`` payload — a market order **with** its
+        ``stopLossOnFill`` and ``takeProfitOnFill`` brackets and a
+        ``clientExtensions.id`` idempotency key, assembled by the caller in a
+        single dict so the bracket is atomic (INV-04): there is no separate
+        bracket call this client could skip.
+
+        INV-07/INV-09: the practice-vs-live endpoint is selected once, here,
+        from ``settings.env`` in ``__init__``; ``orders.py`` never reads ``env``
+        or the token.
+
+        Transient/network failures (``requests.RequestException``) are **not**
+        swallowed — they propagate so the caller's retry-with-backoff layer can
+        reuse the same ``clientExtensions.id`` (a retry of a landed order
+        de-dupes; INV-15).  HTTP 4xx/5xx surface as ``OandaAPIError`` exactly
+        like the candle path, carrying the broker status code so the caller can
+        distinguish a retryable 5xx from a terminal 4xx rejection.
+
+        Args:
+            order_body: the v20 ``OrderCreate`` request body
+                (``{"order": {...}}``), already carrying brackets + the
+                ``clientExtensions`` idempotency id.
+
+        Returns:
+            The raw OANDA response dict (``orderFillTransaction`` /
+            ``orderCancelTransaction`` / ``orderRejectTransaction`` etc.).
+
+        Raises:
+            OandaAPIError: on any HTTP 4xx/5xx from OANDA.
+            requests.RequestException: on a network-level transport failure
+                (propagated for the retry layer).
+        """
+        account_id = self._settings.oanda_account_id
+        try:
+            req = oanda_orders.OrderCreate(accountID=account_id, data=order_body)
+            return self._api.request(req)  # type: ignore[no-any-return]
+        except V20Error as exc:
+            raise OandaAPIError(exc.code, exc.msg) from exc
+
+    def account_summary(self) -> dict[str, Any]:
+        """Fetch the OANDA account summary (equity, balance, open P&L).
+
+        Calls ``GET /v3/accounts/{accountID}/summary``.  Used by the execution
+        path / kill switch (INV-16: the broker is the source of truth for
+        equity and realised day P&L).  Practice/live is selected once from
+        ``settings.env`` (INV-09).
+
+        Returns:
+            The raw OANDA account-summary response dict.
+
+        Raises:
+            OandaAPIError: on any HTTP 4xx/5xx from OANDA.
+        """
+        account_id = self._settings.oanda_account_id
+        try:
+            req = oanda_accounts.AccountSummary(accountID=account_id)
+            return self._api.request(req)  # type: ignore[no-any-return]
+        except V20Error as exc:
+            raise OandaAPIError(exc.code, exc.msg) from exc
 
     def get_candles(
         self,

--- a/data/store.py
+++ b/data/store.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     # only attribute access on the entries, so a TYPE_CHECKING import is safe.
     from backtest.walkforward import ApprovedSetEntry
     from signals.ranker import Candidate
+    from execution.models import Fill, Order, Position
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +199,90 @@ class Store:
             (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
+    # ------------------------------------------------------------------
+    # Execution tables (Phase 3 — order-placement owns this migration).
+    # Column lists are pinned by docs/features/order-placement.md
+    # (DRIFT-01/02).  All timestamps are UTC RFC 3339 TEXT (INV-03).
+    # ------------------------------------------------------------------
+
+    #: ``orders`` — the intent to open a bracketed position.  ``client_order_id``
+    #: is the PK; the deterministic INV-15 idempotency key.
+    _CREATE_ORDERS_SQL: str = """
+        CREATE TABLE IF NOT EXISTS orders (
+            client_order_id    TEXT    NOT NULL PRIMARY KEY,
+            instrument         TEXT    NOT NULL,
+            direction          TEXT    NOT NULL,
+            units              INTEGER NOT NULL,
+            stop_loss_price    REAL    NOT NULL,
+            take_profit_price  REAL    NOT NULL,
+            candidate_ref      TEXT    NOT NULL,
+            created_at         TEXT    NOT NULL,
+            status             TEXT    NOT NULL
+        )
+    """
+
+    #: ``fills`` — the broker's confirmation, keyed by ``client_order_id`` so the
+    #: pre-submit idempotency read is a single PK lookup (INV-15).  A rejected
+    #: order still records a row (status="rejected") with no position.
+    _CREATE_FILLS_SQL: str = """
+        CREATE TABLE IF NOT EXISTS fills (
+            client_order_id    TEXT    NOT NULL PRIMARY KEY,
+            broker_trade_id    TEXT    NOT NULL,
+            fill_price         REAL    NOT NULL,
+            units_filled       INTEGER NOT NULL,
+            slippage           REAL    NOT NULL,
+            status             TEXT    NOT NULL,
+            filled_at          TEXT    NOT NULL
+        )
+    """
+
+    #: ``positions`` — open/closed bracketed position.  PK ``broker_trade_id``.
+    #: ``realized_pl`` is nullable until close (written by reconciliation).
+    _CREATE_POSITIONS_SQL: str = """
+        CREATE TABLE IF NOT EXISTS positions (
+            broker_trade_id    TEXT    NOT NULL PRIMARY KEY,
+            instrument         TEXT    NOT NULL,
+            units              INTEGER NOT NULL,
+            entry_price        REAL    NOT NULL,
+            stop_loss_price    REAL    NOT NULL,
+            take_profit_price  REAL    NOT NULL,
+            candidate_ref      TEXT    NOT NULL,
+            opened_at          TEXT    NOT NULL,
+            unrealized_pl      REAL    NOT NULL,
+            closed_at          TEXT,
+            realized_pl        REAL
+        )
+    """
+
+    #: Insert one order row.  ``INSERT OR REPLACE`` keeps a retry of the same
+    #: ``client_order_id`` idempotent at the store layer.
+    _INSERT_ORDER_SQL: str = """
+        INSERT OR REPLACE INTO orders
+            (client_order_id, instrument, direction, units, stop_loss_price,
+             take_profit_price, candidate_ref, created_at, status)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    #: Insert one fill row (idempotent on ``client_order_id``).
+    _INSERT_FILL_SQL: str = """
+        INSERT OR REPLACE INTO fills
+            (client_order_id, broker_trade_id, fill_price, units_filled,
+             slippage, status, filled_at)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?)
+    """
+
+    #: Insert one position row (idempotent on ``broker_trade_id``).
+    _INSERT_POSITION_SQL: str = """
+        INSERT OR REPLACE INTO positions
+            (broker_trade_id, instrument, units, entry_price, stop_loss_price,
+             take_profit_price, candidate_ref, opened_at, unrealized_pl,
+             closed_at, realized_pl)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
     _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
@@ -256,6 +341,9 @@ class Store:
         self._conn.execute(self._CREATE_INSTRUMENTS_SQL)
         self._conn.execute(self._CREATE_APPROVED_SET_SQL)
         self._conn.execute(self._CREATE_WATCHLIST_SQL)
+        self._conn.execute(self._CREATE_ORDERS_SQL)
+        self._conn.execute(self._CREATE_FILLS_SQL)
+        self._conn.execute(self._CREATE_POSITIONS_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -746,6 +834,170 @@ class Store:
                 }
             )
         return result
+
+    # ------------------------------------------------------------------
+    # Execution tables (Phase 3 — order-placement persists; reconciliation
+    # later updates positions.realized_pl/closed_at).
+    # ------------------------------------------------------------------
+
+    def write_order(self, order: "Order", status: str) -> None:
+        """Persist one ``Order`` row with its current ``status``.
+
+        Idempotent on ``client_order_id`` (``INSERT OR REPLACE``): re-submitting
+        the same order updates the stored status rather than duplicating it
+        (INV-15).  Timestamps are written as UTC RFC 3339 TEXT (INV-03).
+
+        Args:
+            order: the ``Order`` being submitted/recorded.
+            status: lifecycle status, e.g. ``"submitted"`` | ``"filled"`` |
+                ``"partial"`` | ``"rejected"``.
+        """
+        self._conn.execute(
+            self._INSERT_ORDER_SQL,
+            (
+                order.client_order_id,
+                order.instrument,
+                str(order.direction.value),
+                int(order.units),
+                float(order.stop_loss_price),
+                float(order.take_profit_price),
+                order.candidate_ref,
+                _to_rfc3339(order.created_at),
+                status,
+            ),
+        )
+        self._conn.commit()
+
+    def write_fill(self, fill: "Fill") -> None:
+        """Persist one filled/partial ``Fill`` row (idempotent on
+        ``client_order_id``).
+
+        ``filled_at`` is stored as UTC RFC 3339 (INV-03).  A *rejected* order is
+        not a valid ``Fill`` (the INV-14 model forbids an empty broker-trade-id
+        and zero units) — use :meth:`write_rejection` for that so the broker's
+        verdict is recorded faithfully without synthesising a fill.
+        """
+        self._conn.execute(
+            self._INSERT_FILL_SQL,
+            (
+                fill.client_order_id,
+                fill.broker_trade_id,
+                float(fill.fill_price),
+                int(fill.units_filled),
+                float(fill.slippage),
+                str(fill.status.value),
+                _to_rfc3339(fill.filled_at),
+            ),
+        )
+        self._conn.commit()
+
+    def write_rejection(
+        self,
+        client_order_id: str,
+        rejected_at: datetime,
+        reason: str = "",
+    ) -> None:
+        """Record a broker rejection in ``fills`` without inventing a fill.
+
+        A rejection is terminal: no ``Position`` is created and the
+        ``Fill`` model cannot represent it (it requires a non-empty
+        broker-trade-id and non-zero units).  We persist a row with
+        ``status="rejected"``, ``broker_trade_id`` holding the (possibly empty)
+        reason for audit, ``fill_price`` 0 and ``units_filled`` 0 — these are
+        store-layer sentinels, never reconstructed into a ``Fill``
+        (:meth:`get_fill_by_client_order_id` returns ``None`` for them).
+        ``rejected_at`` is sourced from the caller's UTC clock (INV-03).
+        """
+        self._conn.execute(
+            self._INSERT_FILL_SQL,
+            (
+                client_order_id,
+                reason,
+                0.0,
+                0,
+                0.0,
+                "rejected",
+                _to_rfc3339(rejected_at),
+            ),
+        )
+        self._conn.commit()
+
+    def write_position(self, position: "Position") -> None:
+        """Persist one ``Position`` row (idempotent on ``broker_trade_id``).
+
+        ``realized_pl`` / ``closed_at`` are nullable and remain ``NULL`` while
+        the position is open — reconciliation writes them on close (INV-16).
+        Timestamps are UTC RFC 3339 (INV-03).
+        """
+        self._conn.execute(
+            self._INSERT_POSITION_SQL,
+            (
+                position.broker_trade_id,
+                position.instrument,
+                int(position.units),
+                float(position.entry_price),
+                float(position.stop_loss_price),
+                float(position.take_profit_price),
+                position.candidate_ref,
+                _to_rfc3339(position.opened_at),
+                float(position.unrealized_pl),
+                _to_rfc3339(position.closed_at)
+                if position.closed_at is not None
+                else None,
+                float(position.realized_pl)
+                if position.realized_pl is not None
+                else None,
+            ),
+        )
+        self._conn.commit()
+
+    def get_fill_by_client_order_id(self, client_order_id: str) -> "Fill | None":
+        """Return the persisted *filled/partial* ``Fill`` for a
+        ``client_order_id``, or ``None``.
+
+        This is the pre-submit idempotency read (INV-15): ``submit_order`` calls
+        it before any broker write; a hit short-circuits and returns the
+        existing fill, so a retry or an operator re-run never opens a second
+        position.  Reconstructs a validated ``Fill`` (the same frozen INV-14
+        shape that was written).
+
+        A *rejected* row (written by :meth:`write_rejection`) is **not** a valid
+        ``Fill`` and is treated as absent here — it returns ``None`` so the
+        idempotency check never resurrects a non-fill as a fill.  (A rejection
+        is terminal; whether a re-run re-attempts is the caller's policy, and
+        the duplicate ``clientExtensions.id`` guards the broker either way.)
+
+        Args:
+            client_order_id: the deterministic idempotency key.
+
+        Returns:
+            The reconstructed ``Fill`` if a filled/partial row exists, else
+            ``None``.
+        """
+        from execution.models import Fill, FillStatus  # local: avoid import cycle
+
+        cursor = self._conn.execute(
+            """
+            SELECT client_order_id, broker_trade_id, fill_price, units_filled,
+                   slippage, status, filled_at
+            FROM   fills
+            WHERE  client_order_id = ?
+              AND  status IN ('filled', 'partial')
+            """,
+            (client_order_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return Fill(
+            client_order_id=row[0],
+            broker_trade_id=row[1],
+            fill_price=float(row[2]),
+            units_filled=int(row[3]),
+            slippage=float(row[4]),
+            status=FillStatus(row[5]),
+            filled_at=pd.to_datetime(row[6], utc=True).to_pydatetime(),
+        )
 
     # ------------------------------------------------------------------
     # Parquet archive

--- a/execution/orders.py
+++ b/execution/orders.py
@@ -1,0 +1,338 @@
+"""Order placement — submit atomic bracketed market orders to OANDA v20.
+
+This is the most safety-critical module in Fathom: it is the only code that
+actually opens a position with real (demo) money.  It is invoked exclusively by
+the deterministic execution path (``fathom execute``), never by Hermes
+(INV-01).
+
+Correctness guarantees enforced here
+------------------------------------
+* **INV-04 — atomic bracket / no naked position.**  Every submission is a single
+  v20 ``OrderCreate`` request whose body carries both ``stopLossOnFill`` and
+  ``takeProfitOnFill``.  There is no code path that opens a position with a
+  separate, skippable bracket call — the bracket either lands with the entry or
+  the order does not fill.
+* **INV-15 — idempotency / no double-fill.**  Two independent guards.  (a) a
+  pre-submit store read on the deterministic ``client_order_id`` returns the
+  existing fill with *no* HTTP if the order already filled; (b) the same
+  ``client_order_id`` is attached as the v20 ``clientExtensions.id`` on every
+  attempt, so even if the store missed a landed order (a crash between the
+  broker ack and the store write), OANDA itself rejects the duplicate client
+  id.  A network retry reuses the identical id and body, so a retry of a
+  silently-landed first attempt can never create a second order.
+* **INV-03 — UTC timestamps.**  ``filled_at`` is parsed from the broker
+  transaction time (always UTC) or, absent that, taken from an injected
+  UTC-aware clock — never ``datetime.now()`` with a naive tz.
+* **INV-07/INV-09 — practice endpoint, single code path.**  This module never
+  imports ``Settings`` or reads ``env``; it receives an already-constructed
+  ``OandaClient`` whose endpoint was chosen once in its ``__init__``.
+* **INV-08 — no secret logged.**  No token is read or logged here; the client
+  owns the credential.
+
+The slippage sign convention is the one frozen on the ``Fill`` model
+(AMBIGUOUS-05): **positive = adverse** vs the candidate ``entry_ref``,
+regardless of direction.
+"""
+
+from __future__ import annotations
+
+import time as _time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Callable
+
+from data.oanda_client import OandaAPIError
+from execution.models import Fill, FillStatus, Order, Position
+from strategies.base import Direction
+
+if TYPE_CHECKING:  # avoid import cycles / heavy deps at runtime
+    from data.oanda_client import OandaClient
+    from data.store import Store
+
+__all__ = ["submit_order", "OrderRejected"]
+
+
+class OrderRejected(Exception):
+    """Raised when the broker rejects an order outright.
+
+    A rejection is terminal and produces **no** ``Position`` and no synthetic
+    ``Fill`` — the broker's verdict is recorded faithfully
+    (``store.write_rejection``) and surfaced as this exception so the caller
+    cannot mistake a rejection for a fill (AC: "never synthesise a fill").
+    """
+
+    def __init__(self, client_order_id: str, reason: str) -> None:
+        self.client_order_id = client_order_id
+        self.reason = reason
+        super().__init__(f"order {client_order_id} rejected: {reason}")
+
+
+# Default retry policy: a small number of attempts with exponential backoff.
+# Only transient failures (network errors / HTTP 5xx) are retried; a 4xx is a
+# terminal client error (e.g. a malformed body) and is not retried.
+_DEFAULT_MAX_ATTEMPTS = 3
+_DEFAULT_BACKOFF_BASE_SECONDS = 0.5
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True if ``exc`` is a retryable transport/server failure.
+
+    A ``requests.RequestException`` (network-level) is transient.  An
+    ``OandaAPIError`` is transient only for HTTP 5xx; a 4xx is a terminal
+    client error and must not be retried (retrying a malformed order just burns
+    attempts).
+    """
+    if isinstance(exc, OandaAPIError):
+        return exc.status_code >= 500
+    # Treat any non-OANDA exception escaping the client (e.g. a
+    # requests.RequestException network failure, which the client deliberately
+    # propagates) as transient.
+    return True
+
+
+def _build_order_body(order: Order, *, precision: int) -> dict[str, Any]:
+    """Assemble the single v20 ``OrderCreate`` body — entry + both brackets.
+
+    The body is built in one dict so the bracket is atomic (INV-04): there is
+    no representation here of "entry now, bracket later".  ``stopLossOnFill`` and
+    ``takeProfitOnFill`` carry absolute prices (resolved by ``build_bracket``)
+    formatted to instrument precision.  ``clientExtensions.id`` carries the
+    deterministic idempotency key (INV-15) so the broker de-dupes a retry.
+    """
+    price_fmt = f"%.{precision}f"
+    return {
+        "order": {
+            "type": "MARKET",
+            "instrument": order.instrument,
+            "units": str(order.units),  # signed; long > 0, short < 0
+            "timeInForce": "FOK",  # fill-or-kill: no resting partials lingering
+            "positionFill": "DEFAULT",
+            "clientExtensions": {"id": order.client_order_id},
+            "stopLossOnFill": {
+                "price": price_fmt % order.stop_loss_price,
+                "timeInForce": "GTC",
+            },
+            "takeProfitOnFill": {
+                "price": price_fmt % order.take_profit_price,
+                "timeInForce": "GTC",
+            },
+        }
+    }
+
+
+def _compute_slippage(order: Order, entry_ref: float, fill_price: float) -> float:
+    """Signed slippage; **positive = adverse** vs ``entry_ref`` (any direction).
+
+    For a long, a fill *above* the reference is adverse (we paid more); for a
+    short, a fill *below* the reference is adverse (we sold cheaper).
+    """
+    if order.direction is Direction.LONG:
+        return fill_price - entry_ref
+    return entry_ref - fill_price
+
+
+def _parse_fill_time(fill_txn: dict[str, Any], fallback: datetime) -> datetime:
+    """Return a UTC-aware fill time from the broker transaction (INV-03).
+
+    OANDA transaction ``time`` is RFC-3339 UTC (``...Z``).  If it is missing we
+    fall back to the injected UTC clock value — never a naive ``datetime.now``.
+    """
+    raw = fill_txn.get("time")
+    if isinstance(raw, str) and raw:
+        s = raw.rstrip("Z")
+        if "." in s:
+            date_part, frac = s.split(".", 1)
+            frac = frac[:6].ljust(6, "0")
+            s = f"{date_part}.{frac}"
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+    if fallback.tzinfo is None:
+        raise ValueError("fallback fill time must be UTC-aware (INV-03).")
+    return fallback
+
+
+def submit_order(
+    order: Order,
+    *,
+    client: "OandaClient",
+    store: "Store",
+    entry_ref: float,
+    precision: int,
+    now: datetime,
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    backoff_base_seconds: float = _DEFAULT_BACKOFF_BASE_SECONDS,
+    sleep: Callable[[float], None] = _time.sleep,
+) -> Fill:
+    """Submit a bracketed market order to OANDA v20 (practice), idempotently.
+
+    Flow (mirrors the spec sequence diagram):
+
+    1. **Idempotency read (INV-15).**  Look up ``order.client_order_id`` in the
+       store; if a filled/partial ``Fill`` already exists, return it with no
+       broker call.
+    2. **Atomic submit (INV-04).**  Build ONE v20 ``OrderCreate`` body with the
+       entry, ``stopLossOnFill``, ``takeProfitOnFill`` and the
+       ``clientExtensions.id`` idempotency key, and submit it.
+    3. **Retry (INV-15).**  On a transient failure (network / HTTP 5xx) retry
+       with exponential backoff, reusing the identical body+id.  Before each
+       retry, re-check the store/broker — a prior attempt that landed but whose
+       ack we lost is detected, not duplicated.
+    4. **Capture + persist.**  Parse the ``orderFillTransaction``; compute signed
+       slippage vs ``entry_ref``; build and persist the ``Order``/``Fill``/
+       ``Position`` rows.
+    5. **Rejection.**  An ``orderRejectTransaction`` / ``orderCancelTransaction``
+       records ``status="rejected"`` (no position) and raises
+       :class:`OrderRejected` — a fill is never synthesised.
+
+    Args:
+        order: the gated, sized, fully-bracketed ``Order`` (INV-04/INV-14).
+        client: an already-constructed ``OandaClient`` (endpoint chosen by
+            ``settings.env``; this module never reads ``env`` — INV-09).
+        store: the persistence layer (orders/fills/positions tables).
+        entry_ref: the candidate's reference entry price, for slippage.
+        precision: instrument display precision for bracket price formatting.
+        now: a UTC-aware clock value used only as a fallback fill time and for
+            the rejection timestamp (INV-03 — never ``datetime.now()`` naive).
+        max_attempts: total submission attempts (>= 1).
+        backoff_base_seconds: base for exponential backoff between retries.
+        sleep: injected sleeper (so tests don't actually wait).
+
+    Returns:
+        The ``Fill`` for the (possibly already-existing) order.
+
+    Raises:
+        OrderRejected: if the broker rejects/cancels the order.
+        OandaAPIError: on a terminal (4xx) broker error or after retries are
+            exhausted on a 5xx.
+        requests.RequestException: if the network keeps failing past
+            ``max_attempts``.
+    """
+    if now.tzinfo is None:
+        raise ValueError("now must be a UTC-aware datetime (INV-03).")
+
+    # 1. Pre-submit idempotency read (INV-15) — no HTTP if already filled.
+    existing = store.get_fill_by_client_order_id(order.client_order_id)
+    if existing is not None:
+        return existing
+
+    body = _build_order_body(order, precision=precision)
+
+    # Record the intent before the broker write so a crash mid-submit leaves an
+    # auditable "submitted" row (reconciliation can later resolve it).
+    store.write_order(order, status="submitted")
+
+    response: dict[str, Any] | None = None
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        # Belt-and-suspenders: a prior attempt may have landed even though its
+        # ack never reached us. Re-check before re-hitting the broker (INV-15).
+        if attempt > 0:
+            already = store.get_fill_by_client_order_id(order.client_order_id)
+            if already is not None:
+                return already
+        try:
+            response = client.create_order(body)
+            break
+        except Exception as exc:  # noqa: BLE001 — re-raised below if terminal
+            last_exc = exc
+            if not _is_transient(exc) or attempt == max_attempts - 1:
+                raise
+            sleep(backoff_base_seconds * (2 ** attempt))
+
+    if response is None:  # pragma: no cover — loop either breaks or raises
+        assert last_exc is not None
+        raise last_exc
+
+    return _resolve_response(order, response, store, entry_ref=entry_ref, now=now)
+
+
+def _resolve_response(
+    order: Order,
+    response: dict[str, Any],
+    store: "Store",
+    *,
+    entry_ref: float,
+    now: datetime,
+) -> Fill:
+    """Turn a v20 ``OrderCreate`` response into a persisted ``Fill``.
+
+    A rejection/cancellation records the verdict and raises ``OrderRejected``;
+    a fill persists ``Fill`` + ``Position`` and returns the ``Fill``.  A partial
+    fill (``units_filled`` strictly between 0 and the ordered units) is recorded
+    with ``status="partial"``.
+    """
+    reject_txn = response.get("orderRejectTransaction") or response.get(
+        "orderCancelTransaction"
+    )
+    fill_txn = response.get("orderFillTransaction")
+
+    if fill_txn is None:
+        reason = ""
+        if isinstance(reject_txn, dict):
+            reason = str(reject_txn.get("reason", "")) or str(
+                reject_txn.get("type", "")
+            )
+        store.write_order(order, status="rejected")
+        store.write_rejection(order.client_order_id, rejected_at=now, reason=reason)
+        raise OrderRejected(order.client_order_id, reason or "no fill transaction")
+
+    fill_price = float(fill_txn["price"])
+    units_filled = int(float(fill_txn["units"]))
+    if units_filled == 0:
+        # Broker returned a fill transaction with zero units — treat as a
+        # rejection rather than constructing an invalid (zero-unit) Fill.
+        store.write_order(order, status="rejected")
+        store.write_rejection(
+            order.client_order_id, rejected_at=now, reason="zero-unit fill"
+        )
+        raise OrderRejected(order.client_order_id, "zero-unit fill")
+
+    partial = abs(units_filled) < abs(order.units)
+    status = FillStatus.PARTIAL if partial else FillStatus.FILLED
+
+    filled_at = _parse_fill_time(fill_txn, now)
+    slippage = _compute_slippage(order, entry_ref, fill_price)
+
+    # broker_trade_id: the opened trade id (present on a fill).  Fall back to the
+    # fill transaction id so the (frozen) non-empty constraint always holds.
+    trade_opened = fill_txn.get("tradeOpened") or {}
+    broker_trade_id = str(
+        trade_opened.get("tradeID")
+        or fill_txn.get("id")
+        or ""
+    )
+    if not broker_trade_id:
+        # No identifiable trade id — cannot build a valid Position/Fill; record
+        # as rejected rather than fabricate one.
+        store.write_order(order, status="rejected")
+        store.write_rejection(
+            order.client_order_id, rejected_at=now, reason="missing trade id"
+        )
+        raise OrderRejected(order.client_order_id, "missing broker trade id")
+
+    fill = Fill(
+        client_order_id=order.client_order_id,
+        broker_trade_id=broker_trade_id,
+        fill_price=fill_price,
+        units_filled=units_filled,
+        slippage=slippage,
+        filled_at=filled_at,
+        status=status,
+    )
+
+    position = Position(
+        broker_trade_id=broker_trade_id,
+        instrument=order.instrument,
+        units=units_filled,
+        entry_price=fill_price,
+        stop_loss_price=order.stop_loss_price,
+        take_profit_price=order.take_profit_price,
+        opened_at=filled_at,
+        unrealized_pl=0.0,
+        closed_at=None,
+        realized_pl=None,
+        candidate_ref=order.candidate_ref,
+    )
+
+    store.write_order(order, status=status.value)
+    store.write_fill(fill)
+    store.write_position(position)
+    return fill

--- a/tests/test_order_placement.py
+++ b/tests/test_order_placement.py
@@ -1,0 +1,452 @@
+"""Unit tests for execution.orders.submit_order + the execution store tables.
+
+Mocks OANDA v20 with the ``responses`` library — NO live HTTP. Covers the
+order-placement acceptance criteria:
+
+* atomic bracket: SL + TP in ONE v20 request (INV-04);
+* idempotency: a duplicate ``client_order_id`` does not create a second broker
+  order (INV-15);
+* a transient error then success yields exactly ONE fill (retry de-dupes);
+* slippage = signed (positive = adverse) vs ``Candidate.entry_ref``;
+* a rejection records ``status="rejected"`` with no position; a partial fill
+  records ``units_filled < units`` and ``status="partial"``;
+* UTC RFC-3339 timestamps on persisted rows (INV-03);
+* no secret appears in any persisted row (INV-08).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import responses as resp_lib
+from pydantic import SecretStr
+from responses import matchers
+
+from config.settings import Settings
+from data.oanda_client import OandaAPIError, OandaClient
+from data.store import Store
+from execution.models import EntryType, Fill, FillStatus, Order
+from execution.orders import OrderRejected, submit_order
+from strategies.base import Direction
+
+PRACTICE_BASE = "https://api-fxpractice.oanda.com"
+ACCOUNT_ID = "001-001-1234567-001"
+ORDERS_URL = f"{PRACTICE_BASE}/v3/accounts/{ACCOUNT_ID}/orders"
+SUMMARY_URL = f"{PRACTICE_BASE}/v3/accounts/{ACCOUNT_ID}/summary"
+
+NOW = datetime(2026, 5, 29, 13, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings(env: str = "demo") -> Settings:
+    return Settings(
+        env=env,
+        oanda_api_token=SecretStr("super-secret-token-DO-NOT-LEAK"),
+        oanda_account_id=ACCOUNT_ID,
+    )
+
+
+def _store() -> Store:
+    return Store(db_path=":memory:")
+
+
+def _long_order(client_order_id: str = "a" * 32) -> Order:
+    return Order(
+        client_order_id=client_order_id,
+        instrument="EUR_USD",
+        direction=Direction.LONG,
+        units=10_000,
+        entry_type=EntryType.MARKET,
+        stop_loss_price=1.08000,
+        take_profit_price=1.09500,
+        candidate_ref="EUR_USD:H1:macrossover",
+        created_at=NOW,
+    )
+
+
+def _short_order(client_order_id: str = "b" * 32) -> Order:
+    return Order(
+        client_order_id=client_order_id,
+        instrument="EUR_USD",
+        direction=Direction.SHORT,
+        units=-10_000,
+        entry_type=EntryType.MARKET,
+        stop_loss_price=1.09500,
+        take_profit_price=1.08000,
+        candidate_ref="EUR_USD:H1:macrossover",
+        created_at=NOW,
+    )
+
+
+def _fill_response(
+    *,
+    price: str = "1.08550",
+    units: str = "10000",
+    trade_id: str = "T-555",
+    fill_time: str = "2026-05-29T13:00:01.000000000Z",
+) -> dict[str, Any]:
+    """A v20 OrderCreate success response with an orderFillTransaction."""
+    return {
+        "orderCreateTransaction": {"id": "1001", "time": fill_time},
+        "orderFillTransaction": {
+            "id": "1002",
+            "time": fill_time,
+            "price": price,
+            "units": units,
+            "tradeOpened": {"tradeID": trade_id, "units": units},
+        },
+        "lastTransactionID": "1002",
+    }
+
+
+def _reject_response(reason: str = "INSUFFICIENT_MARGIN") -> dict[str, Any]:
+    return {
+        "orderRejectTransaction": {
+            "id": "2001",
+            "time": "2026-05-29T13:00:01.000000000Z",
+            "type": "MARKET_ORDER_REJECT",
+            "reason": reason,
+        },
+        "lastTransactionID": "2001",
+    }
+
+
+def _client() -> OandaClient:
+    return OandaClient(_settings())
+
+
+def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Atomic bracket (INV-04)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicBracket:
+    @resp_lib.activate
+    def test_sl_and_tp_in_one_request(self) -> None:
+        captured: list[dict[str, Any]] = []
+
+        def _capture(request: Any) -> tuple[int, dict[str, str], str]:
+            captured.append(json.loads(request.body))
+            return (201, {}, json.dumps(_fill_response()))
+
+        resp_lib.add_callback(resp_lib.POST, ORDERS_URL, callback=_capture)
+
+        store = _store()
+        order = _long_order()
+        submit_order(
+            order,
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+
+        assert len(captured) == 1, "exactly one v20 request (atomic, INV-04)"
+        body = captured[0]["order"]
+        assert "stopLossOnFill" in body
+        assert "takeProfitOnFill" in body
+        assert body["stopLossOnFill"]["price"] == "1.08000"
+        assert body["takeProfitOnFill"]["price"] == "1.09500"
+        # The idempotency key is attached as the v20 client extension (INV-15).
+        assert body["clientExtensions"]["id"] == order.client_order_id
+
+    @resp_lib.activate
+    def test_units_signed_for_short(self) -> None:
+        captured: list[dict[str, Any]] = []
+
+        def _capture(request: Any) -> tuple[int, dict[str, str], str]:
+            captured.append(json.loads(request.body))
+            return (201, {}, json.dumps(_fill_response(units="-10000")))
+
+        resp_lib.add_callback(resp_lib.POST, ORDERS_URL, callback=_capture)
+        store = _store()
+        submit_order(
+            _short_order(),
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        assert captured[0]["order"]["units"] == "-10000"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency (INV-15)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    @resp_lib.activate
+    def test_duplicate_submit_no_second_order(self) -> None:
+        """A second submit of the same client_order_id makes no broker call."""
+        # Only ONE response is registered. If submit_order hit the broker
+        # twice, responses would raise ConnectionError on the second call.
+        resp_lib.add(
+            resp_lib.POST, ORDERS_URL, json=_fill_response(), status=201
+        )
+        store = _store()
+        order = _long_order()
+        kwargs = dict(
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        first = submit_order(order, **kwargs)  # type: ignore[arg-type]
+        second = submit_order(order, **kwargs)  # type: ignore[arg-type]
+
+        assert isinstance(first, Fill) and isinstance(second, Fill)
+        assert first.broker_trade_id == second.broker_trade_id
+        # Exactly one HTTP call was made.
+        assert len(resp_lib.calls) == 1
+        # Exactly one position row exists.
+        cur = store._conn.execute("SELECT COUNT(*) FROM positions")
+        assert cur.fetchone()[0] == 1
+
+    @resp_lib.activate
+    def test_transient_then_success_exactly_one_fill(self) -> None:
+        """A 503 then a 201 yields exactly one filled position (retry reuses id)."""
+        resp_lib.add(resp_lib.POST, ORDERS_URL, status=503, body="service down")
+        resp_lib.add(
+            resp_lib.POST, ORDERS_URL, json=_fill_response(), status=201
+        )
+        store = _store()
+        order = _long_order()
+        fill = submit_order(
+            order,
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        assert fill.status is FillStatus.FILLED
+        assert len(resp_lib.calls) == 2  # one failed, one succeeded
+        cur = store._conn.execute("SELECT COUNT(*) FROM positions")
+        assert cur.fetchone()[0] == 1
+        cur = store._conn.execute(
+            "SELECT COUNT(*) FROM fills WHERE status='filled'"
+        )
+        assert cur.fetchone()[0] == 1
+
+    @resp_lib.activate
+    def test_terminal_4xx_not_retried(self) -> None:
+        """A 400 is terminal: surfaced immediately, not retried into 5xx loop."""
+        resp_lib.add(resp_lib.POST, ORDERS_URL, status=400, body="bad order")
+        store = _store()
+        with pytest.raises(OandaAPIError) as exc:
+            submit_order(
+                _long_order(),
+                client=_client(),
+                store=store,
+                entry_ref=1.08500,
+                precision=5,
+                now=NOW,
+                sleep=_no_sleep,
+            )
+        assert exc.value.status_code == 400
+        assert len(resp_lib.calls) == 1  # no retry on a 4xx
+
+
+# ---------------------------------------------------------------------------
+# Slippage capture
+# ---------------------------------------------------------------------------
+
+
+class TestSlippage:
+    @resp_lib.activate
+    def test_long_adverse_slippage_positive(self) -> None:
+        # Long, filled above entry_ref => adverse => positive slippage.
+        resp_lib.add(
+            resp_lib.POST,
+            ORDERS_URL,
+            json=_fill_response(price="1.08600"),
+            status=201,
+        )
+        store = _store()
+        fill = submit_order(
+            _long_order(),
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        assert fill.slippage == pytest.approx(1.08600 - 1.08500)
+        assert fill.slippage > 0
+
+    @resp_lib.activate
+    def test_short_adverse_slippage_positive(self) -> None:
+        # Short, filled below entry_ref => adverse => positive slippage.
+        resp_lib.add(
+            resp_lib.POST,
+            ORDERS_URL,
+            json=_fill_response(price="1.08400", units="-10000"),
+            status=201,
+        )
+        store = _store()
+        fill = submit_order(
+            _short_order(),
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        assert fill.slippage == pytest.approx(1.08500 - 1.08400)
+        assert fill.slippage > 0
+
+
+# ---------------------------------------------------------------------------
+# Rejection / partial
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionAndPartial:
+    @resp_lib.activate
+    def test_rejection_records_status_no_position(self) -> None:
+        resp_lib.add(
+            resp_lib.POST, ORDERS_URL, json=_reject_response(), status=201
+        )
+        store = _store()
+        order = _long_order()
+        with pytest.raises(OrderRejected):
+            submit_order(
+                order,
+                client=_client(),
+                store=store,
+                entry_ref=1.08500,
+                precision=5,
+                now=NOW,
+                sleep=_no_sleep,
+            )
+        cur = store._conn.execute("SELECT COUNT(*) FROM positions")
+        assert cur.fetchone()[0] == 0
+        cur = store._conn.execute(
+            "SELECT status FROM fills WHERE client_order_id=?",
+            (order.client_order_id,),
+        )
+        assert cur.fetchone()[0] == "rejected"
+        # A rejected row is not resurrected as a Fill by the idempotency read.
+        assert store.get_fill_by_client_order_id(order.client_order_id) is None
+
+    @resp_lib.activate
+    def test_partial_fill_recorded(self) -> None:
+        resp_lib.add(
+            resp_lib.POST,
+            ORDERS_URL,
+            json=_fill_response(units="4000"),
+            status=201,
+        )
+        store = _store()
+        fill = submit_order(
+            _long_order(),  # ordered 10_000
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        assert fill.status is FillStatus.PARTIAL
+        assert abs(fill.units_filled) < 10_000
+        assert fill.units_filled == 4000
+
+
+# ---------------------------------------------------------------------------
+# INV-03 (UTC) and INV-08 (no secret leaked)
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampsAndSecrets:
+    @resp_lib.activate
+    def test_persisted_timestamps_are_utc_rfc3339(self) -> None:
+        resp_lib.add(
+            resp_lib.POST, ORDERS_URL, json=_fill_response(), status=201
+        )
+        store = _store()
+        order = _long_order()
+        submit_order(
+            order,
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        cur = store._conn.execute(
+            "SELECT filled_at FROM fills WHERE client_order_id=?",
+            (order.client_order_id,),
+        )
+        filled_at = cur.fetchone()[0]
+        assert filled_at.endswith("Z")
+        # Parses as UTC and round-trips through the Fill model.
+        reread = store.get_fill_by_client_order_id(order.client_order_id)
+        assert reread is not None
+        assert reread.filled_at.tzinfo is not None
+        assert reread.filled_at.utcoffset() == timezone.utc.utcoffset(None)
+
+    @resp_lib.activate
+    def test_no_secret_in_persisted_rows(self) -> None:
+        resp_lib.add(
+            resp_lib.POST, ORDERS_URL, json=_fill_response(), status=201
+        )
+        store = _store()
+        order = _long_order()
+        submit_order(
+            order,
+            client=_client(),
+            store=store,
+            entry_ref=1.08500,
+            precision=5,
+            now=NOW,
+            sleep=_no_sleep,
+        )
+        secret = "super-secret-token-DO-NOT-LEAK"
+        for table in ("orders", "fills", "positions"):
+            cur = store._conn.execute(f"SELECT * FROM {table}")
+            for row in cur.fetchall():
+                for value in row:
+                    assert secret not in str(value)
+
+
+# ---------------------------------------------------------------------------
+# Account summary endpoint (INV-09 single env reader)
+# ---------------------------------------------------------------------------
+
+
+class TestAccountSummary:
+    @resp_lib.activate
+    def test_account_summary_hits_practice_endpoint(self) -> None:
+        resp_lib.add(
+            resp_lib.GET,
+            SUMMARY_URL,
+            json={"account": {"balance": "100000.0", "NAV": "100000.0"}},
+            status=200,
+        )
+        summary = _client().account_summary()
+        assert summary["account"]["balance"] == "100000.0"
+        request_url = resp_lib.calls[0].request.url
+        assert request_url is not None
+        assert request_url.startswith(PRACTICE_BASE)


### PR DESCRIPTION
## Summary

Implements the execution engine that submits sized, bracketed, idempotent demo orders to the OANDA v20 **practice** account — the most safety-critical code in Fathom (double-fill / naked-position risk). Also owns the store migration for `orders`/`fills`/`positions`.

- `execution/orders.py::submit_order(order, *, client, store, entry_ref, precision, now, ...) -> Fill`
- `data/store.py`: new `orders`/`fills`/`positions` tables + write/read helpers (this spec owns the migration)
- `data/oanda_client.py`: v20 order-create + account-summary endpoints
- `tests/test_order_placement.py`: 12 tests, v20 mocked with `responses` (no live HTTP)

## INV compliance

- **INV-04 (atomic bracket / no naked position):** the only submission path builds `stopLossOnFill` + `takeProfitOnFill` into a single `OrderCreate` body. There is no entry-then-bracket two-call path. A test asserts exactly one HTTP request carrying both bracket keys.
- **INV-15 (idempotency / no double-fill):** belt-and-suspenders. (a) a pre-submit store read on the deterministic `client_order_id` short-circuits with the existing `Fill` and zero HTTP; (b) the same id is attached as the v20 `clientExtensions.id` so the broker de-dupes even if the store missed a landed order. Retries reuse the identical body+id and re-check the store before re-hitting the broker. Tests assert a duplicate submit makes no second order and a transient-then-success yields exactly one filled position.
- **INV-07 / INV-09 (practice only, single env reader):** `orders.py` imports neither `Settings` nor `env`; it receives an already-constructed `OandaClient`. The practice endpoint is selected once in the client. The live token is never referenced.
- **INV-03 (UTC RFC-3339):** `filled_at` is parsed from the broker UTC transaction time (fallback to an injected UTC clock — never naive `datetime.now()`); all persisted timestamps are RFC-3339 `...Z`.
- **INV-08 (no secret persisted/logged):** no token is read or logged in `orders.py`; a test scans every persisted row across all three tables for the token string.

## Store schema added (spec-pinned, DRIFT-01/02)

- `orders` — PK `client_order_id`; `instrument, direction, units, stop_loss_price, take_profit_price, candidate_ref, created_at, status`
- `fills` — PK `client_order_id`; `broker_trade_id, fill_price, units_filled, slippage, status, filled_at`
- `positions` — PK `broker_trade_id`; `instrument, units, entry_price, stop_loss_price, take_profit_price, candidate_ref, opened_at, unrealized_pl, closed_at (nullable), realized_pl (nullable)`

## Tests / checks

- `./.venv/bin/python -m mypy .` → Success: no issues found in 61 source files
- `./.venv/bin/python -m pytest -q` → 710 passed (698 baseline + 12 new)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)