### PR TITLE
P3-T-03: position-sizing (stop-derived units, 0.25% cap)

### DIFF
--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -1,0 +1,9 @@
+"""Risk package — per-trade position sizing (P3-T-03).
+
+Owns the most safety-critical calculation in Fathom: the 0.25%-of-equity
+per-trade risk cap (INV-05).  See :mod:`risk.sizing`.
+"""
+
+from risk.sizing import SizingResult, size_position
+
+__all__ = ["SizingResult", "size_position"]

--- a/risk/sizing.py
+++ b/risk/sizing.py
@@ -1,0 +1,213 @@
+"""Position sizing — derive a signed unit count from stop distance + equity.
+
+This module owns **INV-05**: no single trade risks more than 0.25% of current
+account equity, and position size is *derived* from the stop distance and that
+risk budget — never a fixed lot.  It is the first gate that can reject a trade:
+an uncomputable or oversized size yields ``units=0`` with a reason, never a
+naked or oversized order (INV-04 / INV-11 boundary).
+
+Design (DRIFT-07 / AMBIGUOUS-02, resolved at the 2026-05-29 cross-spec audit)
+----------------------------------------------------------------------------
+* Per-unit risk in **account currency** is::
+
+      per_unit_risk = stop_distance × quote_to_account_rate
+
+  ``stop_distance`` is a *price distance* (in the instrument's quote currency,
+  e.g. USD for EUR_USD, JPY for USD_JPY).  ``rate`` (``quote_to_account_rate``)
+  converts one unit of the **quote** currency into the **account** currency.
+  There is deliberately **no** ``InstrumentMeta.pip_value`` field — per-unit
+  risk derives from ``stop_distance`` and ``rate`` only.
+
+  - quote == account (EUR_USD, USD account)  → ``rate = 1.0``.
+  - quote != account (USD_JPY, USD account)  → ``rate = 1 / USD_JPY_mid``
+    (the value of 1 JPY in USD).  The caller (execution CLI/orchestrator)
+    computes ``rate`` from the latest cached candle mid; this function takes it
+    as an input and is therefore pure.
+
+* ``risk_budget = equity × risk_fraction`` (``risk_fraction`` defaults to
+  ``0.0025`` = 0.25%, the INV-05 cap).
+
+* ``units = floor(risk_budget / per_unit_risk)``, signed by direction.  Floor is
+  strictly non-increasing, so ``|units| × per_unit_risk ≤ risk_budget`` always
+  holds — the cap cannot be silently exceeded (the INV-05 property test pins
+  this across random inputs).
+
+* **Reject** (``units=0`` + reason) when ``stop_distance ≤ 0`` (INV-04/11 — never
+  sized naked), when ``rate``/``equity`` are non-finite or non-positive, or when
+  the largest cap-respecting size is below ``InstrumentMeta.min_trade_size`` —
+  we never round *up* to the minimum (that would breach the cap).  No
+  max-trade-size clamp (OANDA exposes no per-instrument max; the book-level cap
+  lives in risk-limits-kill-switch).
+
+Account currency is assumed **USD** for the Phase 3 demo account (config-driven
+at the call site; this pure function only needs the already-resolved ``rate``).
+
+Purity: no network, no clock, no store access.  ``equity`` and ``rate`` are
+inputs (INV-03 has no bearing here — there are no timestamps).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+from data.oanda_client import InstrumentMeta
+from signals.ranker import Candidate
+from strategies.base import Direction
+
+__all__ = ["SizingResult", "DEFAULT_RISK_FRACTION", "ACCOUNT_CURRENCY", "size_position"]
+
+#: The INV-05 per-trade risk cap as a fraction of equity (0.25%).  This is the
+#: single most safety-critical constant in the system.  It is the *default*
+#: ``risk_fraction``; a caller may pass a smaller value but the cap it enforces
+#: can never be silently exceeded (floor-only sizing guarantees this).
+DEFAULT_RISK_FRACTION: float = 0.0025
+
+#: Account currency for the Phase 3 demo account.  Documented here for the
+#: ``rate`` contract: ``rate`` converts the instrument's *quote* currency into
+#: this currency.  Config-driven at the call site (the CLI resolves the rate);
+#: this constant exists only to document the assumption.
+ACCOUNT_CURRENCY: str = "USD"
+
+
+class SizingResult(BaseModel):
+    """The outcome of a sizing decision.
+
+    Fields
+    ------
+    units       : signed integer unit count (long > 0, short < 0).  ``0`` means
+                  **rejected** — never place an order on a zero result.
+    risk_amount : the actual money at risk in account currency if the stop is
+                  hit (``|units| × per_unit_risk``).  ``0.0`` on rejection.  By
+                  construction ``risk_amount ≤ equity × risk_fraction`` (INV-05).
+    reason      : human-readable rejection reason, set iff ``units == 0``;
+                  ``None`` on a successful size.  Surfaced by the execution CLI.
+    """
+
+    units: int
+    risk_amount: float
+    reason: Optional[str] = None
+
+    @field_validator("risk_amount")
+    @classmethod
+    def _risk_non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError(f"risk_amount must be >= 0, got {v}")
+        return v
+
+
+def _reject(reason: str) -> SizingResult:
+    """Build a rejection result (``units=0``, no money at risk)."""
+    return SizingResult(units=0, risk_amount=0.0, reason=reason)
+
+
+def size_position(
+    candidate: Candidate,
+    equity: float,
+    *,
+    instrument_meta: InstrumentMeta,
+    rate: float = 1.0,
+    risk_fraction: float = DEFAULT_RISK_FRACTION,
+) -> SizingResult:
+    """Derive a signed unit count for ``candidate`` under the INV-05 cap.
+
+    Args:
+        candidate: the approved, frozen ``Candidate`` (INV-13); read-only.  Its
+            ``stop_distance`` (a quote-currency price distance) and ``direction``
+            drive the size.
+        equity: current account equity in account currency (an input — fetched
+            once by the orchestrator; not read here).  Must be finite and > 0.
+        instrument_meta: the instrument's OANDA metadata; only
+            ``min_trade_size`` is consulted (the reject floor).  There is no
+            ``pip_value`` field and no max-size field.
+        rate: quote→account conversion rate (``quote_to_account_rate``).
+            ``1.0`` when the quote currency *is* the account currency (e.g.
+            EUR_USD with a USD account).  For a non-account-quote pair (e.g.
+            USD_JPY with a USD account) this is the value of 1 quote-currency
+            unit in account currency (``1 / USD_JPY_mid``).  Must be finite > 0.
+        risk_fraction: fraction of equity at risk per trade.  Defaults to
+            ``0.0025`` (the INV-05 0.25% cap).  Must be finite and > 0.
+
+    Returns:
+        A ``SizingResult``.  On success ``units`` is signed by direction and
+        ``risk_amount = |units| × stop_distance × rate ≤ equity × risk_fraction``
+        (INV-05).  On any rejection ``units == 0`` and ``reason`` is set.
+
+    Notes:
+        Pure and deterministic — no network, no clock, no store.  Never raises
+        on bad sizing inputs; it rejects with a reason instead, so the execution
+        path always gets a definite, safe answer (never a naked or oversized
+        order).
+    """
+    # --- 1. Validate the cap parameters (defensive; reject, never raise). ---
+    if not math.isfinite(risk_fraction) or risk_fraction <= 0:
+        return _reject(
+            f"risk_fraction must be finite and > 0, got {risk_fraction!r}."
+        )
+    if not math.isfinite(equity) or equity <= 0:
+        return _reject(f"equity must be finite and > 0, got {equity!r}.")
+    if not math.isfinite(rate) or rate <= 0:
+        return _reject(
+            f"quote_to_account_rate must be finite and > 0, got {rate!r}."
+        )
+
+    # --- 2. Reject a naked / uncomputable stop (INV-04 / INV-11 boundary). ---
+    stop_distance = candidate.stop_distance
+    if not math.isfinite(stop_distance) or stop_distance <= 0:
+        return _reject(
+            "stop_distance must be finite and > 0 — a candidate with no valid "
+            f"stop is rejected, never sized naked (INV-04); got {stop_distance!r}."
+        )
+
+    # --- 3. Resolve direction sign (long > 0, short < 0; FLAT/unknown reject). -
+    try:
+        direction = Direction(candidate.direction)
+    except ValueError:
+        return _reject(
+            f"untradeable direction {candidate.direction!r} (expected LONG/SHORT)."
+        )
+    if direction is Direction.LONG:
+        sign = 1
+    elif direction is Direction.SHORT:
+        sign = -1
+    else:  # Direction.FLAT
+        return _reject(
+            f"untradeable direction {candidate.direction!r} (expected LONG/SHORT)."
+        )
+
+    # --- 4. Per-unit risk in account currency (DRIFT-07). -------------------
+    # stop_distance is a quote-currency price distance; rate converts it to the
+    # account currency.  Both factors are > 0 here, so per_unit_risk > 0.
+    per_unit_risk = stop_distance * rate
+    if not math.isfinite(per_unit_risk) or per_unit_risk <= 0:
+        # Defensive: only reachable via float overflow/underflow of the product.
+        return _reject(
+            "per-unit risk is not finite/positive after conversion "
+            f"(stop_distance={stop_distance!r}, rate={rate!r})."
+        )
+
+    # --- 5. Risk budget and floor-only sizing (INV-05 cap). -----------------
+    risk_budget = equity * risk_fraction
+    raw_units = risk_budget / per_unit_risk
+    # floor() only ever rounds DOWN, so |units| * per_unit_risk <= risk_budget.
+    # This is the line that makes the 0.25% cap unbreachable: there is no path
+    # that rounds up or clamps to a minimum.
+    magnitude = math.floor(raw_units)
+
+    # --- 6. Reject when the cap cannot fund the minimum trade size. ---------
+    # We never round UP to min_trade_size — that would breach the cap.
+    min_trade_size = instrument_meta.min_trade_size
+    if magnitude < min_trade_size or magnitude < 1:
+        return _reject(
+            f"risk budget {risk_budget:.6g} (= equity {equity:.6g} × "
+            f"{risk_fraction:.6g}) funds only {magnitude} units at a per-unit "
+            f"risk of {per_unit_risk:.6g}, below the instrument minimum "
+            f"{min_trade_size:.6g}. Rejected (never rounded up to the minimum)."
+        )
+
+    units = sign * magnitude
+    risk_amount = magnitude * per_unit_risk
+
+    return SizingResult(units=units, risk_amount=risk_amount, reason=None)

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,362 @@
+"""Tests for ``risk.sizing`` — the INV-05 0.25%-of-equity per-trade cap.
+
+The headline guarantee is property-tested hard (hypothesis): realized risk
+(``|units| × per_unit_risk``) never exceeds ``equity × risk_fraction``.  Worked
+hand-computed fixtures pin the conversion maths for a quote==account pair
+(EUR_USD) and a non-account-quote pair (USD_JPY).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from data.oanda_client import InstrumentMeta
+from risk.sizing import DEFAULT_RISK_FRACTION, size_position
+from signals.ranker import Candidate
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    *,
+    instrument: str = "EUR_USD",
+    direction: str = "LONG",
+    stop_distance: float = 0.0050,
+    entry_ref: float = 1.1000,
+    target_distance: float = 0.0100,
+) -> Candidate:
+    """Build a minimal valid Candidate; only direction + stop_distance matter."""
+    return Candidate(
+        instrument=instrument,
+        timeframe="H1",
+        strategy_name="macrossover_10_50",
+        direction=direction,
+        entry_ref=entry_ref,
+        stop_distance=stop_distance,
+        target_distance=target_distance,
+        oos_sharpe_mean=1.0,
+        quality_score=0.5,
+        rank=1,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=False,
+        generated_at="2026-05-29T00:00:00Z",
+    )
+
+
+def _meta(
+    *,
+    name: str = "EUR_USD",
+    pip_location: int = -4,
+    min_trade_size: float = 1.0,
+) -> InstrumentMeta:
+    """Build an InstrumentMeta; only min_trade_size is consulted by sizing."""
+    return InstrumentMeta(
+        name=name,
+        pip_location=pip_location,
+        min_trade_size=min_trade_size,
+        margin_rate=0.02,
+        display_precision=5 if pip_location == -4 else 3,
+        long_rate=0.0,
+        short_rate=0.0,
+        financing_days_of_week=[2],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worked hand-computed fixtures (AC: EUR_USD quote=USD, USD_JPY quote=JPY)
+# ---------------------------------------------------------------------------
+
+
+def test_eur_usd_worked_example_hits_cap_exactly() -> None:
+    """EUR_USD, USD account (rate=1).
+
+    equity=100_000, risk_fraction=0.0025 → budget=250 USD.
+    stop_distance=0.0050 (50 pips) → per_unit_risk=0.0050 USD/unit.
+    units = floor(250 / 0.0050) = 50_000 ; risk = 50_000 × 0.0050 = 250.0 = cap.
+    """
+    result = size_position(
+        _candidate(instrument="EUR_USD", direction="LONG", stop_distance=0.0050),
+        equity=100_000.0,
+        instrument_meta=_meta(name="EUR_USD", pip_location=-4),
+        rate=1.0,
+    )
+    assert result.units == 50_000  # LONG → positive
+    assert result.risk_amount == pytest.approx(250.0, abs=1e-9)
+    assert result.risk_amount <= 100_000.0 * DEFAULT_RISK_FRACTION + 1e-9
+    assert result.reason is None
+
+
+def test_usd_jpy_worked_example_conversion() -> None:
+    """USD_JPY, USD account — quote is JPY, so a conversion rate is required.
+
+    equity=100_000 USD, budget=250 USD.
+    stop_distance=0.50 (50 pips, JPY price units).
+    USD_JPY mid = 150.0 → rate = 1/150 USD per JPY.
+    per_unit_risk = 0.50 × (1/150) = 0.0033333... USD/unit.
+    units = floor(250 / 0.0033333...) = floor(250 × 150 / 0.50) = 75_000.
+    SHORT → units = -75_000 ; risk = 75_000 × 0.0033333... = 250.0 = cap.
+    """
+    rate = 1.0 / 150.0
+    result = size_position(
+        _candidate(instrument="USD_JPY", direction="SHORT", stop_distance=0.50),
+        equity=100_000.0,
+        instrument_meta=_meta(name="USD_JPY", pip_location=-2),
+        rate=rate,
+    )
+    assert result.units == -75_000  # SHORT → negative
+    assert result.risk_amount == pytest.approx(250.0, abs=1e-6)
+    assert result.risk_amount <= 100_000.0 * DEFAULT_RISK_FRACTION + 1e-6
+    assert result.reason is None
+
+
+def test_floor_rounds_down_below_cap_when_not_exact() -> None:
+    """A budget that does not divide evenly floors down — strictly under cap."""
+    # budget = 250 ; per_unit_risk = 0.0050 × 1 → raw = 50000 exact; perturb stop
+    # so the division is not integral: stop=0.0051 → raw=49019.6 → floor 49019.
+    result = size_position(
+        _candidate(stop_distance=0.0051),
+        equity=100_000.0,
+        instrument_meta=_meta(),
+        rate=1.0,
+    )
+    assert result.units == 49_019
+    assert result.risk_amount < 250.0  # strictly under the cap
+    assert result.risk_amount == pytest.approx(49_019 * 0.0051, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Rejection paths (AC: stop<=0, budget < min_trade_size, bad inputs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_stop", [0.0, -0.0010, -1.0])
+def test_non_positive_stop_rejected(bad_stop: float) -> None:
+    """stop_distance <= 0 → reject (never sized naked, INV-04/11)."""
+    # Candidate's own validator forbids stop<=0, so construct then mutate the
+    # field to exercise sizing's own guard directly.
+    cand = _candidate()
+    object.__setattr__(cand, "stop_distance", bad_stop)
+    result = size_position(
+        cand, equity=100_000.0, instrument_meta=_meta(), rate=1.0
+    )
+    assert result.units == 0
+    assert result.risk_amount == 0.0
+    assert result.reason is not None
+    assert "stop_distance" in result.reason
+
+
+def test_budget_too_small_for_min_trade_size_rejected() -> None:
+    """A budget that funds fewer than min_trade_size units → reject, not round up."""
+    # equity tiny → budget tiny; min_trade_size large.
+    result = size_position(
+        _candidate(stop_distance=0.0050),
+        equity=10.0,  # budget = 10 × 0.0025 = 0.025 USD
+        instrument_meta=_meta(min_trade_size=1.0),
+        rate=1.0,
+    )
+    # raw = 0.025 / 0.0050 = 5 → floor 5; but lift min_trade_size to force reject:
+    assert result.units == 5  # this funds 5 units; min=1 so it is allowed
+    # Now a genuinely-too-small budget:
+    result2 = size_position(
+        _candidate(stop_distance=0.0050),
+        equity=1.0,  # budget = 0.0025 → raw = 0.5 → floor 0
+        instrument_meta=_meta(min_trade_size=1.0),
+        rate=1.0,
+    )
+    assert result2.units == 0
+    assert result2.risk_amount == 0.0
+    assert result2.reason is not None
+    assert "minimum" in result2.reason
+
+
+def test_min_trade_size_floor_never_rounds_up() -> None:
+    """When the cap funds 100 units but min is 500, reject (never round up)."""
+    result = size_position(
+        _candidate(stop_distance=0.0050),
+        equity=200.0,  # budget = 0.5 USD → raw = 100 units
+        instrument_meta=_meta(min_trade_size=500.0),
+        rate=1.0,
+    )
+    assert result.units == 0
+    assert result.reason is not None
+
+
+@pytest.mark.parametrize(
+    "equity,rate,rf",
+    [
+        (0.0, 1.0, 0.0025),
+        (-100.0, 1.0, 0.0025),
+        (float("nan"), 1.0, 0.0025),
+        (float("inf"), 1.0, 0.0025),
+        (100_000.0, 0.0, 0.0025),
+        (100_000.0, -1.0, 0.0025),
+        (100_000.0, float("nan"), 0.0025),
+        (100_000.0, 1.0, 0.0),
+        (100_000.0, 1.0, -0.001),
+        (100_000.0, 1.0, float("nan")),
+    ],
+)
+def test_bad_scalar_inputs_rejected(equity: float, rate: float, rf: float) -> None:
+    """Non-finite / non-positive equity, rate, or risk_fraction → reject."""
+    result = size_position(
+        _candidate(),
+        equity=equity,
+        instrument_meta=_meta(),
+        rate=rate,
+        risk_fraction=rf,
+    )
+    assert result.units == 0
+    assert result.risk_amount == 0.0
+    assert result.reason is not None
+
+
+# ---------------------------------------------------------------------------
+# Sign convention (AC: signed units by direction)
+# ---------------------------------------------------------------------------
+
+
+def test_long_units_positive_short_units_negative() -> None:
+    long_res = size_position(
+        _candidate(direction="LONG"),
+        equity=100_000.0,
+        instrument_meta=_meta(),
+        rate=1.0,
+    )
+    short_res = size_position(
+        _candidate(direction="SHORT"),
+        equity=100_000.0,
+        instrument_meta=_meta(),
+        rate=1.0,
+    )
+    assert long_res.units > 0
+    assert short_res.units < 0
+    assert abs(long_res.units) == abs(short_res.units)  # magnitude direction-free
+
+
+def test_flat_direction_rejected() -> None:
+    cand = _candidate()
+    object.__setattr__(cand, "direction", "FLAT")
+    result = size_position(
+        cand, equity=100_000.0, instrument_meta=_meta(), rate=1.0
+    )
+    assert result.units == 0
+    assert result.reason is not None
+
+
+def test_default_risk_fraction_is_the_cap() -> None:
+    """The default risk_fraction is exactly the INV-05 0.25% cap."""
+    assert DEFAULT_RISK_FRACTION == 0.0025
+
+
+# ---------------------------------------------------------------------------
+# INV-05 PROPERTY: realized risk never exceeds equity × risk_fraction
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    equity=st.floats(
+        min_value=1.0, max_value=1e9, allow_nan=False, allow_infinity=False
+    ),
+    stop_distance=st.floats(
+        min_value=1e-6, max_value=10.0, allow_nan=False, allow_infinity=False
+    ),
+    rate=st.floats(
+        min_value=1e-6, max_value=1e4, allow_nan=False, allow_infinity=False
+    ),
+    risk_fraction=st.floats(
+        min_value=1e-6, max_value=0.0025, allow_nan=False, allow_infinity=False
+    ),
+    direction=st.sampled_from(["LONG", "SHORT"]),
+    min_trade_size=st.floats(min_value=1.0, max_value=1000.0),
+)
+def test_inv05_realized_risk_never_exceeds_cap(
+    equity: float,
+    stop_distance: float,
+    rate: float,
+    risk_fraction: float,
+    direction: str,
+    min_trade_size: float,
+) -> None:
+    """INV-05: |units| × per_unit_risk ≤ equity × risk_fraction, ALWAYS.
+
+    This is the headline invariant.  Across random equity/stop/rate/fraction
+    combinations, the realized money at risk if the stop is hit must never
+    exceed the cap.  The floor-only sizing makes this an identity, not a
+    statistical near-miss.
+    """
+    cand = _candidate(direction=direction, stop_distance=stop_distance)
+    result = size_position(
+        cand,
+        equity=equity,
+        instrument_meta=_meta(min_trade_size=min_trade_size),
+        rate=rate,
+        risk_fraction=risk_fraction,
+    )
+
+    cap = equity * risk_fraction
+    per_unit_risk = stop_distance * rate
+
+    if result.units == 0:
+        # Rejected: nothing is risked.
+        assert result.risk_amount == 0.0
+        return
+
+    # Realized risk recomputed independently from the returned units.
+    realized = abs(result.units) * per_unit_risk
+    # Allow a tiny relative tolerance for float multiplication noise only.
+    assert realized <= cap * (1 + 1e-9) + 1e-9, (
+        f"INV-05 breached: realized={realized} > cap={cap} "
+        f"(units={result.units}, per_unit_risk={per_unit_risk})"
+    )
+    # The reported risk_amount agrees with the recomputed realized risk.
+    assert result.risk_amount == pytest.approx(realized, rel=1e-9, abs=1e-12)
+    # And the reported risk_amount is itself within the cap.
+    assert result.risk_amount <= cap * (1 + 1e-9) + 1e-9
+
+
+@settings(max_examples=300, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    equity=st.floats(
+        min_value=1.0, max_value=1e9, allow_nan=False, allow_infinity=False
+    ),
+    stop_distance=st.floats(
+        min_value=1e-6, max_value=10.0, allow_nan=False, allow_infinity=False
+    ),
+    rate=st.floats(
+        min_value=1e-6, max_value=1e4, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_inv05_cap_cannot_be_exceeded_by_one_more_unit(
+    equity: float, stop_distance: float, rate: float
+) -> None:
+    """The size is the LARGEST cap-respecting size: one more unit breaches it.
+
+    Proves there is no silent under-sizing and no rounding-up: ``units`` is the
+    floor of the exact ratio, so ``(|units|+1) × per_unit_risk`` would exceed the
+    cap whenever a real position was opened.
+    """
+    cand = _candidate(direction="LONG", stop_distance=stop_distance)
+    result = size_position(
+        cand,
+        equity=equity,
+        instrument_meta=_meta(min_trade_size=1.0),
+        rate=rate,
+        risk_fraction=DEFAULT_RISK_FRACTION,
+    )
+    if result.units == 0:
+        return
+    cap = equity * DEFAULT_RISK_FRACTION
+    per_unit_risk = stop_distance * rate
+    one_more = (abs(result.units) + 1) * per_unit_risk
+    assert one_more > cap - 1e-9
+    # And units equals the mathematical floor of the exact ratio.
+    assert abs(result.units) == math.floor(cap / per_unit_risk)


### PR DESCRIPTION
Closes #78.

Adds `risk/sizing.py` — `size_position(candidate, equity, *, instrument_meta, rate=1.0, risk_fraction=0.0025) -> SizingResult` — the deterministic function that derives a signed unit count from a `Candidate`'s stop distance and account equity, owning the INV-05 0.25%-of-equity per-trade cap.

## Conversion maths (DRIFT-07)
Per-unit risk in account currency = `stop_distance × quote_to_account_rate`. There is **no** `InstrumentMeta.pip_value` field; risk derives from the price-distance stop and the quote→account `rate`:
- quote == account (EUR_USD, USD account) → `rate = 1.0`.
- quote != account (USD_JPY, USD account) → `rate = 1 / USD_JPY_mid` (value of 1 JPY in USD).

`rate` is an **input** (the CLI/orchestrator resolves it from the latest cached candle mid, AMBIGUOUS-02), keeping this function pure — no network, no clock, no store.

Then `risk_budget = equity × risk_fraction`; `units = floor(risk_budget / per_unit_risk)`, signed by direction (LONG > 0, SHORT < 0). No max-size clamp (book-level cap lives in risk-limits-kill-switch).

## How INV-05 is property-guaranteed
`floor()` only rounds **down**, so `|units| × per_unit_risk ≤ risk_budget = equity × risk_fraction` is an identity, not a near-miss. There is no rounding-up path: a budget too small to fund `min_trade_size` rejects (`units=0`, reason) rather than rounding up to the minimum. `risk_fraction` defaults to `0.0025` and is the only multiplier, so the cap cannot be silently exceeded.

The hypothesis property test asserts `|units| × per_unit_risk ≤ equity × risk_fraction` across 500 random equity/stop/rate/fraction/direction combinations, and a second property asserts `units` is the *largest* cap-respecting size (one more unit would breach the cap). Hand-computed EUR_USD (rate=1, hits cap exactly at 50k units) and USD_JPY (1/150 conversion, 75k units) fixtures pin the maths.

## Rejections (never naked, never oversized)
- `stop_distance ≤ 0` or non-finite → reject (INV-04/INV-11 boundary).
- non-finite/non-positive `equity`, `rate`, or `risk_fraction` → reject.
- `FLAT`/unknown direction → reject.
- budget < `min_trade_size` → reject.

## Verification
- `mypy .` → Success, 0 issues (66 source files).
- `pytest -q` → 751 passed (728 baseline + 23 new), exit 0.

Touches only `risk/sizing.py`, `risk/__init__.py`, `tests/test_sizing.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)