### PR TITLE
P3-T-02: extract signals/correlation.py (shared Pearson primitive)

### DIFF
--- a/.claude/context/signals.md
+++ b/.claude/context/signals.md
@@ -221,3 +221,51 @@ in the P2 coordinator branch; `pyproject.toml` NOT modified here).
 
 **Merge plan:** `gh pr merge 63 --squash --delete-branch` (lead action after
 reviewer pass).
+
+## P3-T-02 — 2026-05-29 (feat/p3-T-02-correlation)
+
+**What was done:**
+- Created `signals/correlation.py` — shared Pearson correlation primitive extracted
+  from `signals/portfolio.py` (behaviour-preserving refactor, no logic change).
+  Exports:
+  - `MIN_CORRELATION_OBS: int = 20` (shared constant)
+  - `split_currencies(instrument: str) -> list[str]` (public name)
+  - `_split_currencies` (alias = same object, backward-compat)
+  - `mid_returns(df: pd.DataFrame) -> pd.Series` (public name)
+  - `_mid_returns` (alias)
+  - `pearson_corr(a: pd.Series, b: pd.Series) -> float | None` (public name)
+  - `_pearson_corr` (alias)
+- Edited `signals/portfolio.py` to remove the three function definitions and
+  `MIN_CORRELATION_OBS` declaration; replaced with explicit re-exports:
+  `from signals.correlation import X as X` (the `as X` form satisfies mypy's
+  "explicit re-export" requirement so `from signals.portfolio import _pearson_corr`
+  etc. remain valid for existing callers without mypy errors).
+- Created `tests/test_correlation.py` — 21 focused tests directly on
+  `signals.correlation`: `split_currencies` (5), `mid_returns` (7 including NaN
+  regression guard), `pearson_corr` (8), `MIN_CORRELATION_OBS` sanity (1).
+
+**Key patterns / gotchas:**
+- The `as X` re-export idiom (`from signals.correlation import _pearson_corr as
+  _pearson_corr`) is required by mypy in strict mode to distinguish an intentional
+  public re-export from an accidental private import. Without it mypy raises
+  `[attr-defined]` for any downstream `from signals.portfolio import _pearson_corr`.
+- Public names (`pearson_corr`, `mid_returns`, `split_currencies`) are preferred for
+  Phase 3 `risk/limits.py` use; the underscore aliases exist only for backward
+  compatibility.
+- `signals/portfolio.py` internal behaviour is byte-identical — `_pearson_corr` and
+  `_split_currencies` are still called directly inside `PortfolioLimiter.apply()`
+  and `_load_returns`; the source of those names just moved one level up the import
+  chain.
+
+**AC verification results:**
+- `python -m pytest tests/test_portfolio.py -q` → **35 passed** (unchanged — test
+  file NOT modified), exit 0
+- `python -m pytest tests/test_correlation.py -q` → **21 passed**, exit 0
+- `python -m pytest -q` (full suite) → **772 passed, 87 warnings**, exit 0
+- `python -m mypy .` (whole repo) → **0 errors, 68 source files**, exit 0
+
+**No new runtime dependencies** (pandas + stdlib only). `pyproject.toml` NOT
+modified. `CLAUDE.md` trigger-table check: NOT edited (no new dep, no new CLI).
+
+**Merge plan:** `gh pr merge 91 --squash --delete-branch` (lead action after
+reviewer pass).

--- a/signals/correlation.py
+++ b/signals/correlation.py
@@ -1,0 +1,107 @@
+"""Shared Pearson correlation primitive for signal modules (P3-T-02).
+
+Provides the low-level helpers that both the Phase 2 portfolio limiter
+(``signals.portfolio``) and the Phase 3 risk-limits module
+(``risk.limits``) need:
+
+* ``pearson_corr`` / ``_pearson_corr`` — pairwise Pearson ρ on aligned
+  return Series, returning ``None`` when data is insufficient.
+* ``mid_returns`` / ``_mid_returns`` — arithmetic daily returns from
+  bid/ask mid close prices.
+* ``split_currencies`` / ``_split_currencies`` — OANDA instrument string
+  splitter (``"EUR_USD"`` → ``["EUR", "USD"]``).
+
+The underscore-prefixed names are the original names as shipped in
+``signals/portfolio.py``; they are kept as aliases so existing callers
+do not break.
+
+INV-03: this module never creates timestamps; it only consumes the
+    UTC-aware index on the return Series passed in.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Shared constant
+# ---------------------------------------------------------------------------
+
+#: Minimum number of overlapping non-NaN return observations required to
+#: treat a computed Pearson ρ as reliable.  Below this count the caller
+#: should skip the correlation check (conservative: do NOT drop on
+#: insufficient data).
+MIN_CORRELATION_OBS: int = 20
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def split_currencies(instrument: str) -> list[str]:
+    """Split an OANDA instrument string into its leg currencies.
+
+    ``"EUR_USD"`` → ``["EUR", "USD"]``.  Returns all non-empty parts split
+    on ``"_"`` — defensive; never raises.
+    """
+    return [p for p in instrument.split("_") if p]
+
+
+def mid_returns(df: pd.DataFrame) -> pd.Series:
+    """Compute daily arithmetic returns from bid/ask mid close prices.
+
+    Uses ``(close_bid + close_ask) / 2`` as the mid price and computes
+    ``pct_change()`` (arithmetic return; sufficient for correlation
+    estimation).  Returns a ``pd.Series`` indexed by ``df["time"]``.
+    If the required columns are absent or the DataFrame is too short,
+    returns an empty Series.
+    """
+    required = {"time", "close_bid", "close_ask"}
+    if not required.issubset(df.columns) or len(df) < 2:
+        return pd.Series(dtype="float64")
+    mid = (df["close_bid"] + df["close_ask"]) / 2.0
+    mid.index = pd.Index(df["time"])
+    returns = mid.pct_change().dropna()
+    return returns
+
+
+def pearson_corr(a: pd.Series, b: pd.Series) -> float | None:
+    """Compute Pearson ρ between two return series on their shared index.
+
+    Aligns on the index (timestamps), drops NaN pairs, and returns ``None``
+    if fewer than ``MIN_CORRELATION_OBS`` observations are available (the
+    caller treats ``None`` as "insufficient data — do not drop").
+
+    Returns:
+        Pearson ρ in [-1, 1], or ``None`` if data is insufficient.
+    """
+    if a.empty or b.empty:
+        return None
+
+    # Align on shared timestamps.  ``sort=True`` suppresses the Pandas 4
+    # DeprecationWarning about the default sort behaviour when concatenating
+    # DatetimeIndex-backed Series; aligning by sorted index is the correct
+    # semantic here (we want the shared timestamps in order).
+    aligned = pd.concat([a.rename("a"), b.rename("b")], axis=1, sort=True).dropna()
+    if len(aligned) < MIN_CORRELATION_OBS:
+        return None
+
+    rho: float = aligned["a"].corr(aligned["b"])
+    # corr() returns NaN if std is zero; treat as None (insufficient).
+    if pd.isna(rho):
+        return None
+    return rho
+
+
+# ---------------------------------------------------------------------------
+# Underscore-prefixed aliases (backward-compat for signals.portfolio)
+# ---------------------------------------------------------------------------
+
+#: Alias for :func:`split_currencies` — original name as shipped.
+_split_currencies = split_currencies
+
+#: Alias for :func:`mid_returns` — original name as shipped.
+_mid_returns = mid_returns
+
+#: Alias for :func:`pearson_corr` — original name as shipped.
+_pearson_corr = pearson_corr

--- a/signals/portfolio.py
+++ b/signals/portfolio.py
@@ -39,6 +39,15 @@ from typing import Protocol
 import pandas as pd
 from pydantic import BaseModel, Field
 
+from signals.correlation import (
+    MIN_CORRELATION_OBS as MIN_CORRELATION_OBS,
+    _mid_returns as _mid_returns,
+    _pearson_corr as _pearson_corr,
+    _split_currencies as _split_currencies,
+    mid_returns as mid_returns,
+    pearson_corr as pearson_corr,
+    split_currencies as split_currencies,
+)
 from signals.ranker import Candidate
 
 _log = logging.getLogger(__name__)
@@ -62,12 +71,6 @@ DEFAULT_MAX_CONCURRENT: int = 5
 #: rolling pairwise correlations.  90 days gives a stable estimate while
 #: remaining within a few seconds of load time on a warm SQLite store.
 DEFAULT_LOOKBACK_DAYS: int = 90
-
-#: Minimum number of overlapping non-NaN return observations required to
-#: treat a computed correlation as reliable.  Below this count the
-#: correlation check is skipped (conservative: the pair is NOT dropped on
-#: insufficient data).
-MIN_CORRELATION_OBS: int = 20
 
 # ---------------------------------------------------------------------------
 # Store Protocol (structural — keeps PortfolioLimiter mockable in tests)
@@ -138,33 +141,6 @@ class PortfolioLimiterConfig(BaseModel):
 # ---------------------------------------------------------------------------
 # PortfolioLimiter
 # ---------------------------------------------------------------------------
-
-
-def _split_currencies(instrument: str) -> list[str]:
-    """Split an OANDA instrument string into its leg currencies.
-
-    ``"EUR_USD"`` → ``["EUR", "USD"]``.  Returns all non-empty parts split
-    on ``"_"`` — defensive; never raises.
-    """
-    return [p for p in instrument.split("_") if p]
-
-
-def _mid_returns(df: pd.DataFrame) -> pd.Series:
-    """Compute daily log-returns from bid/ask mid close prices.
-
-    Uses ``(close_bid + close_ask) / 2`` as the mid price and computes
-    ``pct_change()`` (arithmetic return; sufficient for correlation
-    estimation).  Returns a ``pd.Series`` indexed by ``df["time"]``.
-    If the required columns are absent or the DataFrame is too short,
-    returns an empty Series.
-    """
-    required = {"time", "close_bid", "close_ask"}
-    if not required.issubset(df.columns) or len(df) < 2:
-        return pd.Series(dtype="float64")
-    mid = (df["close_bid"] + df["close_ask"]) / 2.0
-    mid.index = pd.Index(df["time"])
-    returns = mid.pct_change().dropna()
-    return returns
 
 
 class PortfolioLimiter:
@@ -341,34 +317,6 @@ class PortfolioLimiter:
         return _mid_returns(df)
 
 
-# ---------------------------------------------------------------------------
-# Internal correlation helper
-# ---------------------------------------------------------------------------
-
-
-def _pearson_corr(a: pd.Series, b: pd.Series) -> float | None:
-    """Compute Pearson ρ between two return series on their shared index.
-
-    Aligns on the index (timestamps), drops NaN pairs, and returns ``None``
-    if fewer than ``MIN_CORRELATION_OBS`` observations are available (the
-    caller treats ``None`` as "insufficient data — do not drop").
-
-    Returns:
-        Pearson ρ in [-1, 1], or ``None`` if data is insufficient.
-    """
-    if a.empty or b.empty:
-        return None
-
-    # Align on shared timestamps.  ``sort=True`` suppresses the Pandas 4
-    # DeprecationWarning about the default sort behaviour when concatenating
-    # DatetimeIndex-backed Series; aligning by sorted index is the correct
-    # semantic here (we want the shared timestamps in order).
-    aligned = pd.concat([a.rename("a"), b.rename("b")], axis=1, sort=True).dropna()
-    if len(aligned) < MIN_CORRELATION_OBS:
-        return None
-
-    rho: float = aligned["a"].corr(aligned["b"])
-    # corr() returns NaN if std is zero; treat as None (insufficient).
-    if pd.isna(rho):
-        return None
-    return rho
+# _pearson_corr, _mid_returns, _split_currencies, and MIN_CORRELATION_OBS are
+# now defined in signals.correlation and imported at the top of this module.
+# They remain accessible from signals.portfolio for backward compatibility.

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,179 @@
+"""Focused unit tests for the extracted signals/correlation.py primitive (P3-T-02).
+
+Tests the correlation helpers directly on signals.correlation (not via the
+portfolio shim) so that the Phase 3 risk-limits module has a green test
+baseline for the shared primitive before it uses it.
+
+These tests are deliberately simple and deterministic — no mocks, no store.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from signals.correlation import (
+    MIN_CORRELATION_OBS,
+    _mid_returns,
+    _pearson_corr,
+    _split_currencies,
+    mid_returns,
+    pearson_corr,
+    split_currencies,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# split_currencies / _split_currencies
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCurrencies:
+    def test_standard_pair(self) -> None:
+        assert split_currencies("EUR_USD") == ["EUR", "USD"]
+
+    def test_xau_usd(self) -> None:
+        assert split_currencies("XAU_USD") == ["XAU", "USD"]
+
+    def test_malformed_no_underscore(self) -> None:
+        result = split_currencies("EURUSD")
+        assert isinstance(result, list)
+
+    def test_empty_string(self) -> None:
+        assert split_currencies("") == []
+
+    def test_underscore_alias_is_same_object(self) -> None:
+        # The underscore alias must be the exact same function.
+        assert _split_currencies is split_currencies
+
+
+# ---------------------------------------------------------------------------
+# mid_returns / _mid_returns
+# ---------------------------------------------------------------------------
+
+
+def _make_candle_df(n: int = MIN_CORRELATION_OBS + 5, seed: int = 0) -> pd.DataFrame:
+    """Build a minimal daily candle DataFrame."""
+    rng = np.random.default_rng(seed)
+    bid = 1.1000 + np.cumsum(rng.normal(0, 0.001, n))
+    ask = bid + 0.0002
+    times = pd.date_range(
+        start=NOW - timedelta(days=n), periods=n, freq="D", tz="UTC"
+    )
+    return pd.DataFrame(
+        {"time": times, "close_bid": bid, "close_ask": ask}
+    )
+
+
+class TestMidReturns:
+    def test_returns_series_correct_length(self) -> None:
+        df = _make_candle_df()
+        result = mid_returns(df)
+        # pct_change() drops one row; all NaN rows for clean data = 1 row dropped.
+        assert len(result) == len(df) - 1
+
+    def test_index_is_subset_of_df_times(self) -> None:
+        df = _make_candle_df()
+        result = mid_returns(df)
+        assert set(result.index).issubset(set(df["time"]))
+
+    def test_empty_df_returns_empty_series(self) -> None:
+        result = mid_returns(pd.DataFrame())
+        assert result.empty
+
+    def test_too_short_returns_empty_series(self) -> None:
+        df = _make_candle_df(n=1)
+        result = mid_returns(df)
+        assert result.empty
+
+    def test_missing_column_returns_empty_series(self) -> None:
+        df = _make_candle_df()
+        result = mid_returns(df.drop(columns=["close_ask"]))
+        assert result.empty
+
+    def test_nan_mid_series_does_not_raise(self) -> None:
+        """NaN close_bid mid-series must not raise (regression guard)."""
+        df = _make_candle_df(n=MIN_CORRELATION_OBS + 10)
+        df.loc[5, "close_bid"] = float("nan")
+        result = mid_returns(df)
+        assert isinstance(result, pd.Series)
+        assert set(result.index).issubset(set(df["time"]))
+
+    def test_underscore_alias_is_same_object(self) -> None:
+        assert _mid_returns is mid_returns
+
+
+# ---------------------------------------------------------------------------
+# pearson_corr / _pearson_corr
+# ---------------------------------------------------------------------------
+
+
+class TestPearsonCorr:
+    def test_returns_none_for_empty_series(self) -> None:
+        assert pearson_corr(pd.Series(dtype="float64"), pd.Series(dtype="float64")) is None
+
+    def test_returns_none_for_insufficient_obs(self) -> None:
+        a = pd.Series([0.01, 0.02], index=[0, 1])
+        b = pd.Series([0.01, 0.02], index=[0, 1])
+        assert pearson_corr(a, b) is None  # < MIN_CORRELATION_OBS
+
+    def test_high_positive_correlation(self) -> None:
+        n = MIN_CORRELATION_OBS + 10
+        idx = list(range(n))
+        a = pd.Series(np.arange(n, dtype=float), index=idx)
+        b = pd.Series(np.arange(n, dtype=float) + 0.001, index=idx)
+        rho = pearson_corr(a, b)
+        assert rho is not None
+        assert rho > 0.99
+
+    def test_high_negative_correlation(self) -> None:
+        n = MIN_CORRELATION_OBS + 10
+        idx = list(range(n))
+        a = pd.Series(np.arange(n, dtype=float), index=idx)
+        b = pd.Series(-np.arange(n, dtype=float), index=idx)
+        rho = pearson_corr(a, b)
+        assert rho is not None
+        assert rho < -0.99
+
+    def test_no_overlap_returns_none(self) -> None:
+        a = pd.Series([0.01] * 30, index=list(range(30)))
+        b = pd.Series([0.01] * 30, index=list(range(100, 130)))
+        assert pearson_corr(a, b) is None
+
+    def test_returns_float_in_range(self) -> None:
+        n = MIN_CORRELATION_OBS + 5
+        idx = list(range(n))
+        a = pd.Series(np.random.default_rng(0).normal(0, 1, n), index=idx)
+        b = pd.Series(np.random.default_rng(1).normal(0, 1, n), index=idx)
+        rho = pearson_corr(a, b)
+        assert rho is not None
+        assert -1.0 <= rho <= 1.0
+
+    def test_constant_series_returns_none(self) -> None:
+        """Zero std → corr() returns NaN → we return None."""
+        n = MIN_CORRELATION_OBS + 5
+        idx = list(range(n))
+        a = pd.Series([1.0] * n, index=idx)
+        b = pd.Series(np.arange(n, dtype=float), index=idx)
+        assert pearson_corr(a, b) is None
+
+    def test_underscore_alias_is_same_object(self) -> None:
+        assert _pearson_corr is pearson_corr
+
+
+# ---------------------------------------------------------------------------
+# MIN_CORRELATION_OBS sanity
+# ---------------------------------------------------------------------------
+
+
+def test_min_correlation_obs_value() -> None:
+    assert MIN_CORRELATION_OBS == 20


### PR DESCRIPTION
## Summary

- Behaviour-preserving extraction of the Pearson correlation helpers from `signals/portfolio.py` into a new shared `signals/correlation.py` module.
- `signals/portfolio.py` re-imports all moved names using explicit `as`-aliases (`from signals.correlation import X as X`) so every existing caller (including `tests/test_portfolio.py`) continues to work without any modification.
- The moved helpers are: `_pearson_corr` / `pearson_corr`, `_mid_returns` / `mid_returns`, `_split_currencies` / `split_currencies`, and the `MIN_CORRELATION_OBS` constant.
- New `tests/test_correlation.py` adds 21 focused unit tests directly against `signals.correlation` — covers empty/short/NaN inputs, index alignment, alias identity, and range checks.

## Verification

- `pytest -q tests/test_portfolio.py` → **35 passed** (unchanged, no edits to test file)
- `pytest -q` (full suite) → **772 passed**
- `mypy .` → **0 errors** (68 source files)

## Test plan

- [x] `pytest tests/test_portfolio.py` — all Phase 2 portfolio tests green unchanged
- [x] `pytest tests/test_correlation.py` — 21 new focused correlation tests green
- [x] `mypy .` — 0 errors
- [x] No changes to ranker.py, charts.py, cli.py, execution/, risk/, or any other module

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)