### PR TITLE
P3-T-04: risk-limits + daily-loss kill switch

### DIFF
--- a/.claude/context/signals.md
+++ b/.claude/context/signals.md
@@ -269,3 +269,61 @@ modified. `CLAUDE.md` trigger-table check: NOT edited (no new dep, no new CLI).
 
 **Merge plan:** `gh pr merge 91 --squash --delete-branch` (lead action after
 reviewer pass).
+
+## P3-T-04 — 2026-05-29 (feat/p3-T-04-limits)
+
+**What was done:**
+- Created `risk/limits.py` — the pure, deterministic **book-level admission gate +
+  daily-loss kill switch** (INV-05 backstop, safety-critical). Like `risk/sizing.py`
+  it can only reject, never green-light. Builds the *bucket-grouping* shape on the
+  shared `signals/correlation.py` primitive (DRIFT-09), distinct from portfolio's
+  per-currency cap.
+- `check_limits(order, *, open_positions, day_pl, equity, start_of_day_equity,
+  config, now, order_risk, returns=None) -> LimitDecision`. Four checks,
+  most-global-first (first breach wins, short-circuits the rest):
+  1. **Kill switch** — `day_pl <= -(daily_loss_cap × start_of_day_equity)` →
+     `kill_switch_active=True`, reject all until next 00:00 UTC (computed from
+     injected `now`, INV-03). `day_pl`/`start_of_day_equity` come from the
+     `account_state` row (DRIFT-02). Non-positive/non-finite SOD-equity is treated
+     as *tripped* (fail-safe — never green-light against an untrustworthy baseline).
+  2. **Max concurrent** — `len(open_positions) >= max_concurrent`.
+  3. **Book risk** — `current_book_risk + order_risk > max_book_risk × equity`.
+     `current_book_risk = Σ position_risk(p)` where
+     `position_risk = |units| × |entry_price − stop_loss_price|` (stop-distance, NOT
+     notional). `order_risk` is the injected `SizingResult.risk_amount` — limits does
+     NOT re-derive it (avoids drift from sizing's own maths).
+  4. **Correlation bucket** — connected-component grouping over
+     `|pearson_corr(ra, rb)| > correlation_threshold`; bucket size >
+     `max_per_correlation_group` rejects. `pearson_corr` returning `None`
+     (insufficient/empty data) creates NO edge (conservative — missing data never
+     forces a grouping, mirrors PortfolioLimiter).
+- `LimitsConfig` (pydantic v2) with APPROVED defaults (D-P3-A/B): `daily_loss_cap=0.01`,
+  `max_concurrent=5`, `max_book_risk=0.01`, `max_per_correlation_group=2`,
+  `correlation_threshold=0.7`. `LimitDecision(allowed, reason, kill_switch_active)`.
+  Read-only `kill_switch_status(...) -> KillSwitchStatus(active, day_pl, cap_amount,
+  reset_at)` — side-effect-free, shares no state with `check_limits`.
+- Exported the new names via `risk/__init__.py` (alongside `sizing`).
+
+**Key patterns / gotchas:**
+- **Purity by injection.** Limits is pure: no store/network/clock. The correlation
+  source is injected as `returns: Mapping[str, pd.Series]` (the shape
+  `signals.correlation.mid_returns` produces) — the CLI/orchestrator loads candles
+  and passes the return map in. This is the bridge between the store-bound
+  `PortfolioLimiter` and the pure book gate. `order_risk` is likewise injected.
+- **Bucketing uses the absolute |ρ|** — a strongly *anti*-correlated pair shares
+  exposure too (a hedge is still one concentrated bet for this cap).
+- Touched ONLY `risk/limits.py`, `risk/__init__.py`, `tests/test_limits.py`. Did NOT
+  edit `sizing.py`, `execution/`, `signals/`, `data/`, `cli.py`.
+
+**AC verification results:**
+- `./.venv/bin/python -m pytest tests/test_limits.py -q` → **27 passed**, exit 0
+- `./.venv/bin/python -m pytest -q` (full suite) → **799 passed, 87 warnings**, exit 0
+  (was 772 before + the new 27)
+- `./.venv/bin/python -m mypy .` (whole repo) → **0 errors, 70 source files**, exit 0
+
+**No new runtime dependencies** (pandas + pydantic + stdlib only). `pyproject.toml`
+NOT modified. `CLAUDE.md` trigger-table check: NOT edited (no new dep, no new CLI,
+no new doc/invariant).
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after
+reviewer pass).

--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -1,9 +1,30 @@
-"""Risk package — per-trade position sizing (P3-T-03).
+"""Risk package — per-trade sizing + book-level limits/kill-switch.
 
-Owns the most safety-critical calculation in Fathom: the 0.25%-of-equity
-per-trade risk cap (INV-05).  See :mod:`risk.sizing`.
+Owns the safety-critical risk gates in Fathom:
+
+* :mod:`risk.sizing` — the 0.25%-of-equity *per-trade* cap (INV-05, P3-T-03).
+* :mod:`risk.limits` — the *book-level* gate + daily-loss kill switch
+  (INV-05 backstop, P3-T-04): exposure caps, correlation-aware shared
+  exposure, and the daily-loss halt.
 """
 
+from risk.limits import (
+    KillSwitchStatus,
+    LimitDecision,
+    LimitsConfig,
+    check_limits,
+    kill_switch_status,
+    position_risk,
+)
 from risk.sizing import SizingResult, size_position
 
-__all__ = ["SizingResult", "size_position"]
+__all__ = [
+    "SizingResult",
+    "size_position",
+    "LimitsConfig",
+    "LimitDecision",
+    "KillSwitchStatus",
+    "check_limits",
+    "kill_switch_status",
+    "position_risk",
+]

--- a/risk/limits.py
+++ b/risk/limits.py
@@ -1,0 +1,453 @@
+"""Book-level risk gate + daily-loss kill switch (P3-T-04).
+
+The deterministic gate that decides whether a freshly-*sized* order is allowed
+onto the book *right now*.  Like sizing (``risk/sizing.py``), it can only
+subtract: every check is a potential reject, never a green light.  It is the
+book-level backstop for **INV-05** — where ``sizing`` caps a *single* trade at
+0.25% of equity, this module caps the *aggregate* book and halts all new entries
+once the day's loss crosses a threshold.
+
+Four checks, evaluated most-global-first (the first breach wins; later checks are
+short-circuited):
+
+1. **Daily-loss kill switch.**  ``day_pl <= -(daily_loss_cap ×
+   start_of_day_equity)`` → reject every order with ``kill_switch_active=True``
+   until the next 00:00 UTC boundary.  ``day_pl`` is today's total P&L vs
+   start-of-day equity (already negative on a loss — see ``data.store`` /
+   DRIFT-02), read from the ``account_state`` row by the caller and injected
+   here.  The reset boundary is computed from the injected ``now`` (INV-03);
+   reconciliation zeroes ``day_pl`` at the new UTC day, so a fresh-day call
+   naturally observes an inactive switch.
+2. **Max concurrent.**  ``len(open_positions) >= max_concurrent`` → reject.
+3. **Book risk.**  ``current_book_risk + order_risk > max_book_risk × equity``
+   → reject.  ``current_book_risk`` is summed from each open position's
+   **stop-distance risk** (``|units| × |entry_price − stop_loss_price|``), never
+   notional.  ``order_risk`` is the prospective order's risk amount in account
+   currency — the ``SizingResult.risk_amount`` already computed by sizing,
+   injected here (this module does not re-derive it).
+4. **Correlation bucket.**  Group the prospective order + open positions into
+   correlation buckets (two instruments share a bucket when
+   ``|pearson_corr| > correlation_threshold``, computed via the shared
+   ``signals/correlation.py`` primitive over injected return Series).  If the
+   order's bucket would then hold more than ``max_per_correlation_group``
+   distinct instruments, reject — correlated pairs count as one bet.
+
+Purity (AC): all state is injected — ``open_positions``, ``day_pl``, ``equity``,
+``start_of_day_equity``, ``now``, ``order_risk``, and the correlation ``returns``
+map.  No DB, no network, no clock beyond the injected ``now`` (INV-03).  The
+function never raises on adversarial inputs; it rejects with a reason, so the
+execution path always gets a definite, safe answer.
+
+DRIFT-09: ``max_per_correlation_group`` (a *bucket-size* / shared-exposure cap)
+is a distinct concept from the portfolio limiter's ``max_per_currency`` (a
+per-leg-currency cap).  Both build on the same ``signals/correlation.py``
+primitive but group differently.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, time, timedelta, timezone
+from typing import Mapping, Optional, Sequence
+
+import pandas as pd
+from pydantic import BaseModel, Field
+
+from execution.models import Order, Position
+from signals.correlation import pearson_corr, split_currencies as split_currencies
+
+__all__ = [
+    "LimitsConfig",
+    "LimitDecision",
+    "KillSwitchStatus",
+    "DEFAULT_DAILY_LOSS_CAP",
+    "DEFAULT_MAX_CONCURRENT",
+    "DEFAULT_MAX_BOOK_RISK",
+    "DEFAULT_MAX_PER_CORRELATION_GROUP",
+    "DEFAULT_CORRELATION_THRESHOLD",
+    "position_risk",
+    "check_limits",
+    "kill_switch_status",
+]
+
+# ---------------------------------------------------------------------------
+# Approved config defaults (D-P3-A / D-P3-B)
+# ---------------------------------------------------------------------------
+
+#: Daily cumulative loss cap as a fraction of start-of-day equity (1.0%).
+#: ~4 max-loss trades at the 0.25% per-trade cap.  Crossing this halts all new
+#: entries until 00:00 UTC.  Operator-overridable via :class:`LimitsConfig`.
+DEFAULT_DAILY_LOSS_CAP: float = 0.01
+
+#: Max simultaneously-open positions allowed on the book.
+DEFAULT_MAX_CONCURRENT: int = 5
+
+#: Max aggregate book risk as a fraction of equity (1.0%) — the sum of every
+#: open position's stop-distance risk plus the prospective order's risk.
+DEFAULT_MAX_BOOK_RISK: float = 0.01
+
+#: Max distinct instruments allowed inside a single correlation bucket (shared
+#: exposure).  Correlated pairs count as one bet; this caps how many we stack.
+DEFAULT_MAX_PER_CORRELATION_GROUP: int = 2
+
+#: Absolute Pearson |ρ| above which two instruments share a correlation bucket.
+DEFAULT_CORRELATION_THRESHOLD: float = 0.7
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+class LimitsConfig(BaseModel):
+    """Tunable, explicit, documented book-level limits (D-P3-A / D-P3-B).
+
+    Every field carries the approved Phase-3 default; a caller may override any
+    subset.  All four are *caps* — raising one can only ever allow more, never
+    weaken the INV-05 per-trade guarantee owned by ``risk/sizing.py``.
+
+    Attributes:
+        daily_loss_cap: fraction of start-of-day equity; ``day_pl`` at/below
+            ``-(daily_loss_cap × start_of_day_equity)`` trips the kill switch.
+        max_concurrent: max simultaneously-open positions.
+        max_book_risk: fraction of equity; aggregate stop-distance risk
+            (open + prospective) may not exceed ``max_book_risk × equity``.
+        max_per_correlation_group: max distinct instruments per correlation
+            bucket (shared exposure).
+        correlation_threshold: absolute Pearson |ρ| above which two instruments
+            share a bucket (0–1).
+    """
+
+    daily_loss_cap: float = Field(
+        default=DEFAULT_DAILY_LOSS_CAP,
+        gt=0.0,
+        le=1.0,
+        description="Daily-loss kill-switch threshold as a fraction of "
+        "start-of-day equity (default 0.01 = 1.0%).",
+    )
+    max_concurrent: int = Field(
+        default=DEFAULT_MAX_CONCURRENT,
+        ge=1,
+        description="Max simultaneously-open positions (default 5).",
+    )
+    max_book_risk: float = Field(
+        default=DEFAULT_MAX_BOOK_RISK,
+        gt=0.0,
+        le=1.0,
+        description="Max aggregate book risk as a fraction of equity "
+        "(default 0.01 = 1.0%).",
+    )
+    max_per_correlation_group: int = Field(
+        default=DEFAULT_MAX_PER_CORRELATION_GROUP,
+        ge=1,
+        description="Max distinct instruments per correlation bucket "
+        "(default 2).",
+    )
+    correlation_threshold: float = Field(
+        default=DEFAULT_CORRELATION_THRESHOLD,
+        ge=0.0,
+        le=1.0,
+        description="Absolute Pearson |ρ| bucket threshold (default 0.7).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result models
+# ---------------------------------------------------------------------------
+
+
+class LimitDecision(BaseModel):
+    """The outcome of a book-level admission check.
+
+    Fields:
+        allowed: ``True`` iff the order passes every check.  ``False`` means
+            rejected — never place the order.
+        reason: human-readable rejection reason, set iff ``allowed is False``;
+            ``None`` on an allowed order.
+        kill_switch_active: ``True`` iff the daily-loss kill switch is currently
+            tripped.  When ``True``, ``allowed`` is always ``False``.
+    """
+
+    allowed: bool
+    reason: Optional[str] = None
+    kill_switch_active: bool = False
+
+
+class KillSwitchStatus(BaseModel):
+    """Read-only snapshot of the daily-loss kill switch (no side effects).
+
+    Fields:
+        active: ``True`` iff ``day_pl`` is at/below the loss cap.
+        day_pl: today's P&L vs start-of-day equity (negative on a loss), as
+            supplied.
+        cap_amount: the loss amount that trips the switch, a positive number
+            (``daily_loss_cap × start_of_day_equity``); the switch is active
+            when ``day_pl <= -cap_amount``.
+        reset_at: the next 00:00 UTC boundary after ``now`` (RFC-3339 via
+            pydantic's UTC-aware datetime); reconciliation zeroes ``day_pl`` at
+            this boundary so a later call sees the switch reset (INV-03).
+    """
+
+    active: bool
+    day_pl: float
+    cap_amount: float
+    reset_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def position_risk(position: Position) -> float:
+    """Stop-distance risk of an open position in account-price terms.
+
+    ``|units| × |entry_price − stop_loss_price|`` — the money lost if the stop
+    is hit, **not** notional exposure.  This is the per-position term summed
+    into ``current_book_risk``.  Defensive: a non-finite result yields ``0.0``
+    rather than poisoning the sum (the position model already enforces positive
+    prices and signed-non-zero units, so this is only reachable via float
+    pathology).
+    """
+    risk = abs(position.units) * abs(position.entry_price - position.stop_loss_price)
+    if not math.isfinite(risk) or risk < 0:
+        return 0.0
+    return risk
+
+
+def _next_utc_midnight(now: datetime) -> datetime:
+    """The next 00:00:00 UTC boundary strictly after ``now`` (INV-03).
+
+    The kill switch resets at this boundary (reconciliation zeroes ``day_pl``).
+    ``now`` is normalised to UTC first so a non-UTC-aware caller still gets a
+    correct boundary; a naive ``now`` is treated as UTC.
+    """
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
+    next_day = (now + timedelta(days=1)).date()
+    return datetime.combine(next_day, time.min, tzinfo=timezone.utc)
+
+
+def _kill_switch_tripped(
+    day_pl: float, start_of_day_equity: float, daily_loss_cap: float
+) -> tuple[bool, float]:
+    """Return ``(active, cap_amount)`` for the daily-loss kill switch.
+
+    ``cap_amount`` is the positive loss threshold
+    ``daily_loss_cap × start_of_day_equity``; the switch is active when
+    ``day_pl <= -cap_amount`` (``day_pl`` is already negative on a loss).
+    Non-finite or non-positive ``start_of_day_equity`` is treated defensively as
+    *tripped* (cap_amount 0.0) — we never green-light when we cannot trust the
+    equity baseline.
+    """
+    if not math.isfinite(start_of_day_equity) or start_of_day_equity <= 0:
+        return True, 0.0
+    if not math.isfinite(day_pl):
+        return True, 0.0
+    cap_amount = daily_loss_cap * start_of_day_equity
+    return (day_pl <= -cap_amount), cap_amount
+
+
+def _correlation_bucket_instruments(
+    target: str,
+    others: Sequence[str],
+    returns: Mapping[str, pd.Series],
+    threshold: float,
+) -> set[str]:
+    """Instruments transitively correlated with ``target`` (its bucket).
+
+    Builds the connected component containing ``target`` over the graph whose
+    edges are instrument pairs with ``|pearson_corr| > threshold`` (computed via
+    the shared ``signals/correlation.py`` primitive on the injected return
+    Series).  ``pearson_corr`` returns ``None`` on insufficient/empty data — we
+    do **not** create an edge in that case (conservative: missing data never
+    *forces* a grouping, mirroring the portfolio limiter).
+
+    The returned set always contains ``target`` itself.
+    """
+    universe = [target, *others]
+    # Deduplicate while preserving order; a bucket is over *distinct* instruments.
+    seen: dict[str, None] = {}
+    for instr in universe:
+        seen.setdefault(instr, None)
+    distinct = list(seen.keys())
+
+    def correlated(a: str, b: str) -> bool:
+        if a == b:
+            return True
+        ra = returns.get(a)
+        rb = returns.get(b)
+        if ra is None or rb is None:
+            return False
+        rho = pearson_corr(ra, rb)
+        if rho is None:
+            return False
+        return abs(rho) > threshold
+
+    # BFS connected component from ``target``.
+    bucket: set[str] = {target}
+    frontier = [target]
+    while frontier:
+        current = frontier.pop()
+        for other in distinct:
+            if other in bucket:
+                continue
+            if correlated(current, other):
+                bucket.add(other)
+                frontier.append(other)
+    return bucket
+
+
+def _allow() -> LimitDecision:
+    return LimitDecision(allowed=True, reason=None, kill_switch_active=False)
+
+
+def _reject(reason: str, *, kill_switch_active: bool = False) -> LimitDecision:
+    return LimitDecision(
+        allowed=False, reason=reason, kill_switch_active=kill_switch_active
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_limits(
+    order: Order,
+    *,
+    open_positions: Sequence[Position],
+    day_pl: float,
+    equity: float,
+    start_of_day_equity: float,
+    config: LimitsConfig,
+    now: datetime,
+    order_risk: float,
+    returns: Optional[Mapping[str, pd.Series]] = None,
+) -> LimitDecision:
+    """Decide whether ``order`` may go onto the book right now.
+
+    Pure and deterministic — every piece of state is injected (no DB, no
+    network, no clock beyond ``now``).  The four checks are evaluated
+    most-global-first; the first breach wins and short-circuits the rest.
+
+    Args:
+        order: the freshly-sized, fully-bracketed prospective order.  Read-only;
+            only ``instrument`` and ``units`` are consulted (sizing/brackets are
+            upstream concerns).
+        open_positions: positions the store believes are currently open.  Each
+            contributes ``position_risk`` (stop-distance, not notional) to the
+            book-risk sum and an instrument to the correlation buckets.
+        day_pl: today's P&L vs start-of-day equity (negative on a loss) from the
+            ``account_state`` row (DRIFT-02).
+        equity: current account equity in account currency; the book-risk cap is
+            a fraction of this.  Non-finite/non-positive → reject (we never
+            green-light against an untrustworthy equity).
+        start_of_day_equity: the snapshotted start-of-day equity from
+            ``account_state`` — the kill-switch baseline.
+        config: the book-level caps (approved defaults in :class:`LimitsConfig`).
+        now: UTC-aware current time; used only to compute the kill-switch reset
+            boundary for reporting (INV-03).  Never an internal ``datetime.now``.
+        order_risk: the prospective order's risk amount in account currency
+            (the ``SizingResult.risk_amount`` already computed by sizing).  Must
+            be finite and >= 0; this module does not re-derive it.
+        returns: optional ``instrument → daily-return Series`` map for the
+            correlation buckets (same shape ``signals.correlation.mid_returns``
+            produces).  When ``None`` or sparse, instruments lacking a usable
+            pair are treated as uncorrelated (conservative).
+
+    Returns:
+        A :class:`LimitDecision`.  ``allowed`` is ``True`` only when every check
+        passes; otherwise ``reason`` explains the breach and, for the daily-loss
+        case, ``kill_switch_active`` is ``True``.
+    """
+    cfg = config
+
+    # --- 1. Daily-loss kill switch (most global; halts everything). ---------
+    tripped, cap_amount = _kill_switch_tripped(
+        day_pl, start_of_day_equity, cfg.daily_loss_cap
+    )
+    if tripped:
+        reset_at = _next_utc_midnight(now)
+        return _reject(
+            f"Daily-loss kill switch active: day_pl={day_pl:.6g} <= "
+            f"-{cap_amount:.6g} ({cfg.daily_loss_cap:.4g} × start-of-day equity "
+            f"{start_of_day_equity:.6g}). No new entries until {reset_at.isoformat()}.",
+            kill_switch_active=True,
+        )
+
+    # --- Guard equity before any fraction-of-equity comparison. -------------
+    if not math.isfinite(equity) or equity <= 0:
+        return _reject(
+            f"equity must be finite and > 0 to evaluate book-risk, got {equity!r}."
+        )
+    if not math.isfinite(order_risk) or order_risk < 0:
+        return _reject(
+            f"order_risk must be finite and >= 0, got {order_risk!r}."
+        )
+
+    # --- 2. Max concurrent. -------------------------------------------------
+    n_open = len(open_positions)
+    if n_open >= cfg.max_concurrent:
+        return _reject(
+            f"Max concurrent positions reached: {n_open} open >= "
+            f"max_concurrent={cfg.max_concurrent}."
+        )
+
+    # --- 3. Book risk (stop-distance risk, not notional). -------------------
+    current_book_risk = sum(position_risk(p) for p in open_positions)
+    book_risk_budget = cfg.max_book_risk * equity
+    if current_book_risk + order_risk > book_risk_budget:
+        return _reject(
+            f"Book-risk cap exceeded: current {current_book_risk:.6g} + order "
+            f"{order_risk:.6g} = {current_book_risk + order_risk:.6g} > "
+            f"{cfg.max_book_risk:.4g} × equity {equity:.6g} = "
+            f"{book_risk_budget:.6g}."
+        )
+
+    # --- 4. Correlation bucket (shared exposure). ---------------------------
+    ret_map: Mapping[str, pd.Series] = returns if returns is not None else {}
+    open_instruments = [p.instrument for p in open_positions]
+    bucket = _correlation_bucket_instruments(
+        order.instrument, open_instruments, ret_map, cfg.correlation_threshold
+    )
+    if len(bucket) > cfg.max_per_correlation_group:
+        peers = sorted(bucket - {order.instrument})
+        return _reject(
+            f"Correlation-group cap exceeded: adding {order.instrument} makes a "
+            f"bucket of {len(bucket)} correlated instruments "
+            f"({', '.join(sorted(bucket))}) > max_per_correlation_group="
+            f"{cfg.max_per_correlation_group} (|ρ| > {cfg.correlation_threshold:.4g} "
+            f"with {', '.join(peers) if peers else 'open book'})."
+        )
+
+    # --- All checks passed: the gate permits the order onto the book. -------
+    return _allow()
+
+
+def kill_switch_status(
+    *,
+    day_pl: float,
+    start_of_day_equity: float,
+    config: LimitsConfig,
+    now: datetime,
+) -> KillSwitchStatus:
+    """Read-only kill-switch snapshot for the CLI/monitor (no side effects).
+
+    Reports whether the daily-loss kill switch is currently tripped, the figure
+    that triggered it (``day_pl`` and the positive ``cap_amount``), and the next
+    00:00 UTC reset boundary computed from ``now`` (INV-03).  Pure: identical
+    inputs always yield an identical status; it mutates nothing and shares no
+    state with :func:`check_limits`.
+    """
+    tripped, cap_amount = _kill_switch_tripped(
+        day_pl, start_of_day_equity, config.daily_loss_cap
+    )
+    return KillSwitchStatus(
+        active=tripped,
+        day_pl=day_pl,
+        cap_amount=cap_amount,
+        reset_at=_next_utc_midnight(now),
+    )

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,453 @@
+"""Tests for ``risk.limits`` — the book-level gate + daily-loss kill switch (P3-T-04).
+
+Covers all four checks (kill switch, max-concurrent, book-risk stop-distance,
+correlation bucket), the 00:00 UTC reset boundary (INV-03), every-reject-has-a-
+reason, the side-effect-free ``kill_switch_status``, and purity (identical
+injected state → identical decision).  No DB, no network, no clock — every
+input is injected.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from execution.models import EntryType, Order, Position
+from risk.limits import (
+    DEFAULT_DAILY_LOSS_CAP,
+    DEFAULT_MAX_BOOK_RISK,
+    DEFAULT_MAX_CONCURRENT,
+    DEFAULT_MAX_PER_CORRELATION_GROUP,
+    LimitDecision,
+    LimitsConfig,
+    check_limits,
+    kill_switch_status,
+    position_risk,
+)
+from strategies.base import Direction
+
+# ---------------------------------------------------------------------------
+# Constants / factories
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+NEXT_MIDNIGHT = datetime(2026, 5, 30, 0, 0, 0, tzinfo=timezone.utc)
+
+EQUITY = 100_000.0
+SOD_EQUITY = 100_000.0
+
+
+def _order(*, instrument: str = "EUR_USD", direction: Direction = Direction.LONG) -> Order:
+    units = 1000 if direction is Direction.LONG else -1000
+    if direction is Direction.LONG:
+        stop, target = 1.0950, 1.1100
+    else:
+        stop, target = 1.1050, 1.0900
+    return Order(
+        client_order_id="a" * 32,
+        instrument=instrument,
+        direction=direction,
+        units=units,
+        entry_type=EntryType.MARKET,
+        stop_loss_price=stop,
+        take_profit_price=target,
+        candidate_ref=f"{instrument}:H1:macrossover_10_50",
+        created_at=NOW,
+    )
+
+
+def _position(
+    *,
+    instrument: str = "GBP_USD",
+    trade_id: str = "T1",
+    units: int = 1000,
+    entry_price: float = 1.2500,
+    stop_loss_price: float = 1.2450,
+    take_profit_price: float = 1.2600,
+) -> Position:
+    return Position(
+        broker_trade_id=trade_id,
+        instrument=instrument,
+        units=units,
+        entry_price=entry_price,
+        stop_loss_price=stop_loss_price,
+        take_profit_price=take_profit_price,
+        opened_at=NOW,
+        unrealized_pl=0.0,
+        candidate_ref=f"{instrument}:H1:macrossover_10_50",
+    )
+
+
+def _returns(values: list[float]) -> pd.Series:
+    """Build a daily-return Series (integer index suffices for pearson_corr)."""
+    return pd.Series(values, index=list(range(len(values))), dtype="float64")
+
+
+def _check(
+    order: Order,
+    *,
+    open_positions: list[Position] | None = None,
+    day_pl: float = 0.0,
+    equity: float = EQUITY,
+    start_of_day_equity: float = SOD_EQUITY,
+    config: LimitsConfig | None = None,
+    now: datetime = NOW,
+    order_risk: float = 50.0,
+    returns: dict[str, pd.Series] | None = None,
+) -> LimitDecision:
+    return check_limits(
+        order,
+        open_positions=open_positions or [],
+        day_pl=day_pl,
+        equity=equity,
+        start_of_day_equity=start_of_day_equity,
+        config=config or LimitsConfig(),
+        now=now,
+        order_risk=order_risk,
+        returns=returns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config defaults are explicit and documented (AC).
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDefaults:
+    def test_approved_defaults(self) -> None:
+        cfg = LimitsConfig()
+        assert cfg.daily_loss_cap == 0.01 == DEFAULT_DAILY_LOSS_CAP
+        assert cfg.max_concurrent == 5 == DEFAULT_MAX_CONCURRENT
+        assert cfg.max_book_risk == 0.01 == DEFAULT_MAX_BOOK_RISK
+        assert cfg.max_per_correlation_group == 2 == DEFAULT_MAX_PER_CORRELATION_GROUP
+        assert cfg.correlation_threshold == 0.7
+
+    def test_caps_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            LimitsConfig(daily_loss_cap=0.0)
+        with pytest.raises(ValueError):
+            LimitsConfig(max_concurrent=0)
+        with pytest.raises(ValueError):
+            LimitsConfig(max_book_risk=0.0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Daily-loss kill switch + 00:00 UTC reset (INV-03).
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    def test_below_cap_allowed(self) -> None:
+        # Loss of 0.5% — below the 1.0% cap.
+        decision = _check(_order(), day_pl=-500.0)
+        assert decision.allowed is True
+        assert decision.kill_switch_active is False
+        assert decision.reason is None
+
+    def test_at_cap_trips(self) -> None:
+        # Exactly -(0.01 * 100_000) = -1000.0 → at the cap → tripped.
+        decision = _check(_order(), day_pl=-1000.0)
+        assert decision.allowed is False
+        assert decision.kill_switch_active is True
+        assert decision.reason is not None
+
+    def test_over_cap_trips(self) -> None:
+        decision = _check(_order(), day_pl=-1500.0)
+        assert decision.allowed is False
+        assert decision.kill_switch_active is True
+
+    def test_kill_switch_rejects_even_a_clean_order(self) -> None:
+        # Empty book, tiny risk, uncorrelated — only the kill switch can reject.
+        decision = _check(
+            _order(), open_positions=[], day_pl=-2000.0, order_risk=1.0
+        )
+        assert decision.allowed is False
+        assert decision.kill_switch_active is True
+
+    def test_reset_boundary_is_next_utc_midnight(self) -> None:
+        status = kill_switch_status(
+            day_pl=-2000.0,
+            start_of_day_equity=SOD_EQUITY,
+            config=LimitsConfig(),
+            now=NOW,
+        )
+        assert status.active is True
+        assert status.reset_at == NEXT_MIDNIGHT
+        assert status.reset_at.tzinfo is not None
+        # 00:00:00 UTC pinned (INV-03).
+        assert status.reset_at.hour == 0
+        assert status.reset_at.minute == 0
+        assert status.reset_at.second == 0
+
+    def test_fresh_utc_day_resets_via_zeroed_day_pl(self) -> None:
+        # Reconciliation zeroes day_pl at the new UTC day; the switch is then off.
+        fresh = datetime(2026, 5, 30, 0, 0, 1, tzinfo=timezone.utc)
+        decision = _check(_order(), day_pl=0.0, now=fresh)
+        assert decision.allowed is True
+        assert decision.kill_switch_active is False
+
+    def test_non_positive_sod_equity_is_treated_as_tripped(self) -> None:
+        decision = _check(_order(), start_of_day_equity=0.0, day_pl=0.0)
+        assert decision.allowed is False
+        assert decision.kill_switch_active is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Max-concurrent boundary.
+# ---------------------------------------------------------------------------
+
+
+class TestMaxConcurrent:
+    def test_at_cap_rejected(self) -> None:
+        positions = [
+            _position(trade_id=f"T{i}", instrument="GBP_USD") for i in range(5)
+        ]
+        decision = _check(_order(), open_positions=positions)
+        assert decision.allowed is False
+        assert decision.kill_switch_active is False
+        assert decision.reason is not None and "concurrent" in decision.reason.lower()
+
+    def test_one_below_cap_allowed(self) -> None:
+        # 4 open with negligible risk, uncorrelated returns → allowed.
+        positions = [
+            _position(
+                trade_id=f"T{i}",
+                instrument=f"X{i}_USD",
+                entry_price=1.0,
+                stop_loss_price=0.99999,
+            )
+            for i in range(4)
+        ]
+        decision = _check(_order(), open_positions=positions, order_risk=1.0)
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Book-risk boundary (stop-distance risk, not notional).
+# ---------------------------------------------------------------------------
+
+
+class TestBookRisk:
+    def test_position_risk_is_stop_distance_not_notional(self) -> None:
+        p = _position(units=1000, entry_price=1.2500, stop_loss_price=1.2450)
+        # |1000| * |1.2500 - 1.2450| = 1000 * 0.0050 = 5.0  (NOT 1250 notional).
+        assert position_risk(p) == pytest.approx(5.0)
+
+    def test_at_budget_allowed(self) -> None:
+        # Budget = 0.01 * 100_000 = 1000.0.  One position risking 950 + order 50.
+        p = _position(units=1, entry_price=1000.0, stop_loss_price=50.0)  # risk 950
+        assert position_risk(p) == pytest.approx(950.0)
+        decision = _check(_order(), open_positions=[p], order_risk=50.0)
+        assert decision.allowed is True
+
+    def test_over_budget_rejected(self) -> None:
+        # 950 current + 51 order = 1001 > 1000 budget.
+        p = _position(units=1, entry_price=1000.0, stop_loss_price=50.0)  # risk 950
+        decision = _check(_order(), open_positions=[p], order_risk=51.0)
+        assert decision.allowed is False
+        assert decision.kill_switch_active is False
+        assert decision.reason is not None and "book-risk" in decision.reason.lower()
+
+    def test_book_risk_sums_across_positions(self) -> None:
+        positions = [
+            _position(trade_id="A", units=1, entry_price=1000.0, stop_loss_price=500.0),  # 500
+            _position(trade_id="B", units=1, entry_price=1000.0, stop_loss_price=500.0),  # 500
+        ]
+        # 1000 current + 1 order = 1001 > 1000 budget.
+        decision = _check(_order(), open_positions=positions, order_risk=1.0)
+        assert decision.allowed is False
+        assert decision.reason is not None and "book-risk" in decision.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Correlation bucket: 2 correlated allowed, 3rd rejected, uncorrelated ok.
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationBucket:
+    def _correlated_returns(self) -> dict[str, pd.Series]:
+        n = 40
+        base = np.arange(n, dtype=float)  # monotonic → ρ ≈ +1 between the three
+        rng = np.random.default_rng(0)
+        return {
+            "EUR_USD": _returns(list(base + rng.normal(0, 1e-9, n))),
+            "GBP_USD": _returns(list(base + rng.normal(0, 1e-9, n))),
+            "AUD_USD": _returns(list(base + rng.normal(0, 1e-9, n))),
+            # Anti-correlated / orthogonal instrument.
+            "USD_JPY": _returns(list(-base + rng.normal(0, 1e-9, n))),
+        }
+
+    def test_two_correlated_allowed(self) -> None:
+        # One correlated open position + the order = bucket of 2 == cap (allowed).
+        returns = self._correlated_returns()
+        p = _position(instrument="GBP_USD")
+        decision = _check(
+            _order(instrument="EUR_USD"),
+            open_positions=[p],
+            returns=returns,
+            order_risk=1.0,
+        )
+        assert decision.allowed is True
+
+    def test_third_correlated_rejected(self) -> None:
+        # Two correlated open + a third correlated order = bucket of 3 > cap.
+        returns = self._correlated_returns()
+        positions = [
+            _position(instrument="GBP_USD", trade_id="G"),
+            _position(instrument="AUD_USD", trade_id="A"),
+        ]
+        decision = _check(
+            _order(instrument="EUR_USD"),
+            open_positions=positions,
+            returns=returns,
+            order_risk=1.0,
+        )
+        assert decision.allowed is False
+        assert decision.kill_switch_active is False
+        assert decision.reason is not None and "correlation" in decision.reason.lower()
+
+    def test_uncorrelated_via_no_returns_allowed(self) -> None:
+        # No returns supplied → no edges → each instrument is its own bucket.
+        positions = [
+            _position(instrument="GBP_USD", trade_id="G"),
+            _position(instrument="AUD_USD", trade_id="A"),
+        ]
+        decision = _check(
+            _order(instrument="EUR_USD"),
+            open_positions=positions,
+            returns=None,
+            order_risk=1.0,
+        )
+        assert decision.allowed is True
+
+    def test_anti_correlated_groups_under_abs_rho(self) -> None:
+        # |ρ| (absolute) is what buckets — a strongly anti-correlated pair shares
+        # exposure too.  Two anti-correlated opens + correlated order > cap.
+        returns = self._correlated_returns()
+        positions = [
+            _position(instrument="EUR_USD", trade_id="E"),  # +base
+            _position(instrument="USD_JPY", trade_id="J"),  # -base, |ρ|≈1
+        ]
+        decision = _check(
+            _order(instrument="GBP_USD"),  # +base
+            open_positions=positions,
+            returns=returns,
+            order_risk=1.0,
+        )
+        assert decision.allowed is False
+        assert decision.reason is not None and "correlation" in decision.reason.lower()
+
+    def test_genuinely_uncorrelated_instrument_allowed(self) -> None:
+        # Two correlated opens + an order whose returns are noise (ρ < 0.7).
+        n = 40
+        base = np.arange(n, dtype=float)
+        noise = np.random.default_rng(7).normal(0, 1, n)
+        returns = {
+            "EUR_USD": _returns(list(base)),
+            "GBP_USD": _returns(list(base)),
+            "NZD_CAD": _returns(list(noise)),
+        }
+        positions = [
+            _position(instrument="EUR_USD", trade_id="E"),
+            _position(instrument="GBP_USD", trade_id="G"),
+        ]
+        decision = _check(
+            _order(instrument="NZD_CAD"),
+            open_positions=positions,
+            returns=returns,
+            order_risk=1.0,
+        )
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Every reject carries a reason; check ordering is most-global-first.
+# ---------------------------------------------------------------------------
+
+
+class TestRejectReasonsAndOrdering:
+    def test_every_reject_has_a_reason(self) -> None:
+        # Kill switch.
+        d1 = _check(_order(), day_pl=-2000.0)
+        # Max concurrent.
+        d2 = _check(
+            _order(),
+            open_positions=[_position(trade_id=f"T{i}") for i in range(5)],
+        )
+        # Book risk.
+        p = _position(units=1, entry_price=1000.0, stop_loss_price=50.0)
+        d3 = _check(_order(), open_positions=[p], order_risk=100.0)
+        for d in (d1, d2, d3):
+            assert d.allowed is False
+            assert d.reason is not None and d.reason != ""
+
+    def test_kill_switch_takes_precedence_over_other_breaches(self) -> None:
+        # Both kill switch AND max-concurrent breached: kill switch wins.
+        positions = [_position(trade_id=f"T{i}") for i in range(5)]
+        decision = _check(_order(), open_positions=positions, day_pl=-2000.0)
+        assert decision.kill_switch_active is True
+        assert decision.reason is not None and "kill switch" in decision.reason.lower()
+
+    def test_non_positive_equity_rejected(self) -> None:
+        decision = _check(_order(), equity=0.0)
+        assert decision.allowed is False
+        assert decision.reason is not None
+
+
+# ---------------------------------------------------------------------------
+# kill_switch_status is read-only / side-effect-free and pure.
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitchStatus:
+    def test_reports_inactive_with_figures(self) -> None:
+        status = kill_switch_status(
+            day_pl=-500.0,
+            start_of_day_equity=SOD_EQUITY,
+            config=LimitsConfig(),
+            now=NOW,
+        )
+        assert status.active is False
+        assert status.day_pl == -500.0
+        assert status.cap_amount == pytest.approx(1000.0)
+        assert status.reset_at == NEXT_MIDNIGHT
+
+    def test_side_effect_free_idempotent(self) -> None:
+        kwargs = dict(
+            day_pl=-1200.0,
+            start_of_day_equity=SOD_EQUITY,
+            config=LimitsConfig(),
+            now=NOW,
+        )
+        s1 = kill_switch_status(**kwargs)  # type: ignore[arg-type]
+        s2 = kill_switch_status(**kwargs)  # type: ignore[arg-type]
+        assert s1 == s2
+        assert s1.active is True
+
+
+# ---------------------------------------------------------------------------
+# Purity: identical injected state → identical decision; inputs not mutated.
+# ---------------------------------------------------------------------------
+
+
+class TestPurity:
+    def test_deterministic(self) -> None:
+        order = _order()
+        positions = [_position(trade_id="P1"), _position(trade_id="P2", instrument="AUD_USD")]
+        returns = {"EUR_USD": _returns(list(np.arange(40.0)))}
+        d1 = _check(order, open_positions=positions, returns=returns, order_risk=10.0)
+        d2 = _check(order, open_positions=positions, returns=returns, order_risk=10.0)
+        assert d1 == d2
+
+    def test_does_not_mutate_inputs(self) -> None:
+        order = _order()
+        positions = [_position(trade_id="P1")]
+        n_before = len(positions)
+        returns = {"EUR_USD": _returns(list(np.arange(40.0)))}
+        keys_before = set(returns.keys())
+        _check(order, open_positions=positions, returns=returns)
+        assert len(positions) == n_before
+        assert set(returns.keys()) == keys_before


### PR DESCRIPTION
Adds `risk/limits.py` — the pure, deterministic **book-level admission gate + daily-loss kill switch** (INV-05 backstop, safety-critical). Like sizing, it can only reject, never green-light. All state is injected — no DB/network/clock beyond the injected `now`.

## The four checks (most-global-first; first breach wins)
1. **Daily-loss kill switch** — `day_pl <= -(daily_loss_cap × start_of_day_equity)` trips `kill_switch_active=True` and rejects all new entries until the next **00:00 UTC** boundary computed from the injected `now` (INV-03). `day_pl` / `start_of_day_equity` come from the `account_state` row (DRIFT-02); `day_pl` is already negative on a loss. A non-positive/non-finite start-of-day equity is treated as *tripped* (fail-safe).
2. **Max concurrent** — `len(open_positions) >= max_concurrent` rejects.
3. **Book risk** — `current_book_risk + order_risk > max_book_risk × equity` rejects. `current_book_risk` sums each open position's **stop-distance risk** (`|units| × |entry_price − stop_loss_price|`), not notional. `order_risk` is the injected `SizingResult.risk_amount` (limits does not re-derive it).
4. **Correlation bucket** — groups prospective + open instruments into connected components over `|pearson_corr| > correlation_threshold` (via the shared `signals/correlation.py` primitive, DRIFT-09); a bucket exceeding `max_per_correlation_group` rejects. Missing/insufficient return data creates no edge (conservative). `max_per_correlation_group` is a distinct concept from portfolio's `max_per_currency`.

## Approved config defaults (D-P3-A / D-P3-B)
`daily_loss_cap=0.01` (1.0% SOD equity) · `max_concurrent=5` · `max_book_risk=0.01` (1.0%) · `max_per_correlation_group=2` · `correlation_threshold=0.7`. Explicit + documented in `LimitsConfig`.

Also: `LimitDecision(allowed, reason, kill_switch_active)`, read-only side-effect-free `kill_switch_status(...)`, exported via `risk/__init__.py`.

## INV-05 compliance
Book-level backstop to the per-trade 0.25% cap: caps aggregate book risk and halts all new entries on the daily-loss threshold. Every cap can only ever *allow more* when raised — it never weakens the per-trade guarantee owned by `risk/sizing.py`. Like sizing, every path can only reject; there is no green-light branch.

## Verification
- `./.venv/bin/python -m pytest tests/test_limits.py -q` → 27 passed, exit 0
- `./.venv/bin/python -m pytest -q` → 799 passed, exit 0
- `./.venv/bin/python -m mypy .` → 0 errors (70 files), exit 0

Touched only `risk/limits.py`, `risk/__init__.py`, `tests/test_limits.py` (+ context entry in `.claude/context/signals.md`).

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)