### PR TITLE
P3-T-05: pretrade-check (in-process Claude veto, INV-02)

### DIFF
--- a/.claude/context/hermes_integration.md
+++ b/.claude/context/hermes_integration.md
@@ -177,3 +177,75 @@ does not need updating for offline unit tests.
 **New CLI command?** NO.
 **PR:** https://github.com/saambaby/fathom/pull/67
 **Merge plan:** `gh pr merge 67 --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P3-T-05 — 2026-05-29 (feat/p3-T-05-pretrade)
+
+**What was done:**
+- Created `hermes_integration/pretrade_check.py` with:
+  - `PretradeVerdict` pydantic v2 model:
+    - `decision: Literal["proceed", "block"]`
+    - `reason: str`
+    - `model_config = {"extra": "forbid"}` — rejects unknown fields at validation time.
+  - `_safe_default()` — private factory returning the INV-02 safe default
+    `PretradeVerdict(decision="block", reason="unparseable response — defaulting to block (INV-02 safe abort)")`.
+  - `parse_pretrade_verdict(raw: str) -> PretradeVerdict` — INV-02 enforcement boundary:
+    empty-string guard → `json.loads` → `isinstance(dict)` check → `PretradeVerdict.model_validate`.
+    Any failure: `_log.warning(...)` + return `_safe_default()`. Never raises. Never returns `proceed` on failure.
+  - `_ClientAdapter` Protocol — injectable interface for the Anthropic SDK.
+  - `_LiveClient` — live adapter wrapping `anthropic.Anthropic()`. The `anthropic` import is
+    deferred inside the class so the whole module is importable without any API key set (offline-safe).
+    API key read from environment automatically (never logged — INV-08). Uses `anthropic.types.TextBlock`
+    for type-safe content block extraction.
+  - `_build_prompt(candidate)` — renders `prompts/pretrade.md` template with all 14 INV-13 Candidate fields.
+  - `pretrade_check(candidate, *, client=None) -> PretradeVerdict` — full safe gate:
+    (1) no client + no key → block immediately (offline safe); (2) build `_LiveClient` if needed;
+    (3) build prompt; (4) call `client.complete(prompt)` — any exception → block; (5) route through
+    `parse_pretrade_verdict`. All failure paths → `_safe_default()` + WARNING log.
+  - Module constant `MODEL = "claude-haiku-4-5"` (D-P3-E pinned small/fast model).
+- Created `hermes_integration/prompts/pretrade.md` — prompt template with all 14 Candidate field
+  placeholders (`{{instrument}}`, `{{timeframe}}`, `{{strategy_name}}`, `{{direction}}`,
+  `{{entry_ref}}`, `{{stop_distance}}`, `{{target_distance}}`, `{{oos_sharpe_mean}}`,
+  `{{quality_score}}`, `{{rank}}`, `{{spread_ok}}`, `{{session_ok}}`, `{{news_flag}}`,
+  `{{generated_at}}`). Instructs Claude to return ONLY `{"decision": "proceed"|"block", "reason": "..."}`.
+  Bias table: default to block on uncertainty. No secrets (INV-08).
+- Updated `hermes_integration/__init__.py` docstring to document the new module.
+- Created `tests/test_pretrade_check.py` — 61 tests, zero live Claude/Anthropic calls:
+  - `TestPretradeVerdictModel` (9 tests): valid proceed/block construction, rejects out-of-enum
+    decision values, missing fields, extra fields (via `model_validate`).
+  - `TestSafeDefault` (3 tests): factory returns PretradeVerdict, decision=block, reason substr.
+  - `TestParsePretradeVerdictWellFormed` (4 tests): proceed/block round-trips, type check.
+  - `TestParsePretradeVerdictMalformedInputs` (24 tests): invalid JSON, partial JSON, prose response,
+    markdown-fenced, empty string, whitespace, missing decision, missing reason, missing all fields,
+    bad decision enum (go/trade/allow/yes/approve), JSON array, null, bare string, number, boolean,
+    null decision, extra field. Plus `test_never_returns_proceed_on_failure` and
+    `test_never_raises_on_any_input` sweeps (INV-02).
+  - `TestParsePretradeVerdictLogging` (4 tests): warning logged on failures; INV-08 no-secret sweep.
+  - `TestPretradeCheckStubClient` (9 tests): proceed/block routing, malformed/empty/bad-enum/extra-field
+    → safe default, returns PretradeVerdict type, raising client → safe default, never raises.
+  - `TestPretradeCheckOfflinePath` (3 tests): no client + no key → block, never raises, logs warning.
+  - `TestModuleIsolation` (5 tests): no execution/orders/risk/sizing attrs; only expected public names.
+
+**INV-02 design decision:**
+- Three independent defence layers in `parse_pretrade_verdict`: (1) empty-string guard, (2) JSON parse
+  try/except, (3) pydantic validate try/except + bare `except Exception` catch-all.
+- `_ClientAdapter` Protocol + injectable `client` parameter: tests inject `_StubClient`/`_RaisingClient`
+  with no live key; the live path (`_LiveClient`) is only exercised at the acceptance gate.
+- `os.environ.get("ANTHROPIC_API_KEY")` offline check: no client + no key → immediate block with no
+  SDK import attempted. Safe for CI with no secrets.
+
+**Offline testability:** `_LiveClient.__init__` defers the `anthropic` import so the whole module is
+importable without a key. Tests use `_StubClient`/`_RaisingClient` injected via `client=` parameter.
+
+**anthropic SDK dep** already in pyproject.toml (added by C-A coordinator edit, commit 422c4f2).
+**pyproject.toml untouched** — no new dependencies.
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command — CLAUDE.md not edited.
+
+**AC verification results:**
+- `mypy .` → "Success: no issues found in 72 source files", exit 0
+- `pytest -q` → 860 passed (799 pre-existing + 61 new), exit 0
+
+**New dependency added to pyproject.toml?** NO (anthropic already present).
+**New CLI command?** NO.
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)

--- a/hermes_integration/__init__.py
+++ b/hermes_integration/__init__.py
@@ -1,10 +1,14 @@
 """Hermes integration — prompt templates, response models, and parse helpers.
 
 This package owns the Fathom-side contract for Claude-powered daily watchlist
-generation.  No ``anthropic`` SDK dependency (D-P2-3): Claude is invoked
-Hermes-side; Fathom supplies the prompt templates, validates the JSON strings
-that come back, and exposes typed pydantic models to downstream pipeline steps.
+generation and the in-process pre-trade veto gate (Phase 3).
 
 Modules:
-    news_risk: NewsRiskVerdict model + parse_news_risk() — INV-02 enforcement.
+    news_risk: NewsRiskVerdict model + parse_news_risk() — INV-02 enforcement
+        (Phase 2, Hermes-side; no anthropic SDK dependency here).
+    pretrade_check: PretradeVerdict model + parse_pretrade_verdict() +
+        pretrade_check() — INV-02 in-process Claude veto before order
+        submission (Phase 3).  Uses the anthropic SDK via an injectable
+        _LiveClient adapter; fully testable offline.
+    narration: fallback_narration() — cosmetic watchlist one-liner (Phase 2).
 """

--- a/hermes_integration/pretrade_check.py
+++ b/hermes_integration/pretrade_check.py
@@ -1,0 +1,376 @@
+"""Pre-trade check — INV-02 enforcement boundary (Phase 3).
+
+The final in-process Claude veto before order submission.  Given an approved
+``Candidate``, it asks Claude for a ``{decision, reason}`` verdict:
+
+* ``PretradeVerdict`` (pydantic v2) — ``{decision: "proceed"|"block", reason: str}``.
+* ``parse_pretrade_verdict(raw)`` — the INV-02 safe-default boundary.  Any
+  failure (invalid JSON, missing field, out-of-enum value, empty string, wrong
+  type) returns ``decision="block"`` and logs at WARNING.  It **never raises**
+  and **never returns** ``decision="proceed"`` on a parse/validation failure.
+* ``pretrade_check(candidate, *, client=None) -> PretradeVerdict`` — builds the
+  prompt from ``prompts/pretrade.md``, calls Claude via an injectable ``client``
+  adapter, and routes the raw response through ``parse_pretrade_verdict``.
+  With ``client=None`` and no ``ANTHROPIC_API_KEY`` set → returns the safe
+  default ``block`` (testable and safe offline).
+
+The asymmetry (INV-02):
+    A false ``block`` costs an opportunity; a false ``proceed`` costs money.
+    The parser is therefore the safe boundary — wrap everything in
+    try/except → block default, not raise.
+
+INV-01: this module returns a verdict only.  No order, execution, or risk
+    function is imported or callable from here.
+INV-08: the ``ANTHROPIC_API_KEY`` is never logged.  It is read from the
+    environment/``.env`` via the ``_LiveClient`` adapter only at call time.
+
+**Model constant (D-P3-E):** ``claude-haiku-4-5`` — small/fast Haiku-tier.
+
+Offline testability: inject a stub via the ``client`` parameter.  Tests do not
+    need a real API key; the live adapter is only exercised at the acceptance gate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ValidationError
+
+from signals.ranker import Candidate
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module constant (D-P3-E) — pinned small/fast model for the pre-trade veto
+# ---------------------------------------------------------------------------
+
+MODEL: str = "claude-haiku-4-5"
+
+# ---------------------------------------------------------------------------
+# Prompt template path
+# ---------------------------------------------------------------------------
+
+_PROMPTS_DIR = pathlib.Path(__file__).parent / "prompts"
+_PROMPT_PATH = _PROMPTS_DIR / "pretrade.md"
+
+# ---------------------------------------------------------------------------
+# Safe default (INV-02) — returned whenever parse_pretrade_verdict fails
+# ---------------------------------------------------------------------------
+
+_SAFE_DEFAULT_DECISION: Literal["block"] = "block"
+_SAFE_DEFAULT_REASON: str = "unparseable response — defaulting to block (INV-02 safe abort)"
+
+
+# ---------------------------------------------------------------------------
+# PretradeVerdict pydantic model
+# ---------------------------------------------------------------------------
+
+
+class PretradeVerdict(BaseModel):
+    """Structured pre-trade veto verdict returned by Claude (in-process).
+
+    Wire format (snake_case, exact enum spellings):
+        ``{"decision": "proceed"|"block", "reason": "..."}``
+
+    Pydantic v2 strict enum validation rejects any value outside the declared
+    literals at construction time, satisfying the INV-02 strict-enum requirement.
+
+    Attributes:
+        decision: The veto verdict.
+            - ``"proceed"`` — trade may continue to sizing/submission.
+            - ``"block"``   — trade is aborted; this is the INV-02 safe default.
+        reason: Human-readable explanation from Claude (or from the safe-default
+            factory when the parse boundary fails).
+    """
+
+    decision: Literal["proceed", "block"]
+    reason: str
+
+    model_config = {"extra": "forbid"}
+
+
+# ---------------------------------------------------------------------------
+# Safe-default factory
+# ---------------------------------------------------------------------------
+
+
+def _safe_default() -> PretradeVerdict:
+    """Return the INV-02 safe default verdict (block)."""
+    return PretradeVerdict(
+        decision=_SAFE_DEFAULT_DECISION,
+        reason=_SAFE_DEFAULT_REASON,
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_pretrade_verdict — INV-02 enforcement boundary
+# ---------------------------------------------------------------------------
+
+
+def parse_pretrade_verdict(raw: str) -> PretradeVerdict:
+    """Parse Claude's JSON response into a ``PretradeVerdict``.
+
+    This is the INV-02 enforcement boundary.  **On ANY failure** — invalid
+    JSON, missing required field, out-of-enum value, empty string, wrong
+    JSON type — returns the safe default
+    ``PretradeVerdict(decision="block", reason="unparseable response — defaulting to block (INV-02 safe abort)")``
+    and logs at WARNING level.  It **never raises** and **never returns**
+    ``decision="proceed"`` on a failure path.
+
+    Args:
+        raw: The raw string returned by Claude (expected to be a JSON object).
+
+    Returns:
+        A validated ``PretradeVerdict``.  On any failure, the safe-default
+        ``block`` verdict is returned instead.
+
+    Examples:
+        >>> parse_pretrade_verdict('{"decision":"proceed","reason":"all checks pass"}')
+        PretradeVerdict(decision='proceed', reason='all checks pass')
+
+        >>> parse_pretrade_verdict("this is not json")
+        PretradeVerdict(decision='block', reason='unparseable response — defaulting to block (INV-02 safe abort)')
+    """
+    # Guard: reject empty / whitespace-only input immediately.
+    if not raw or not raw.strip():
+        _log.warning(
+            "parse_pretrade_verdict: empty response — returning safe default (INV-02)"
+        )
+        return _safe_default()
+
+    try:
+        data: Any = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        _log.warning(
+            "parse_pretrade_verdict: JSON decode failed (%s) — returning safe default (INV-02)",
+            exc,
+        )
+        return _safe_default()
+
+    # json.loads can return non-dict values (e.g. a bare string, list, or null).
+    if not isinstance(data, dict):
+        _log.warning(
+            "parse_pretrade_verdict: expected a JSON object, got %s — returning safe default (INV-02)",
+            type(data).__name__,
+        )
+        return _safe_default()
+
+    try:
+        verdict = PretradeVerdict.model_validate(data)
+    except ValidationError as exc:
+        _log.warning(
+            "parse_pretrade_verdict: pydantic validation failed (%s) — returning safe default (INV-02)",
+            exc,
+        )
+        return _safe_default()
+    except Exception as exc:  # noqa: BLE001 — catch-all for absolute safety (INV-02)
+        _log.warning(
+            "parse_pretrade_verdict: unexpected error (%s: %s) — returning safe default (INV-02)",
+            type(exc).__name__,
+            exc,
+        )
+        return _safe_default()
+
+    return verdict
+
+
+# ---------------------------------------------------------------------------
+# Client adapter protocol — injectable for tests
+# ---------------------------------------------------------------------------
+
+
+class _ClientAdapter(Protocol):
+    """Thin adapter interface for the Anthropic SDK.
+
+    The live implementation (``_LiveClient``) wraps ``anthropic.Anthropic``.
+    Tests inject a ``_StubClient`` that returns a fixed payload without any
+    network call.  ``pretrade_check`` accepts any object satisfying this
+    protocol via the ``client`` parameter.
+    """
+
+    def complete(self, prompt: str) -> str:
+        """Send a text prompt to Claude and return the raw text response.
+
+        Args:
+            prompt: The full prompt string.
+
+        Returns:
+            The raw text from Claude's first content block.
+
+        Raises:
+            Any exception from the underlying SDK — callers must wrap in
+            try/except and fall back to the safe default (INV-02).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Live adapter — isolates the ``anthropic`` SDK import (INV-08)
+# ---------------------------------------------------------------------------
+
+
+class _LiveClient:
+    """Live Anthropic SDK adapter.
+
+    The ``anthropic`` import is deferred to this class so the whole module +
+    tests are importable with no API key set (offline-testable, INV-08).
+
+    INV-08: the API key is read from the environment at construction time
+    (via the SDK's standard ``ANTHROPIC_API_KEY`` env-var lookup).  It is
+    NEVER logged or stored as an attribute.
+    """
+
+    def __init__(self) -> None:
+        # Lazy import — keeps the module importable without a live key.
+        import anthropic
+
+        # The SDK reads ANTHROPIC_API_KEY from the environment automatically.
+        # We do NOT pass the key explicitly so it is never visible in this
+        # module's attribute namespace (INV-08).
+        self._client = anthropic.Anthropic()
+
+    def complete(self, prompt: str) -> str:
+        """Call the Anthropic API with a single user turn and return the text."""
+        import anthropic
+
+        message = self._client.messages.create(
+            model=MODEL,
+            max_tokens=256,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        # Extract the first text content block (INV-02: any other shape → caller
+        # catches the AttributeError and returns the safe default).
+        block = message.content[0]
+        if not isinstance(block, anthropic.types.TextBlock):
+            raise ValueError(
+                f"Unexpected content block type from Claude: {type(block).__name__}"
+            )
+        return block.text
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt(candidate: Candidate) -> str:
+    """Render the prompt template with the candidate's facts.
+
+    Reads ``prompts/pretrade.md`` once per call.  All candidate fields are
+    substituted into ``{{placeholder}}`` slots.
+
+    Args:
+        candidate: The ranked ``Candidate`` to be vetted.
+
+    Returns:
+        The rendered prompt string ready for submission to Claude.
+
+    Raises:
+        FileNotFoundError: if the prompt template is missing (programming error).
+    """
+    template = _PROMPT_PATH.read_text(encoding="utf-8")
+    rendered = template.replace("{{instrument}}", candidate.instrument)
+    rendered = rendered.replace("{{timeframe}}", candidate.timeframe)
+    rendered = rendered.replace("{{strategy_name}}", candidate.strategy_name)
+    rendered = rendered.replace("{{direction}}", candidate.direction)
+    rendered = rendered.replace("{{entry_ref}}", str(candidate.entry_ref))
+    rendered = rendered.replace("{{stop_distance}}", str(candidate.stop_distance))
+    rendered = rendered.replace("{{target_distance}}", str(candidate.target_distance))
+    rendered = rendered.replace("{{oos_sharpe_mean}}", str(candidate.oos_sharpe_mean))
+    rendered = rendered.replace("{{quality_score}}", str(candidate.quality_score))
+    rendered = rendered.replace("{{rank}}", str(candidate.rank))
+    rendered = rendered.replace("{{spread_ok}}", str(candidate.spread_ok))
+    rendered = rendered.replace("{{session_ok}}", str(candidate.session_ok))
+    rendered = rendered.replace("{{news_flag}}", str(candidate.news_flag))
+    rendered = rendered.replace("{{generated_at}}", candidate.generated_at)
+    return rendered
+
+
+# ---------------------------------------------------------------------------
+# pretrade_check — public API
+# ---------------------------------------------------------------------------
+
+
+def pretrade_check(
+    candidate: Candidate,
+    *,
+    client: _ClientAdapter | None = None,
+) -> PretradeVerdict:
+    """Run the pre-trade Claude veto for a ranked ``Candidate``.
+
+    This is the INV-02 safe gate.  The live ``anthropic`` SDK call is isolated
+    in the ``_LiveClient`` adapter so this function (and the whole module) is
+    fully testable offline.  Inject a stub via ``client`` in tests.
+
+    Algorithm:
+        1. If no ``client`` is provided and ``ANTHROPIC_API_KEY`` is not set,
+           return the safe default ``block`` immediately (offline-safe).
+        2. If no ``client`` is provided and a key is available, instantiate
+           ``_LiveClient``.
+        3. Build the prompt from ``prompts/pretrade.md``.
+        4. Call ``client.complete(prompt)`` — any SDK/network exception is
+           caught, logged at WARNING, and returns the safe default ``block``.
+        5. Route the raw response through ``parse_pretrade_verdict`` (the INV-02
+           enforcement boundary).
+
+    Args:
+        candidate: The ranked ``Candidate`` to be vetted.
+        client: An injectable adapter satisfying ``_ClientAdapter``.  Pass a
+            stub in tests.  Defaults to ``None`` (auto-detect live vs offline).
+
+    Returns:
+        A ``PretradeVerdict``.  Always ``block`` on any failure path (INV-02).
+    """
+    # Step 1 — no client and no key → safe offline default (no crash, no key error).
+    if client is None and not os.environ.get("ANTHROPIC_API_KEY"):
+        _log.warning(
+            "pretrade_check: no client and ANTHROPIC_API_KEY not set — "
+            "returning safe default block (INV-02 offline path)"
+        )
+        return _safe_default()
+
+    # Step 2 — build the live client if none injected.
+    active_client: _ClientAdapter
+    if client is None:
+        try:
+            active_client = _LiveClient()
+        except Exception as exc:  # noqa: BLE001 — SDK import/init failure
+            _log.warning(
+                "pretrade_check: failed to initialise live client (%s: %s) — "
+                "returning safe default (INV-02)",
+                type(exc).__name__,
+                exc,
+            )
+            return _safe_default()
+    else:
+        active_client = client
+
+    # Step 3 — build the prompt.
+    try:
+        prompt = _build_prompt(candidate)
+    except Exception as exc:  # noqa: BLE001 — prompt template missing / IO error
+        _log.warning(
+            "pretrade_check: failed to build prompt (%s: %s) — "
+            "returning safe default (INV-02)",
+            type(exc).__name__,
+            exc,
+        )
+        return _safe_default()
+
+    # Step 4 — call Claude.
+    try:
+        raw = active_client.complete(prompt)
+    except Exception as exc:  # noqa: BLE001 — SDK/network error → safe default
+        _log.warning(
+            "pretrade_check: API call failed (%s: %s) — returning safe default (INV-02)",
+            type(exc).__name__,
+            exc,
+        )
+        return _safe_default()
+
+    # Step 5 — parse through the INV-02 enforcement boundary.
+    return parse_pretrade_verdict(raw)

--- a/hermes_integration/prompts/pretrade.md
+++ b/hermes_integration/prompts/pretrade.md
@@ -1,0 +1,74 @@
+# Prompt: Pre-Trade Check
+
+**Used by:** `hermes_integration/pretrade_check.py` (in-process, Phase 3)
+**For:** Final Claude veto immediately before order submission — given an approved Candidate
+**Returns:** A single JSON object — no prose, no markdown, no explanation outside the JSON
+
+---
+
+## Instructions
+
+You are a strict forex risk guard. Your job is to perform a final sanity check on a trade
+candidate that has already passed all deterministic filters (approved-set gate, spread/session
+checks, news gate, risk sizing). You may **only block or proceed** — you cannot size, modify,
+or delay the trade.
+
+**Default to block when uncertain.** A false block costs an opportunity; a false proceed risks
+real money on a bad trade. When you are unsure, return `"decision": "block"`.
+
+Your response must be **exactly one JSON object** matching this schema — nothing else:
+
+```json
+{
+  "decision": "proceed" | "block",
+  "reason": "<concise explanation, ≤ 120 characters>"
+}
+```
+
+**Field rules (strict — these are validated by machine):**
+- `decision`: exactly one of the two strings above, lowercase, no variations.
+- `reason`: a plain string; no quotes-within-quotes; no newlines; ≤ 120 characters.
+
+**Do not** wrap in markdown fences. **Do not** add commentary before or after the JSON.
+**Do not** include extra fields. Output only the JSON object, nothing else.
+
+---
+
+## Decision guidance
+
+| Condition | Recommended verdict |
+|---|---|
+| Candidate facts are internally consistent (entry, stop, target all positive, RR ≥ 1) | `"proceed"` |
+| Stop distance is zero or negative | `"block"` |
+| Target distance is zero or negative | `"block"` |
+| Entry reference price looks implausible for the instrument | `"block"` |
+| OOS Sharpe mean is negative or zero | `"block"` |
+| Quality score is exactly 0.0 (no signal strength) | `"block"` |
+| Any field is missing, null, or nonsensical | `"block"` |
+| Claude is uncertain about any dimension | `"block"` |
+
+For plausible, internally-consistent candidate facts: return `"proceed"`.
+For any concern or ambiguity: return `"block"`.
+
+---
+
+## Candidate facts
+
+**Instrument:** {{instrument}}
+**Timeframe:** {{timeframe}}
+**Strategy:** {{strategy_name}}
+**Direction:** {{direction}}
+**Entry reference price:** {{entry_ref}}
+**Stop distance:** {{stop_distance}}
+**Target distance:** {{target_distance}}
+**OOS Sharpe mean:** {{oos_sharpe_mean}}
+**Quality score:** {{quality_score}}
+**Rank:** {{rank}}
+**Spread OK:** {{spread_ok}}
+**Session OK:** {{session_ok}}
+**News flag:** {{news_flag}}
+**Generated at:** {{generated_at}}
+
+---
+
+Respond now with **only** the JSON object.

--- a/tests/test_pretrade_check.py
+++ b/tests/test_pretrade_check.py
@@ -1,0 +1,569 @@
+"""Tests for hermes_integration.pretrade_check — INV-02 enforcement.
+
+Coverage:
+    - PretradeVerdict: valid construction, field access, strict enum rejection.
+    - parse_pretrade_verdict: well-formed JSON → valid verdict.
+    - Malformed inputs → safe default (decision="block"), no exception,
+      never "proceed" (INV-02 exhaustive battery).
+    - pretrade_check with an injected stub client routes through the parser.
+    - No client + no key → safe-default block (offline path).
+    - No order/execution/risk imports callable from this module (INV-01).
+
+No live Claude / Anthropic calls anywhere in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from hermes_integration.pretrade_check import (
+    PretradeVerdict,
+    _safe_default,
+    parse_pretrade_verdict,
+    pretrade_check,
+)
+from signals.ranker import Candidate
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+_SAFE_DEFAULT_REASON_SUBSTR = "defaulting to block"
+
+
+def _is_safe_default(verdict: PretradeVerdict) -> bool:
+    """Return True if verdict is the INV-02 safe default (block)."""
+    return verdict.decision == "block" and _SAFE_DEFAULT_REASON_SUBSTR in verdict.reason
+
+
+def _make_candidate(**overrides: Any) -> Candidate:
+    """Build a minimal valid Candidate for testing."""
+    defaults: dict[str, Any] = {
+        "instrument": "EUR_USD",
+        "timeframe": "H1",
+        "strategy_name": "macrossover_10_50",
+        "direction": "LONG",
+        "entry_ref": 1.0850,
+        "stop_distance": 0.0030,
+        "target_distance": 0.0045,
+        "oos_sharpe_mean": 0.42,
+        "quality_score": 0.75,
+        "rank": 1,
+        "spread_ok": True,
+        "session_ok": True,
+        "news_flag": False,
+        "generated_at": "2026-05-29T10:00:00Z",
+    }
+    defaults.update(overrides)
+    return Candidate(**defaults)
+
+
+class _StubClient:
+    """Stub adapter: returns a fixed raw response without any network call."""
+
+    def __init__(self, raw_response: str) -> None:
+        self._raw = raw_response
+
+    def complete(self, prompt: str) -> str:  # noqa: ARG002
+        return self._raw
+
+
+class _RaisingClient:
+    """Stub adapter: raises an exception to simulate SDK/network failure."""
+
+    def complete(self, prompt: str) -> str:  # noqa: ARG002
+        raise RuntimeError("simulated SDK error")
+
+
+# ---------------------------------------------------------------------------
+# PretradeVerdict — model validation
+# ---------------------------------------------------------------------------
+
+
+class TestPretradeVerdictModel:
+    """PretradeVerdict field validation and strict enum enforcement."""
+
+    def test_valid_proceed(self) -> None:
+        v = PretradeVerdict(decision="proceed", reason="all checks pass")
+        assert v.decision == "proceed"
+        assert v.reason == "all checks pass"
+
+    def test_valid_block(self) -> None:
+        v = PretradeVerdict(decision="block", reason="stop is zero")
+        assert v.decision == "block"
+        assert v.reason == "stop is zero"
+
+    def test_rejects_bad_decision_go(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict.model_validate({"decision": "go", "reason": "ok"})
+
+    def test_rejects_bad_decision_trade(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict.model_validate({"decision": "trade", "reason": "ok"})
+
+    def test_rejects_bad_decision_allow(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict.model_validate({"decision": "allow", "reason": "ok"})
+
+    def test_rejects_bad_decision_none(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict.model_validate({"decision": None, "reason": "ok"})
+
+    def test_rejects_missing_decision(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict(reason="ok")  # type: ignore[call-arg]
+
+    def test_rejects_missing_reason(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict(decision="proceed")  # type: ignore[call-arg]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            PretradeVerdict(
+                decision="proceed",
+                reason="ok",
+                confidence=0.9,  # type: ignore[call-arg]
+            )
+
+
+# ---------------------------------------------------------------------------
+# _safe_default — factory
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDefault:
+    """_safe_default() returns a stable INV-02 block verdict."""
+
+    def test_returns_pretrade_verdict(self) -> None:
+        v = _safe_default()
+        assert isinstance(v, PretradeVerdict)
+
+    def test_decision_is_block(self) -> None:
+        v = _safe_default()
+        assert v.decision == "block"
+
+    def test_reason_contains_abort_phrase(self) -> None:
+        v = _safe_default()
+        assert _SAFE_DEFAULT_REASON_SUBSTR in v.reason
+
+
+# ---------------------------------------------------------------------------
+# parse_pretrade_verdict — well-formed input
+# ---------------------------------------------------------------------------
+
+
+class TestParsePretradeVerdictWellFormed:
+    """parse_pretrade_verdict returns a valid verdict for well-formed Claude JSON."""
+
+    def test_proceed_verdict(self) -> None:
+        raw = json.dumps({"decision": "proceed", "reason": "all checks pass"})
+        v = parse_pretrade_verdict(raw)
+        assert v.decision == "proceed"
+        assert v.reason == "all checks pass"
+
+    def test_block_verdict(self) -> None:
+        raw = json.dumps({"decision": "block", "reason": "stop distance is zero"})
+        v = parse_pretrade_verdict(raw)
+        assert v.decision == "block"
+        assert v.reason == "stop distance is zero"
+
+    def test_returns_pretrade_verdict_type(self) -> None:
+        raw = json.dumps({"decision": "proceed", "reason": "ok"})
+        v = parse_pretrade_verdict(raw)
+        assert isinstance(v, PretradeVerdict)
+
+    def test_both_decision_values_round_trip(self) -> None:
+        for decision in ("proceed", "block"):
+            raw = json.dumps({"decision": decision, "reason": "test"})
+            v = parse_pretrade_verdict(raw)
+            assert v.decision == decision
+
+
+# ---------------------------------------------------------------------------
+# parse_pretrade_verdict — malformed input → safe default (INV-02 exhaustive)
+# ---------------------------------------------------------------------------
+
+
+class TestParsePretradeVerdictMalformedInputs:
+    """Each malformed input must: return safe default, never raise, never proceed (INV-02)."""
+
+    # -- Invalid JSON --
+
+    def test_invalid_json_string(self) -> None:
+        v = parse_pretrade_verdict("this is not json")
+        assert _is_safe_default(v)
+        assert v.decision == "block"
+
+    def test_invalid_json_partial(self) -> None:
+        v = parse_pretrade_verdict('{"decision": "proceed"')  # truncated
+        assert _is_safe_default(v)
+
+    def test_invalid_json_prose_response(self) -> None:
+        v = parse_pretrade_verdict("The trade looks fine to me, you should proceed.")
+        assert _is_safe_default(v)
+
+    def test_invalid_json_markdown_wrapped(self) -> None:
+        # Claude sometimes wraps in code fences despite instructions.
+        v = parse_pretrade_verdict(
+            '```json\n{"decision":"proceed","reason":"ok"}\n```'
+        )
+        assert _is_safe_default(v)
+
+    # -- Empty / whitespace --
+
+    def test_empty_string(self) -> None:
+        v = parse_pretrade_verdict("")
+        assert _is_safe_default(v)
+
+    def test_whitespace_only(self) -> None:
+        v = parse_pretrade_verdict("   \n\t  ")
+        assert _is_safe_default(v)
+
+    # -- Missing required fields --
+
+    def test_missing_decision(self) -> None:
+        raw = json.dumps({"reason": "all looks fine"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_missing_reason(self) -> None:
+        raw = json.dumps({"decision": "proceed"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_missing_all_fields(self) -> None:
+        v = parse_pretrade_verdict("{}")
+        assert _is_safe_default(v)
+
+    # -- Out-of-enum decision values --
+
+    def test_bad_decision_go(self) -> None:
+        raw = json.dumps({"decision": "go", "reason": "looks good"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_bad_decision_trade(self) -> None:
+        raw = json.dumps({"decision": "trade", "reason": "fine"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_bad_decision_allow(self) -> None:
+        raw = json.dumps({"decision": "allow", "reason": "ok"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_bad_decision_yes(self) -> None:
+        raw = json.dumps({"decision": "yes", "reason": "ok"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_bad_decision_approve(self) -> None:
+        raw = json.dumps({"decision": "approve", "reason": "ok"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    # -- Wrong JSON types --
+
+    def test_json_array_not_object(self) -> None:
+        raw = json.dumps([{"decision": "proceed", "reason": "ok"}])
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_json_null(self) -> None:
+        v = parse_pretrade_verdict("null")
+        assert _is_safe_default(v)
+
+    def test_json_bare_string(self) -> None:
+        v = parse_pretrade_verdict('"proceed"')
+        assert _is_safe_default(v)
+
+    def test_json_number(self) -> None:
+        v = parse_pretrade_verdict("42")
+        assert _is_safe_default(v)
+
+    def test_json_boolean(self) -> None:
+        v = parse_pretrade_verdict("true")
+        assert _is_safe_default(v)
+
+    def test_decision_is_null(self) -> None:
+        raw = json.dumps({"decision": None, "reason": "ok"})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    def test_reason_missing_decision_null(self) -> None:
+        raw = json.dumps({"decision": None, "reason": None})
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    # -- Extra fields (model forbids extras) --
+
+    def test_extra_field_rejected(self) -> None:
+        raw = json.dumps(
+            {"decision": "proceed", "reason": "ok", "confidence": 0.9}
+        )
+        v = parse_pretrade_verdict(raw)
+        assert _is_safe_default(v)
+
+    # -- INV-02 core invariant: never "proceed" on parse failure --
+
+    def test_never_returns_proceed_on_failure(self) -> None:
+        """Malformed inputs must never return decision='proceed' (INV-02)."""
+        bad_inputs = [
+            "",
+            "not json",
+            "null",
+            "[]",
+            "{}",
+            '{"decision":"go","reason":"ok"}',
+            '{"decision":"trade","reason":"ok"}',
+            '{"reason":"ok"}',
+            '{"decision":"proceed"}',  # missing reason
+        ]
+        for raw in bad_inputs:
+            v = parse_pretrade_verdict(raw)
+            assert v.decision != "proceed", (
+                f"INV-02 violated: parse_pretrade_verdict returned 'proceed' "
+                f"for bad input: {raw!r}"
+            )
+
+    # -- No exception raised (INV-02) --
+
+    def test_never_raises_on_any_input(self) -> None:
+        """parse_pretrade_verdict must never raise, regardless of input (INV-02)."""
+        bad_inputs = [
+            "",
+            "not json",
+            '{"decision":"go","reason":"x"}',
+            '{"reason":"ok"}',
+            "null",
+            "[]",
+            '{"decision": "proceed"}',
+            "true",
+            "42",
+            '"a bare string"',
+        ]
+        for raw in bad_inputs:
+            try:
+                parse_pretrade_verdict(raw)
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(
+                    f"parse_pretrade_verdict raised {type(exc).__name__} "
+                    f"for input {raw!r}: {exc}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# parse_pretrade_verdict — logging behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestParsePretradeVerdictLogging:
+    """Failures are logged at WARNING; no secrets leak (INV-08)."""
+
+    def test_logs_warning_on_invalid_json(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.pretrade_check"):
+            parse_pretrade_verdict("not json at all")
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_logs_warning_on_empty(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.pretrade_check"):
+            parse_pretrade_verdict("")
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_logs_warning_on_bad_enum(self, caplog: pytest.LogCaptureFixture) -> None:
+        raw = json.dumps({"decision": "go", "reason": "x"})
+        with caplog.at_level(logging.WARNING, logger="hermes_integration.pretrade_check"):
+            parse_pretrade_verdict(raw)
+        assert any("safe default" in r.message.lower() for r in caplog.records)
+
+    def test_no_secret_token_in_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """INV-08: no secret values appear in log output."""
+        sensitive = "sk-ant-VERY_SECRET_TOKEN_12345"
+        with caplog.at_level(logging.DEBUG, logger="hermes_integration.pretrade_check"):
+            parse_pretrade_verdict(sensitive)
+        for record in caplog.records:
+            assert sensitive not in record.message, (
+                "INV-08: a secret token appeared in the log output"
+            )
+
+
+# ---------------------------------------------------------------------------
+# pretrade_check — stub-client routing (offline, no API key)
+# ---------------------------------------------------------------------------
+
+
+class TestPretradeCheckStubClient:
+    """pretrade_check with an injected stub routes through parse_pretrade_verdict."""
+
+    def test_stub_returning_proceed_routes_to_proceed(self) -> None:
+        raw = json.dumps({"decision": "proceed", "reason": "all checks pass"})
+        stub = _StubClient(raw)
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert v.decision == "proceed"
+        assert v.reason == "all checks pass"
+
+    def test_stub_returning_block_routes_to_block(self) -> None:
+        raw = json.dumps({"decision": "block", "reason": "stop is zero"})
+        stub = _StubClient(raw)
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert v.decision == "block"
+        assert v.reason == "stop is zero"
+
+    def test_stub_returning_malformed_json_gives_safe_default(self) -> None:
+        stub = _StubClient("not valid json at all")
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert _is_safe_default(v)
+
+    def test_stub_returning_empty_gives_safe_default(self) -> None:
+        stub = _StubClient("")
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert _is_safe_default(v)
+
+    def test_stub_returning_bad_enum_gives_safe_default(self) -> None:
+        raw = json.dumps({"decision": "go", "reason": "fine"})
+        stub = _StubClient(raw)
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert _is_safe_default(v)
+
+    def test_stub_returning_extra_field_gives_safe_default(self) -> None:
+        raw = json.dumps({"decision": "proceed", "reason": "ok", "confidence": 0.9})
+        stub = _StubClient(raw)
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert _is_safe_default(v)
+
+    def test_returns_pretrade_verdict_type(self) -> None:
+        raw = json.dumps({"decision": "proceed", "reason": "ok"})
+        stub = _StubClient(raw)
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=stub)
+        assert isinstance(v, PretradeVerdict)
+
+    def test_raising_client_gives_safe_default(self) -> None:
+        """SDK/network failure → safe default block (INV-02)."""
+        candidate = _make_candidate()
+        v = pretrade_check(candidate, client=_RaisingClient())
+        assert _is_safe_default(v)
+
+    def test_raising_client_never_raises(self) -> None:
+        """pretrade_check must never propagate SDK exceptions (INV-02)."""
+        candidate = _make_candidate()
+        try:
+            pretrade_check(candidate, client=_RaisingClient())
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"pretrade_check raised {type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# pretrade_check — no client + no key → offline safe default
+# ---------------------------------------------------------------------------
+
+
+class TestPretradeCheckOfflinePath:
+    """With no client and no ANTHROPIC_API_KEY, pretrade_check returns block."""
+
+    def test_no_client_no_key_returns_block(self) -> None:
+        candidate = _make_candidate()
+        with patch.dict(os.environ, {}, clear=False):
+            # Ensure key is absent for this test.
+            env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+            try:
+                v = pretrade_check(candidate, client=None)
+                assert _is_safe_default(v)
+                assert v.decision == "block"
+            finally:
+                if env_backup is not None:
+                    os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+    def test_no_client_no_key_never_raises(self) -> None:
+        candidate = _make_candidate()
+        env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+        try:
+            try:
+                pretrade_check(candidate, client=None)
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(f"pretrade_check raised {type(exc).__name__}: {exc}")
+        finally:
+            if env_backup is not None:
+                os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+    def test_no_client_no_key_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        candidate = _make_candidate()
+        env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="hermes_integration.pretrade_check"
+            ):
+                pretrade_check(candidate, client=None)
+            assert any(
+                "safe default" in r.message.lower() or "no client" in r.message.lower()
+                for r in caplog.records
+            )
+        finally:
+            if env_backup is not None:
+                os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+
+# ---------------------------------------------------------------------------
+# INV-01: no order/execution/risk imports from this module
+# ---------------------------------------------------------------------------
+
+
+class TestModuleIsolation:
+    """No order, execution, or risk function is importable from pretrade_check (INV-01)."""
+
+    def test_no_execution_import(self) -> None:
+        import hermes_integration.pretrade_check as mod
+
+        assert not hasattr(mod, "execution"), (
+            "INV-01: execution module exposed from pretrade_check"
+        )
+
+    def test_no_orders_import(self) -> None:
+        import hermes_integration.pretrade_check as mod
+
+        assert not hasattr(mod, "orders"), (
+            "INV-01: orders callable exposed from pretrade_check"
+        )
+
+    def test_no_risk_import(self) -> None:
+        import hermes_integration.pretrade_check as mod
+
+        assert not hasattr(mod, "risk"), (
+            "INV-01: risk module exposed from pretrade_check"
+        )
+
+    def test_no_sizing_import(self) -> None:
+        import hermes_integration.pretrade_check as mod
+
+        assert not hasattr(mod, "sizing"), (
+            "INV-01: sizing callable exposed from pretrade_check"
+        )
+
+    def test_only_expected_public_names(self) -> None:
+        """Public API is limited to: PretradeVerdict, parse_pretrade_verdict,
+        pretrade_check, MODEL.  No order/risk/execution names present."""
+        import hermes_integration.pretrade_check as mod
+
+        public_names = {n for n in dir(mod) if not n.startswith("_")}
+        # These must be present
+        assert "PretradeVerdict" in public_names
+        assert "parse_pretrade_verdict" in public_names
+        assert "pretrade_check" in public_names
+        assert "MODEL" in public_names
+        # These must NOT be present
+        forbidden = {"place_order", "submit_order", "size_position", "kill_switch"}
+        overlap = public_names & forbidden
+        assert not overlap, f"INV-01: forbidden names exposed: {overlap}"


### PR DESCRIPTION
## Summary

- Adds `hermes_integration/pretrade_check.py`: `PretradeVerdict` (pydantic v2, `decision: Literal["proceed","block"]`, `extra="forbid"`), `parse_pretrade_verdict` (INV-02 safe-default boundary — any parse/validation/empty failure → `block`, never raises, never returns `proceed` on failure, WARNING logged), and `pretrade_check(candidate, *, client=None)` (builds prompt from `prompts/pretrade.md`, calls Claude via an injectable `_ClientAdapter`, routes response through the parser).
- The `anthropic` SDK import is deferred inside `_LiveClient` so the whole module and tests are importable offline with no key set. Tests inject `_StubClient` / `_RaisingClient` — zero live API calls in the test suite.
- With `client=None` and no `ANTHROPIC_API_KEY` env var, `pretrade_check` returns the safe default `block` immediately (no crash, no import error).
- Adds `hermes_integration/prompts/pretrade.md`: prompt template with all 14 INV-13 Candidate field placeholders; instructs Claude to return only `{"decision": "proceed"|"block", "reason": "..."}` with a default-to-block bias table.
- 61 new tests: full INV-02 malformed-input battery (invalid JSON, missing fields, out-of-enum, wrong JSON types, empty/whitespace, extra fields), stub-client routing, offline safe-default path, module isolation (no execution/risk/orders importable — INV-01).
- Pinned model constant: `MODEL = "claude-haiku-4-5"` (D-P3-E small/fast).

## Test plan

- [ ] `mypy .` → 0 errors (72 source files)
- [ ] `pytest -q` → 860 passed (799 pre-existing + 61 new)
- [ ] `parse_pretrade_verdict` never returns `proceed` on any failure input (INV-02 sweep)
- [ ] `pretrade_check` with `_RaisingClient` → `block` (never raises)
- [ ] No client + no `ANTHROPIC_API_KEY` → safe-default `block`
- [ ] No execution/risk/orders import reachable from the module (INV-01)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)