### PR TITLE
P3-T-08: deviation-monitor (always-on watcher + DeviationEvent)

### DIFF
--- a/.claude/context/monitoring.md
+++ b/.claude/context/monitoring.md
@@ -1,0 +1,97 @@
+# Monitoring context
+
+## P3-T-08 — deviation-monitor — 2026-05-29 (feat/p3-T-08-monitor)
+
+**What was done:**
+
+Created `monitoring/` package from scratch:
+- `monitoring/__init__.py` — package init; exports `DeviationEvent`, `Watcher`, `WatcherConfig`.
+- `monitoring/watcher.py` — the always-on watcher: `DeviationEvent` model, `Alerter` Protocol,
+  `ExecutionResponder` Protocol, `WatcherConfig`, `PositionSnapshot`, four pure rule predicates
+  (`check_adverse`, `check_slippage`, `check_vol`, `check_feed_health`), debounce machinery,
+  and `Watcher` with `run()` loop (queue-based + iterable modes).
+- `scripts/run_monitor.py` — the always-on entrypoint (stream → queue bridge → watcher).
+- `tests/test_deviation_monitor.py` — 38 new tests covering all 4 rules + debounce + UTC +
+  INV-01 + feed-health resilience.
+
+**DeviationEvent shape (frozen, producer):**
+```
+event_id: str          # sha256(trade_id|rule|debounce_window)[:32] — idempotent
+instrument: str
+deviation_type: Literal["adverse","slippage","vol","feed_health"]
+detail: str            # human-readable figure
+broker_trade_id: str | None   # None for feed_health
+severity: Literal["info","warn","severe"]
+created_at: AwareDatetime     # UTC-aware (INV-03)
+```
+T-09 `monitor-alerts` consumes this exact shape.
+
+**Alerter interface for T-09:**
+```python
+class Alerter(Protocol):
+    def send(self, event: DeviationEvent) -> None: ...
+```
+Inject any object satisfying this protocol. `NoOpAlerter` is the default stub.
+
+**ExecutionResponder interface (auto-response, default-off, INV-01):**
+```python
+class ExecutionResponder(Protocol):
+    def respond(
+        self,
+        action: Literal["flatten", "tighten_stop"],
+        broker_trade_id: str,
+        instrument: str,
+    ) -> None: ...
+```
+`NoOpExecutionResponder` is the default stub. Watcher never calls v20 directly.
+
+**Four deviation rules (pure predicates):**
+1. `check_adverse(position, current_price, config)` — per-tick; fires warn when past
+   `adverse_fraction` of stop_dist; severe when past the full stop distance.
+2. `check_slippage(position, config)` — per-tick; fires on the recorded fill slippage;
+   warn when above threshold, severe when ≥ 3x threshold.
+3. `check_vol(position, recent_prices, config)` — per-tick after enough history;
+   range of last `vol_lookback` ticks vs `vol_atr_multiplier × stop_dist`.
+4. `check_feed_health(instrument, last_tick_time, config)` — wall-clock elapsed since
+   last tick vs `heartbeat_timeout_seconds`; also triggered by `gap_detected=True` on
+   a tick (stream reconnected).
+
+**Debounce:**
+Per `(broker_trade_id, deviation_type)` key; suppresses repeats within the same
+`event_id` (same sha256 window). The window is `floor(epoch / debounce_seconds)`.
+
+**WatcherConfig defaults (safe for demo):**
+- `adverse_fraction=0.5`, `slippage_threshold=0.0002`, `vol_atr_multiplier=2.0`
+- `vol_lookback=20`, `heartbeat_timeout_seconds=15.0`, `reconcile_interval_seconds=60.0`
+- `debounce_seconds=300.0`, `severe_response="alert_only"` (INV-01)
+
+**INV-01 enforcement:** `severe_response` defaults to `"alert_only"`. Auto-response
+(`auto_flatten` / `tighten_stop`) is behind a config flag and delegated to the injected
+`ExecutionResponder` — never v20 inline. Watcher has no `submit_order` method.
+
+**Key patterns / gotchas:**
+- `Watcher` accepts either `tick_iterable` (for tests/replay) or `tick_source` (a queue)
+  — both set, queue wins; neither, exits immediately.
+- `store_loader` is `Callable[[], list[PositionSnapshot]]` — injected lambda wraps
+  `store.load_open_positions()` in production; lambdas in tests.
+- `PositionSnapshot` is a lightweight pydantic model for the watcher — does not import
+  `execution.models.Position` to avoid import cycles; production `store_loader` maps
+  `Position` → `PositionSnapshot`.
+- `pyproject.toml` `[tool.setuptools.packages.find]` now includes `monitoring*`,
+  `execution*`, `risk*` (was missing these packages from the find include list).
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_deviation_monitor.py -v` → **38 passed**, exit 0
+- `python -m pytest -q` (full suite) → **898 passed, 87 warnings**, exit 0
+- `python -m mypy .` → **"Success: no issues found in 76 source files"**, exit 0
+
+**New dependency added to pyproject.toml?** NO — `monitoring/` uses only stdlib + pydantic
++ pandas (already in deps). `pyproject.toml` `packages.find.include` extended to add
+`monitoring*`, `execution*`, `risk*` (build config only, no new dep).
+
+**CLAUDE.md trigger-table check:**
+- New package added → `pyproject.toml` packages.find.include extended. CLAUDE.md Stack:
+  no new library dep, no update needed.
+- No new CLI command.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,0 +1,10 @@
+"""Fathom deviation monitor — always-on watcher for open positions.
+
+Exports:
+    DeviationEvent  — the pydantic model (the producer; monitor-alerts T-09 consumes it).
+    Watcher         — the always-on loop: ticks → rule evaluation → alerter.
+"""
+
+from monitoring.watcher import DeviationEvent, Watcher, WatcherConfig
+
+__all__ = ["DeviationEvent", "Watcher", "WatcherConfig"]

--- a/monitoring/watcher.py
+++ b/monitoring/watcher.py
@@ -31,10 +31,14 @@ Four deviation rules
 
 Debounce
 --------
-Each (broker_trade_id, rule) key is debounced: once an event fires, it will
-not re-fire until ``debounce_seconds`` has elapsed.  ``event_id`` is
-``sha256(broker_trade_id + "|" + rule + "|" + debounce-window-start)[:32]``
-so re-persistence is idempotent within a window.
+Each (position, rule) key is debounced: once an event fires, it will not
+re-fire until ``debounce_seconds`` has elapsed.  ``event_id`` is a 32-char
+SHA-256 prefix over the combination of (broker_trade_id, rule, window-start)
+for position rules, or (instrument, rule, window-start) for feed_health events
+(which have no broker_trade_id).  Using the instrument in the feed_health key
+ensures that each instrument debounces its own feed-health stream
+independently — a stale feed on one instrument never suppresses the alert for
+another.  Re-persistence is idempotent within a window.
 
 Alerter protocol
 ----------------
@@ -295,9 +299,23 @@ class PositionSnapshot(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _event_id(broker_trade_id: str | None, deviation_type: str, window_ts: str) -> str:
-    """Compute a stable, idempotent event_id for a (position, rule, window)."""
-    key = f"{broker_trade_id or 'feed_health'}|{deviation_type}|{window_ts}"
+def _event_id(
+    broker_trade_id: str | None,
+    deviation_type: str,
+    window_ts: str,
+    instrument: str | None = None,
+) -> str:
+    """Compute a stable, idempotent event_id for a (position, rule, window).
+
+    For feed_health events (broker_trade_id is None) the ``instrument`` is
+    included so that each instrument produces an independent id and each
+    instrument's own debounce stream is isolated from other instruments.
+    """
+    if broker_trade_id is not None:
+        key = f"{broker_trade_id}|{deviation_type}|{window_ts}"
+    else:
+        # feed_health path: scope the key to the instrument
+        key = f"feed_health|{instrument or ''}|{deviation_type}|{window_ts}"
     return hashlib.sha256(key.encode()).hexdigest()[:32]
 
 
@@ -460,7 +478,7 @@ def check_feed_health(
     now = datetime.now(timezone.utc)
     window_ts = _debounce_window_ts(now, config.debounce_seconds)
     return DeviationEvent(
-        event_id=_event_id(None, "feed_health", window_ts),
+        event_id=_event_id(None, "feed_health", window_ts, instrument=instrument),
         instrument=instrument,
         deviation_type="feed_health",
         detail=f"no tick for {elapsed:.1f}s (timeout {config.heartbeat_timeout_seconds}s)",
@@ -521,7 +539,10 @@ class Watcher:
         self._responder: ExecutionResponder = execution_responder or NoOpExecutionResponder()
         self._instruments = instruments or ["EUR_USD"]
 
-        # Debounce state: maps (broker_trade_id|None, rule) → last event_id fired
+        # Debounce state: maps (broker_trade_id_or_instrument, rule) → last event_id fired
+        # For position rules: key is (broker_trade_id, deviation_type).
+        # For feed_health (broker_trade_id is None): key is (instrument, "feed_health")
+        # so each instrument maintains an independent debounce slot.
         self._debounce: dict[tuple[str | None, str], str] = {}
 
         # Per-instrument recent prices (for vol rule)
@@ -643,7 +664,7 @@ class Watcher:
         now = datetime.now(timezone.utc)
         window_ts = _debounce_window_ts(now, self._config.debounce_seconds)
         event = DeviationEvent(
-            event_id=_event_id(None, "feed_health", window_ts),
+            event_id=_event_id(None, "feed_health", window_ts, instrument=instrument),
             instrument=instrument,
             deviation_type="feed_health",
             detail="gap_detected: stream reconnected (data continuity broken)",
@@ -654,8 +675,18 @@ class Watcher:
         self._maybe_emit(event)
 
     def _maybe_emit(self, event: DeviationEvent) -> None:
-        """Debounce and emit an event; trigger auto-response if configured."""
-        key: tuple[str | None, str] = (event.broker_trade_id, event.deviation_type)
+        """Debounce and emit an event; trigger auto-response if configured.
+
+        For feed_health events (broker_trade_id is None) the debounce key
+        includes the instrument so that each instrument's feed-health stream
+        is debounced independently.  Position-based rules (adverse, slippage,
+        vol) continue to be keyed by broker_trade_id.
+        """
+        if event.broker_trade_id is None:
+            # feed_health: one independent debounce slot per instrument
+            key: tuple[str | None, str] = (event.instrument, event.deviation_type)
+        else:
+            key = (event.broker_trade_id, event.deviation_type)
         # Debounce: skip if the same event_id was already fired for this window
         if self._debounce.get(key) == event.event_id:
             logger.debug(

--- a/monitoring/watcher.py
+++ b/monitoring/watcher.py
@@ -1,0 +1,699 @@
+"""Deviation monitor — always-on watcher for open positions (P3-T-08).
+
+Watches live ticks from the Phase 1B ``PriceStream`` against open positions
+loaded from the store.  Evaluates four deviation rules per position on every
+tick and emits a ``DeviationEvent`` to the injected ``alerter`` when a rule
+fires.  Debounce per (position, rule) prevents alert storms.
+
+Invariants
+----------
+* **INV-01** — the watcher never opens a position; auto-response is
+  default-off and is delegated to a deterministic ``execution/`` function
+  (close or modify of an *existing* position).  The watcher is not a Hermes
+  tool and never calls the v20 order API inline.
+* **INV-03** — all ``DeviationEvent.created_at`` timestamps are UTC-aware.
+* **AMBIGUOUS-01 resolution** — ``alert_only`` (default) | ``auto_flatten`` |
+  ``tighten_stop``, behind a default-off config flag.  On demo the default is
+  alert-only.
+
+Four deviation rules
+--------------------
+1. **adverse** — the current price has moved adversely past a configurable
+   fraction of the stop distance from entry.
+2. **slippage** — the fill slippage on record for this position exceeds the
+   threshold.
+3. **vol** — the recent price range (high-low over the last ``vol_lookback``
+   ticks) exceeds ``vol_atr_multiplier`` times the ATR at open (derived from
+   ``stop_distance`` as a proxy).
+4. **feed_health** — no tick has arrived within ``heartbeat_timeout_seconds``
+   (reuses the gap-detected signal from the Phase 1B stream, and checks
+   elapsed wall-clock time).
+
+Debounce
+--------
+Each (broker_trade_id, rule) key is debounced: once an event fires, it will
+not re-fire until ``debounce_seconds`` has elapsed.  ``event_id`` is
+``sha256(broker_trade_id + "|" + rule + "|" + debounce-window-start)[:32]``
+so re-persistence is idempotent within a window.
+
+Alerter protocol
+----------------
+The ``Alerter`` protocol is minimal — just ``send(event: DeviationEvent)``.
+The concrete implementation (Discord / log) lives in monitor-alerts (T-09).
+
+Auto-response (default-off, INV-01)
+-----------------------------------
+``WatcherConfig.severe_response`` controls the response to a ``severe``-
+severity deviation:
+* ``"alert_only"`` (default) — emit the event only; no execution call.
+* ``"auto_flatten"`` — emit + call the delegated ``execution_responder``
+  with ``("flatten", position)``.
+* ``"tighten_stop"`` — emit + call with ``("tighten_stop", position)``.
+
+The ``execution_responder`` is injected and defaults to a no-op stub so the
+watcher is safe when auto-response is disabled (the default).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import queue
+import time
+from datetime import datetime, timezone
+from typing import Callable, Literal, Protocol, Sequence
+
+import pandas as pd
+from pydantic import AwareDatetime, BaseModel, field_validator
+
+from data.stream import PriceTick
+
+logger = logging.getLogger("fathom.monitoring.watcher")
+
+# ---------------------------------------------------------------------------
+# DeviationEvent — the producer (T-09 monitor-alerts consumes this shape)
+# ---------------------------------------------------------------------------
+
+DeviationType = Literal["adverse", "slippage", "vol", "feed_health"]
+SeverityLevel = Literal["info", "warn", "severe"]
+SevereResponse = Literal["alert_only", "auto_flatten", "tighten_stop"]
+
+
+class DeviationEvent(BaseModel):
+    """A single deviation event emitted by the watcher (INV-03, INV-14 analogue).
+
+    This is the producer shape.  ``monitor-alerts`` (T-09) consumes it.  Field
+    names, types, and flat shape are frozen once this ships (analogous to INV-13
+    for Candidate and INV-14 for Order/Fill/Position).
+
+    Fields
+    ------
+    event_id         : str — stable per (broker_trade_id, rule,
+                       debounce-window-start) so re-persistence is idempotent.
+                       ``sha256(broker_trade_id|deviation_type|window_ts)[:32]``.
+    instrument       : str — OANDA instrument identifier.
+    deviation_type   : ``"adverse"`` | ``"slippage"`` | ``"vol"`` |
+                       ``"feed_health"``.
+    detail           : str — short human-readable figure, e.g.
+                       ``"adverse 0.00150 (threshold 0.00120)"``.
+    broker_trade_id  : str | None — ``None`` for feed_health events (no
+                       position context).
+    severity         : ``"info"`` | ``"warn"`` | ``"severe"``.
+    created_at       : UTC-aware datetime (INV-03).
+    """
+
+    event_id: str
+    instrument: str
+    deviation_type: DeviationType
+    detail: str
+    broker_trade_id: str | None = None
+    severity: SeverityLevel
+    created_at: AwareDatetime  # UTC-aware (INV-03; pydantic rejects naive)
+
+    @field_validator("event_id", "instrument", "detail")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("created_at")
+    @classmethod
+    def _utc_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError(
+                "created_at must be UTC-aware (INV-03). "
+                "Use datetime.now(timezone.utc), never datetime.now()."
+            )
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Alerter protocol — T-09 implements the concrete delivery; watcher uses this
+# ---------------------------------------------------------------------------
+
+
+class Alerter(Protocol):
+    """Minimal alerter interface.  T-09 implements Discord/log delivery.
+
+    The watcher injects any object that satisfies this protocol — duck-typed,
+    not subclassed.  A no-op stub is provided for tests and as the default.
+    """
+
+    def send(self, event: DeviationEvent) -> None:
+        """Deliver a deviation event to the downstream channel."""
+        ...
+
+
+class NoOpAlerter:
+    """A silent alerter stub (default when no real alerter is injected)."""
+
+    def send(self, event: DeviationEvent) -> None:  # noqa: D401
+        """No-op: discard the event (use in tests or when alerter not wired)."""
+        logger.debug("NoOpAlerter.send: %s", event.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Execution responder protocol — thin call-through for auto-response (INV-01)
+# ---------------------------------------------------------------------------
+
+
+class ExecutionResponder(Protocol):
+    """Thin call-through to execution/ for auto-response (default-off, INV-01).
+
+    The watcher never calls the v20 order API inline.  On ``auto_flatten`` or
+    ``tighten_stop``, it calls this injected responder with
+    ``(action, position)`` — the responder is the bridge to
+    ``execution/orders.py`` close/modify functions (to be implemented when
+    those functions ship).  Default is a no-op stub.
+    """
+
+    def respond(
+        self,
+        action: Literal["flatten", "tighten_stop"],
+        broker_trade_id: str,
+        instrument: str,
+    ) -> None:
+        """Delegate the auto-response to the execution layer (INV-01)."""
+        ...
+
+
+class NoOpExecutionResponder:
+    """Default no-op responder (default-off; INV-01: never opens a position)."""
+
+    def respond(
+        self,
+        action: Literal["flatten", "tighten_stop"],
+        broker_trade_id: str,
+        instrument: str,
+    ) -> None:
+        logger.debug(
+            "NoOpExecutionResponder: action=%s trade=%s instrument=%s (no-op)",
+            action,
+            broker_trade_id,
+            instrument,
+        )
+
+
+# ---------------------------------------------------------------------------
+# WatcherConfig — thresholds, cadence, response policy
+# ---------------------------------------------------------------------------
+
+
+class WatcherConfig(BaseModel):
+    """Configuration for the Watcher.
+
+    All thresholds have sensible defaults for demo use.
+
+    Fields
+    ------
+    adverse_fraction         : float — fraction of stop distance that
+                               constitutes an adverse excursion alert.
+                               Default 0.5 (halfway to stop → warn).
+    slippage_threshold       : float — absolute slippage beyond which a
+                               slippage event fires.  Default 0.0002 (2 pips
+                               for 5-dp pairs like EUR_USD).
+    vol_atr_multiplier       : float — range expansion factor above the
+                               inferred ATR (stop_distance as proxy) that
+                               triggers a vol spike event.  Default 2.0.
+    vol_lookback             : int — number of recent ticks over which to
+                               compute the high-low range for the vol rule.
+                               Default 20.
+    heartbeat_timeout_seconds: float — wall-clock seconds with no tick before
+                               a feed_health event fires.  Default 15.0
+                               (slightly above the Phase 1B 10 s stream
+                               timeout so the watcher fires after the stream
+                               has already tried to reconnect).
+    reconcile_interval_seconds: float — how often to refresh open positions
+                               from the store (not the broker — the store is
+                               reconciled separately).  Default 60.0.
+    debounce_seconds         : float — minimum seconds between repeated events
+                               for the same (broker_trade_id, rule).  Default
+                               300.0 (5 minutes).
+    severe_response          : ``"alert_only"`` (default) | ``"auto_flatten"``
+                               | ``"tighten_stop"``.  Controls what the watcher
+                               does beyond emitting the event when severity is
+                               ``"severe"``.  Default is alert-only (safe for
+                               demo, INV-01).
+    """
+
+    adverse_fraction: float = 0.5
+    slippage_threshold: float = 0.0002
+    vol_atr_multiplier: float = 2.0
+    vol_lookback: int = 20
+    heartbeat_timeout_seconds: float = 15.0
+    reconcile_interval_seconds: float = 60.0
+    debounce_seconds: float = 300.0
+    severe_response: SevereResponse = "alert_only"
+
+    @field_validator("adverse_fraction", "slippage_threshold", "vol_atr_multiplier")
+    @classmethod
+    def _positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(f"threshold must be > 0, got {v}")
+        return v
+
+    @field_validator("vol_lookback")
+    @classmethod
+    def _lookback_positive(cls, v: int) -> int:
+        if v < 2:
+            raise ValueError(f"vol_lookback must be >= 2, got {v}")
+        return v
+
+    @field_validator("heartbeat_timeout_seconds", "reconcile_interval_seconds", "debounce_seconds")
+    @classmethod
+    def _seconds_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(f"timeout/interval must be > 0, got {v}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# PositionSnapshot — lightweight copy of what the watcher tracks per position
+# ---------------------------------------------------------------------------
+
+
+class PositionSnapshot(BaseModel):
+    """A position the watcher tracks per tick.
+
+    Separate from ``execution.models.Position`` so the watcher can be tested
+    without importing the full execution package and to allow independent
+    evolution.  Fields mirror those of ``Position`` that the rules need.
+    """
+
+    broker_trade_id: str
+    instrument: str
+    units: int           # signed (long > 0, short < 0)
+    entry_price: float
+    stop_loss_price: float
+    take_profit_price: float
+    fill_slippage: float = 0.0  # from the fill record; 0 if not available
+
+
+# ---------------------------------------------------------------------------
+# Pure rule predicates
+# ---------------------------------------------------------------------------
+
+
+def _event_id(broker_trade_id: str | None, deviation_type: str, window_ts: str) -> str:
+    """Compute a stable, idempotent event_id for a (position, rule, window)."""
+    key = f"{broker_trade_id or 'feed_health'}|{deviation_type}|{window_ts}"
+    return hashlib.sha256(key.encode()).hexdigest()[:32]
+
+
+def _debounce_window_ts(now: datetime, debounce_seconds: float) -> str:
+    """Return a string representing the debounce window the timestamp falls in."""
+    # Floor to the nearest debounce_seconds boundary from epoch.
+    epoch_s = now.timestamp()
+    window_start = int(epoch_s // debounce_seconds) * debounce_seconds
+    return str(int(window_start))
+
+
+def check_adverse(
+    position: PositionSnapshot,
+    current_price: float,
+    config: WatcherConfig,
+) -> DeviationEvent | None:
+    """Fire if the current price has moved adversely past ``adverse_fraction``
+    of the stop distance.
+
+    For a LONG position: adverse = price below entry by >= fraction * stop_dist.
+    For a SHORT position: adverse = price above entry by >= fraction * stop_dist.
+
+    Returns a ``DeviationEvent`` (not yet emitted — caller handles debounce/emit),
+    or ``None`` if the rule does not fire.
+    """
+    stop_dist = abs(position.entry_price - position.stop_loss_price)
+    if stop_dist <= 0:
+        return None  # degenerate position; cannot evaluate
+
+    threshold = config.adverse_fraction * stop_dist
+    is_long = position.units > 0
+
+    if is_long:
+        excursion = position.entry_price - current_price  # positive = down
+    else:
+        excursion = current_price - position.entry_price  # positive = up
+
+    if excursion < threshold:
+        return None
+
+    # Severity: warn by default; severe if excursion >= stop distance itself.
+    severity: SeverityLevel = "severe" if excursion >= stop_dist else "warn"
+
+    now = datetime.now(timezone.utc)
+    window_ts = _debounce_window_ts(now, config.debounce_seconds)
+    return DeviationEvent(
+        event_id=_event_id(position.broker_trade_id, "adverse", window_ts),
+        instrument=position.instrument,
+        deviation_type="adverse",
+        detail=(
+            f"adverse excursion {excursion:.5f} "
+            f"(threshold {threshold:.5f}, stop_dist {stop_dist:.5f})"
+        ),
+        broker_trade_id=position.broker_trade_id,
+        severity=severity,
+        created_at=now,
+    )
+
+
+def check_slippage(
+    position: PositionSnapshot,
+    config: WatcherConfig,
+) -> DeviationEvent | None:
+    """Fire if the fill slippage recorded for this position exceeds the threshold.
+
+    Slippage sign convention: positive = adverse (per INV-14 Fill model).
+    """
+    if position.fill_slippage <= config.slippage_threshold:
+        return None
+
+    severity: SeverityLevel = (
+        "severe"
+        if position.fill_slippage >= config.slippage_threshold * 3
+        else "warn"
+    )
+
+    now = datetime.now(timezone.utc)
+    window_ts = _debounce_window_ts(now, config.debounce_seconds)
+    return DeviationEvent(
+        event_id=_event_id(position.broker_trade_id, "slippage", window_ts),
+        instrument=position.instrument,
+        deviation_type="slippage",
+        detail=(
+            f"fill slippage {position.fill_slippage:.5f} "
+            f"exceeds threshold {config.slippage_threshold:.5f}"
+        ),
+        broker_trade_id=position.broker_trade_id,
+        severity=severity,
+        created_at=now,
+    )
+
+
+def check_vol(
+    position: PositionSnapshot,
+    recent_prices: Sequence[float],
+    config: WatcherConfig,
+) -> DeviationEvent | None:
+    """Fire if the recent price range exceeds ``vol_atr_multiplier`` times the
+    ATR proxy (stop distance as inferred ATR).
+
+    The ATR at open is proxied by ``stop_distance`` (the position was sized by
+    an ATR-derived stop per INV-11).  Range = max(prices) - min(prices) over
+    the last ``vol_lookback`` ticks.
+
+    Returns ``None`` if fewer than 2 prices are available (not enough data).
+    """
+    if len(recent_prices) < 2:
+        return None
+
+    window = list(recent_prices)[-config.vol_lookback:]
+    if len(window) < 2:
+        return None
+
+    price_range = max(window) - min(window)
+    stop_dist = abs(position.entry_price - position.stop_loss_price)
+    if stop_dist <= 0:
+        return None  # degenerate; cannot compare
+
+    threshold = config.vol_atr_multiplier * stop_dist
+    if price_range < threshold:
+        return None
+
+    severity: SeverityLevel = (
+        "severe"
+        if price_range >= threshold * 2
+        else "warn"
+    )
+
+    now = datetime.now(timezone.utc)
+    window_ts = _debounce_window_ts(now, config.debounce_seconds)
+    return DeviationEvent(
+        event_id=_event_id(position.broker_trade_id, "vol", window_ts),
+        instrument=position.instrument,
+        deviation_type="vol",
+        detail=(
+            f"vol range {price_range:.5f} "
+            f"exceeds {config.vol_atr_multiplier}× stop_dist "
+            f"({threshold:.5f})"
+        ),
+        broker_trade_id=position.broker_trade_id,
+        severity=severity,
+        created_at=now,
+    )
+
+
+def check_feed_health(
+    instrument: str,
+    last_tick_time: float,
+    config: WatcherConfig,
+) -> DeviationEvent | None:
+    """Fire if no tick has arrived within ``heartbeat_timeout_seconds``.
+
+    ``last_tick_time`` is a ``time.monotonic()`` value set on every tick.
+    Returns a feed_health event (no broker_trade_id) if stale.
+    """
+    elapsed = time.monotonic() - last_tick_time
+    if elapsed < config.heartbeat_timeout_seconds:
+        return None
+
+    now = datetime.now(timezone.utc)
+    window_ts = _debounce_window_ts(now, config.debounce_seconds)
+    return DeviationEvent(
+        event_id=_event_id(None, "feed_health", window_ts),
+        instrument=instrument,
+        deviation_type="feed_health",
+        detail=f"no tick for {elapsed:.1f}s (timeout {config.heartbeat_timeout_seconds}s)",
+        broker_trade_id=None,
+        severity="severe",
+        created_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watcher — the always-on loop
+# ---------------------------------------------------------------------------
+
+
+class Watcher:
+    """Always-on deviation watcher.
+
+    Consumes ticks from a queue (or any iterable of ``PriceTick``), refreshes
+    open positions from the store periodically, evaluates the four deviation
+    rules per position on every tick, debounces, and emits ``DeviationEvent``
+    objects to the injected ``alerter``.
+
+    Args:
+        tick_source         : iterable of ``PriceTick`` (or a
+                              ``queue.Queue[PriceTick | None]`` where ``None``
+                              is the shutdown sentinel).  Typically the live
+                              ``PriceStream`` but any iterable works for tests.
+        store_loader        : callable ``() -> list[PositionSnapshot]``.
+                              Called every ``config.reconcile_interval_seconds``
+                              to refresh open positions.  Wraps
+                              ``store.load_open_positions()`` in production.
+        alerter             : any object with ``send(DeviationEvent) -> None``.
+                              Default is ``NoOpAlerter``.
+        config              : ``WatcherConfig`` (defaults are safe for demo).
+        execution_responder : injected responder for auto-response actions
+                              (default-off, INV-01).  Default is
+                              ``NoOpExecutionResponder``.
+        instruments         : list of instruments to track for feed-health.
+                              Defaults to ``["EUR_USD"]``.
+    """
+
+    def __init__(
+        self,
+        *,
+        tick_source: "queue.Queue[PriceTick | None] | None" = None,
+        tick_iterable: "list[PriceTick] | None" = None,
+        store_loader: Callable[[], list[PositionSnapshot]] | None = None,
+        alerter: Alerter | None = None,
+        config: WatcherConfig | None = None,
+        execution_responder: ExecutionResponder | None = None,
+        instruments: list[str] | None = None,
+    ) -> None:
+        self._tick_queue: "queue.Queue[PriceTick | None] | None" = tick_source
+        self._tick_iterable: "list[PriceTick] | None" = tick_iterable
+        self._store_loader = store_loader or (lambda: [])
+        self._alerter: Alerter = alerter or NoOpAlerter()
+        self._config = config or WatcherConfig()
+        self._responder: ExecutionResponder = execution_responder or NoOpExecutionResponder()
+        self._instruments = instruments or ["EUR_USD"]
+
+        # Debounce state: maps (broker_trade_id|None, rule) → last event_id fired
+        self._debounce: dict[tuple[str | None, str], str] = {}
+
+        # Per-instrument recent prices (for vol rule)
+        self._recent_prices: dict[str, list[float]] = {}
+
+        # Open positions (refreshed periodically)
+        self._positions: list[PositionSnapshot] = []
+        self._last_reconcile: float = 0.0
+
+        # Feed-health: last tick arrival time per instrument
+        self._last_tick_time: dict[str, float] = {i: time.monotonic() for i in self._instruments}
+
+    def run(self) -> None:
+        """Main loop: consume ticks, evaluate rules, emit events.
+
+        Exits when the tick source signals done (``None`` sentinel from queue or
+        iterable exhausted).  A feed-health check is also performed on each tick
+        (and after each no-tick timeout).
+
+        This method blocks until the source is exhausted or ``stop()`` is called.
+        """
+        self._last_reconcile = time.monotonic() - self._config.reconcile_interval_seconds
+        self._positions = self._store_loader()
+
+        if self._tick_iterable is not None:
+            self._run_from_iterable()
+        elif self._tick_queue is not None:
+            self._run_from_queue()
+        else:
+            logger.warning("Watcher.run(): no tick source provided — exiting immediately")
+
+    def _run_from_iterable(self) -> None:
+        """Consume ticks from a pre-built iterable (tests / replay mode)."""
+        assert self._tick_iterable is not None
+        for tick in self._tick_iterable:
+            self._on_tick(tick)
+        # After iterable exhausted, do one final feed-health pass.
+        self._check_all_feed_health()
+
+    def _run_from_queue(self) -> None:
+        """Consume ticks from a queue; ``None`` sentinel shuts down."""
+        assert self._tick_queue is not None
+        while True:
+            try:
+                item = self._tick_queue.get(
+                    timeout=self._config.heartbeat_timeout_seconds
+                )
+            except queue.Empty:
+                # Timeout — check feed health
+                self._check_all_feed_health()
+                continue
+
+            if item is None:
+                # Shutdown sentinel
+                break
+
+            self._on_tick(item)
+
+    def _on_tick(self, tick: PriceTick) -> None:
+        """Process one tick: update state, evaluate rules, emit events."""
+        instrument = tick.instrument
+        mid = (tick.bid + tick.ask) / 2.0
+
+        # Update last-tick time for feed-health (using monotonic clock)
+        self._last_tick_time[instrument] = time.monotonic()
+
+        # Update recent prices for this instrument
+        prices = self._recent_prices.setdefault(instrument, [])
+        prices.append(mid)
+        # Keep a bounded window: 2× vol_lookback to avoid unbounded memory
+        max_prices = self._config.vol_lookback * 2
+        if len(prices) > max_prices:
+            self._recent_prices[instrument] = prices[-max_prices:]
+
+        # Periodic position refresh
+        now_mono = time.monotonic()
+        if now_mono - self._last_reconcile >= self._config.reconcile_interval_seconds:
+            self._positions = self._store_loader()
+            self._last_reconcile = now_mono
+
+        # Evaluate rules for each open position on this instrument
+        for pos in self._positions:
+            if pos.instrument != instrument:
+                continue
+            self._evaluate_position(pos, mid)
+
+        # Feed-health check (gap_detected from stream means reconnect happened)
+        if tick.gap_detected:
+            self._emit_feed_health_event(instrument)
+
+    def _evaluate_position(
+        self,
+        position: PositionSnapshot,
+        current_price: float,
+    ) -> None:
+        """Evaluate all rules for one position at the current price."""
+        recent = self._recent_prices.get(position.instrument, [])
+
+        candidates = [
+            check_adverse(position, current_price, self._config),
+            check_slippage(position, self._config),
+            check_vol(position, recent, self._config),
+        ]
+
+        for event in candidates:
+            if event is not None:
+                self._maybe_emit(event)
+
+    def _check_all_feed_health(self) -> None:
+        """Check feed health for all tracked instruments."""
+        for instrument in self._instruments:
+            last = self._last_tick_time.get(instrument, 0.0)
+            event = check_feed_health(instrument, last, self._config)
+            if event is not None:
+                self._maybe_emit(event)
+
+    def _emit_feed_health_event(self, instrument: str) -> None:
+        """Emit a feed_health event for gap_detected ticks."""
+        now = datetime.now(timezone.utc)
+        window_ts = _debounce_window_ts(now, self._config.debounce_seconds)
+        event = DeviationEvent(
+            event_id=_event_id(None, "feed_health", window_ts),
+            instrument=instrument,
+            deviation_type="feed_health",
+            detail="gap_detected: stream reconnected (data continuity broken)",
+            broker_trade_id=None,
+            severity="severe",
+            created_at=now,
+        )
+        self._maybe_emit(event)
+
+    def _maybe_emit(self, event: DeviationEvent) -> None:
+        """Debounce and emit an event; trigger auto-response if configured."""
+        key: tuple[str | None, str] = (event.broker_trade_id, event.deviation_type)
+        # Debounce: skip if the same event_id was already fired for this window
+        if self._debounce.get(key) == event.event_id:
+            logger.debug(
+                "Watcher debounce: suppressed repeated %s event for trade=%s",
+                event.deviation_type,
+                event.broker_trade_id,
+            )
+            return
+
+        self._debounce[key] = event.event_id
+        logger.info(
+            "Watcher emitting %s/%s event for %s trade=%s",
+            event.deviation_type,
+            event.severity,
+            event.instrument,
+            event.broker_trade_id,
+        )
+        self._alerter.send(event)
+
+        # Auto-response (default-off, INV-01)
+        if (
+            event.severity == "severe"
+            and self._config.severe_response != "alert_only"
+            and event.broker_trade_id is not None
+        ):
+            action: Literal["flatten", "tighten_stop"] = (
+                "flatten"
+                if self._config.severe_response == "auto_flatten"
+                else "tighten_stop"
+            )
+            logger.warning(
+                "Watcher auto-response: %s for trade=%s instrument=%s",
+                action,
+                event.broker_trade_id,
+                event.instrument,
+            )
+            self._responder.respond(
+                action,
+                broker_trade_id=event.broker_trade_id,
+                instrument=event.instrument,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ py-modules = ["cli"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["config*", "data*", "strategies*", "backtest*", "scripts*", "signals*", "hermes_integration*"]
+include = ["config*", "data*", "strategies*", "backtest*", "scripts*", "signals*", "hermes_integration*", "monitoring*", "execution*", "risk*"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/run_monitor.py
+++ b/scripts/run_monitor.py
@@ -1,0 +1,184 @@
+"""Always-on deviation monitor entrypoint (P3-T-08).
+
+Constructs the live ``PriceStream``, store loader, alerter, and ``Watcher``
+and calls ``watcher.run()`` indefinitely.
+
+Usage::
+
+    ./.venv/bin/python scripts/run_monitor.py [--instruments EUR_USD,GBP_USD]
+                                              [--db-path PATH]
+                                              [--heartbeat-timeout SECS]
+                                              [--debounce-secs SECS]
+                                              [--reconcile-interval SECS]
+                                              [--severe-response alert_only|auto_flatten|tighten_stop]
+
+Invariants
+----------
+* **INV-01** — never opens a position; alert-only by default.
+* **INV-03** — all event timestamps UTC-aware.
+* **INV-08** — credentials from ``Settings``/.env; never printed/logged.
+* **INV-09** — single code path; demo/live differentiated by ``settings.env``.
+
+The alerter is a ``NoOpAlerter`` stub (logs only) until monitor-alerts T-09
+ships.  To wire a real alerter, replace the stub with the T-09 implementation
+and pass it in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import queue
+import sys
+import threading
+from pathlib import Path
+from typing import Callable
+
+# Allow running as `python scripts/run_monitor.py` without installing.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config.settings import Settings
+from data.store import Store
+from data.stream import PriceStream
+from monitoring.watcher import (
+    NoOpAlerter,
+    NoOpExecutionResponder,
+    PositionSnapshot,
+    Watcher,
+    WatcherConfig,
+)
+
+logger = logging.getLogger("fathom.scripts.run_monitor")
+
+
+def _build_store_loader(store: Store) -> "Callable[[], list[PositionSnapshot]]":
+    """Return a callable that loads open positions as PositionSnapshots."""
+
+    def _load() -> list[PositionSnapshot]:
+        raw = store.load_open_positions()
+        snapshots: list[PositionSnapshot] = []
+        for pos in raw:
+            snapshots.append(
+                PositionSnapshot(
+                    broker_trade_id=pos.broker_trade_id,
+                    instrument=pos.instrument,
+                    units=pos.units,
+                    entry_price=pos.entry_price,
+                    stop_loss_price=pos.stop_loss_price,
+                    take_profit_price=pos.take_profit_price,
+                    fill_slippage=0.0,  # slippage not yet wired from fills table
+                )
+            )
+        return snapshots
+
+    return _load
+
+
+def main() -> None:
+    """Parse args, build components, run the watcher (blocking)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Fathom deviation monitor — always-on position watcher"
+    )
+    parser.add_argument(
+        "--instruments",
+        default="EUR_USD",
+        help="Comma-separated OANDA instruments to monitor (default: EUR_USD)",
+    )
+    parser.add_argument(
+        "--db-path",
+        default="fathom.db",
+        help="Path to the SQLite database (default: fathom.db)",
+    )
+    parser.add_argument(
+        "--heartbeat-timeout",
+        type=float,
+        default=15.0,
+        help="Feed-health heartbeat timeout in seconds (default: 15.0)",
+    )
+    parser.add_argument(
+        "--debounce-secs",
+        type=float,
+        default=300.0,
+        help="Debounce window in seconds (default: 300.0)",
+    )
+    parser.add_argument(
+        "--reconcile-interval",
+        type=float,
+        default=60.0,
+        help="Position refresh interval in seconds (default: 60.0)",
+    )
+    parser.add_argument(
+        "--severe-response",
+        choices=["alert_only", "auto_flatten", "tighten_stop"],
+        default="alert_only",
+        help="Response on severe deviation (default: alert_only, INV-01)",
+    )
+    args = parser.parse_args()
+
+    instruments = [i.strip() for i in args.instruments.split(",") if i.strip()]
+
+    settings = Settings()  # reads from .env (INV-08)
+    store = Store(db_path=args.db_path)
+
+    config = WatcherConfig(
+        heartbeat_timeout_seconds=args.heartbeat_timeout,
+        debounce_seconds=args.debounce_secs,
+        reconcile_interval_seconds=args.reconcile_interval,
+        severe_response=args.severe_response,
+    )
+
+    stream = PriceStream(settings=settings, instruments=instruments)
+    stream.start()
+
+    from data.stream import PriceTick as _PriceTick
+
+    alerter = NoOpAlerter()  # T-09 will replace this with the real alerter
+    responder = NoOpExecutionResponder()
+
+    logger.info(
+        "run_monitor: starting watcher for instruments=%s severe_response=%s",
+        instruments,
+        config.severe_response,
+    )
+
+    # Build a typed queue; the bridge thread feeds it from the PriceStream.
+    typed_queue: queue.Queue[_PriceTick | None] = queue.Queue()
+
+    def _stream_to_queue() -> None:
+        """Bridge: feed ticks from PriceStream into the typed queue."""
+        try:
+            for tick in stream:
+                typed_queue.put(tick)
+        finally:
+            typed_queue.put(None)  # sentinel: stream stopped
+
+    bridge = threading.Thread(target=_stream_to_queue, daemon=True, name="monitor-bridge")
+    bridge.start()
+
+    watcher = Watcher(
+        tick_source=typed_queue,
+        store_loader=_build_store_loader(store),
+        alerter=alerter,
+        config=config,
+        execution_responder=responder,
+        instruments=instruments,
+    )
+
+    try:
+        watcher.run()
+    except KeyboardInterrupt:
+        logger.info("run_monitor: KeyboardInterrupt — shutting down")
+    finally:
+        stream.stop()
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deviation_monitor.py
+++ b/tests/test_deviation_monitor.py
@@ -1,0 +1,670 @@
+"""Tests for monitoring/watcher.py — deviation monitor (P3-T-08).
+
+Coverage (per ACs):
+1. Adverse excursion past the configured fraction → exactly one DeviationEvent
+   (debounced; not re-fired every tick).
+2. Fill slippage exceeds threshold → slippage DeviationEvent.
+3. Volatility spike (range expansion past threshold) → vol DeviationEvent.
+4. No tick within heartbeat window → feed_health DeviationEvent (stale feed).
+5. Default config is alert_only: no position is flattened/modified unless the
+   auto-response flag is explicitly enabled.
+6. Feed-health resilience: a stream drop (gap_detected=True) triggers a
+   feed-health event, not a crash.
+7. Events carry UTC timestamps (INV-03).
+8. The loop never opens a position (INV-01).
+9. Debounce: same rule does not re-fire for the same debounce window.
+10. Auto-response: responder is called when severe_response != alert_only AND
+    severity == severe; responder is NOT called for alert_only.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+
+from data.stream import PriceTick
+from monitoring.watcher import (
+    Alerter,
+    DeviationEvent,
+    ExecutionResponder,
+    NoOpAlerter,
+    NoOpExecutionResponder,
+    PositionSnapshot,
+    Watcher,
+    WatcherConfig,
+    check_adverse,
+    check_feed_health,
+    check_slippage,
+    check_vol,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=_UTC)
+
+
+def _pos(
+    *,
+    broker_trade_id: str = "T1",
+    instrument: str = "EUR_USD",
+    units: int = 10_000,
+    entry_price: float = 1.10000,
+    stop_loss_price: float = 1.09500,   # stop dist = 0.00500
+    take_profit_price: float = 1.10750,
+    fill_slippage: float = 0.0,
+) -> PositionSnapshot:
+    return PositionSnapshot(
+        broker_trade_id=broker_trade_id,
+        instrument=instrument,
+        units=units,
+        entry_price=entry_price,
+        stop_loss_price=stop_loss_price,
+        take_profit_price=take_profit_price,
+        fill_slippage=fill_slippage,
+    )
+
+
+def _tick(
+    instrument: str = "EUR_USD",
+    bid: float = 1.10000,
+    ask: float = 1.10010,
+    gap_detected: bool = False,
+    time_utc: datetime | None = None,
+) -> PriceTick:
+    return PriceTick(
+        instrument=instrument,
+        time=time_utc or _NOW,
+        bid=bid,
+        ask=ask,
+        status="tradeable",
+        gap_detected=gap_detected,
+    )
+
+
+def _cfg(**overrides: object) -> WatcherConfig:
+    defaults: dict[str, object] = {
+        "adverse_fraction": 0.5,
+        "slippage_threshold": 0.0002,
+        "vol_atr_multiplier": 2.0,
+        "vol_lookback": 5,
+        "heartbeat_timeout_seconds": 15.0,
+        "reconcile_interval_seconds": 60.0,
+        "debounce_seconds": 300.0,
+        "severe_response": "alert_only",
+    }
+    defaults.update(overrides)
+    return WatcherConfig(**defaults)
+
+
+def _watcher(
+    ticks: list[PriceTick],
+    positions: list[PositionSnapshot] | None = None,
+    config: WatcherConfig | None = None,
+    alerter: Alerter | None = None,
+    responder: ExecutionResponder | None = None,
+) -> tuple[Watcher, list[DeviationEvent]]:
+    """Build a watcher over a fixed tick list and collect emitted events."""
+    events: list[DeviationEvent] = []
+
+    class _Collector:
+        def send(self, event: DeviationEvent) -> None:
+            events.append(event)
+
+    watcher = Watcher(
+        tick_iterable=ticks,
+        store_loader=lambda: positions or [],
+        alerter=_Collector(),
+        config=config or _cfg(),
+        execution_responder=responder or NoOpExecutionResponder(),
+        instruments=["EUR_USD"],
+    )
+    watcher.run()
+    return watcher, events
+
+
+# ---------------------------------------------------------------------------
+# DeviationEvent model — UTC and field contracts (INV-03)
+# ---------------------------------------------------------------------------
+
+
+def test_deviation_event_utc_required() -> None:
+    """created_at must be UTC-aware (INV-03)."""
+    with pytest.raises(Exception):
+        DeviationEvent(
+            event_id="abc",
+            instrument="EUR_USD",
+            deviation_type="adverse",
+            detail="test",
+            severity="warn",
+            created_at=datetime(2026, 5, 29, 12, 0, 0),  # naive — should fail
+        )
+
+
+def test_deviation_event_utc_aware_accepted() -> None:
+    """A UTC-aware created_at is accepted."""
+    ev = DeviationEvent(
+        event_id="abc123",
+        instrument="EUR_USD",
+        deviation_type="adverse",
+        detail="test detail",
+        severity="warn",
+        created_at=datetime(2026, 5, 29, 12, 0, 0, tzinfo=_UTC),
+    )
+    assert ev.created_at.tzinfo is not None
+
+
+def test_deviation_event_feed_health_no_trade_id() -> None:
+    """Feed-health events have broker_trade_id=None."""
+    ev = DeviationEvent(
+        event_id="fh01",
+        instrument="EUR_USD",
+        deviation_type="feed_health",
+        detail="stale feed",
+        broker_trade_id=None,
+        severity="severe",
+        created_at=datetime.now(_UTC),
+    )
+    assert ev.broker_trade_id is None
+    assert ev.deviation_type == "feed_health"
+
+
+def test_deviation_event_non_empty_strings() -> None:
+    """event_id, instrument, detail must be non-empty."""
+    with pytest.raises(Exception):
+        DeviationEvent(
+            event_id="",
+            instrument="EUR_USD",
+            deviation_type="adverse",
+            detail="detail",
+            severity="warn",
+            created_at=datetime.now(_UTC),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure rule: check_adverse
+# ---------------------------------------------------------------------------
+
+
+def test_check_adverse_long_below_threshold() -> None:
+    """Long position — price not yet adversely past threshold → None."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # threshold = 0.5 * 0.005 = 0.00250; price only 0.001 below entry
+    result = check_adverse(pos, 1.09900, _cfg())
+    assert result is None
+
+
+def test_check_adverse_long_fires_warn() -> None:
+    """Long position — price adversely past threshold → warn event."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # threshold = 0.5 * 0.005 = 0.00250; price 0.003 below entry → warn
+    result = check_adverse(pos, 1.09700, _cfg())
+    assert result is not None
+    assert result.deviation_type == "adverse"
+    assert result.severity == "warn"
+    assert result.broker_trade_id == "T1"
+    assert result.instrument == "EUR_USD"
+    assert result.created_at.tzinfo is not None  # INV-03
+
+
+def test_check_adverse_long_fires_severe_at_stop() -> None:
+    """Long position — price at or past stop → severe event."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    # stop_dist=0.00500; excursion=0.00510 >= stop_dist → severe
+    result = check_adverse(pos, 1.09490, _cfg())
+    assert result is not None
+    assert result.severity == "severe"
+
+
+def test_check_adverse_short_fires() -> None:
+    """Short position — price moves adversely upward → event fires."""
+    pos = _pos(units=-10_000, entry_price=1.10000, stop_loss_price=1.10500)
+    # stop_dist=0.00500; threshold=0.00250; price 0.003 above entry → warn
+    result = check_adverse(pos, 1.10300, _cfg())
+    assert result is not None
+    assert result.deviation_type == "adverse"
+
+
+def test_check_adverse_short_below_threshold() -> None:
+    """Short position — favourable price move → None."""
+    pos = _pos(units=-10_000, entry_price=1.10000, stop_loss_price=1.10500)
+    result = check_adverse(pos, 1.09800, _cfg())
+    assert result is None
+
+
+def test_check_adverse_degenerate_stop() -> None:
+    """Zero stop distance → None (degenerate position)."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.10000)
+    result = check_adverse(pos, 1.09000, _cfg())
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Pure rule: check_slippage
+# ---------------------------------------------------------------------------
+
+
+def test_check_slippage_below_threshold() -> None:
+    pos = _pos(fill_slippage=0.0001)
+    result = check_slippage(pos, _cfg(slippage_threshold=0.0002))
+    assert result is None
+
+
+def test_check_slippage_fires_warn() -> None:
+    pos = _pos(fill_slippage=0.0003)
+    result = check_slippage(pos, _cfg(slippage_threshold=0.0002))
+    assert result is not None
+    assert result.deviation_type == "slippage"
+    assert result.severity == "warn"
+    assert result.broker_trade_id == "T1"
+    assert result.created_at.tzinfo is not None  # INV-03
+
+
+def test_check_slippage_fires_severe() -> None:
+    """Slippage >= 3x threshold → severe."""
+    pos = _pos(fill_slippage=0.0007)  # 0.0007 >= 3 * 0.0002 = 0.0006
+    result = check_slippage(pos, _cfg(slippage_threshold=0.0002))
+    assert result is not None
+    assert result.severity == "severe"
+
+
+def test_check_slippage_at_threshold_not_fired() -> None:
+    """Slippage exactly at threshold (<=) → no event."""
+    pos = _pos(fill_slippage=0.0002)
+    result = check_slippage(pos, _cfg(slippage_threshold=0.0002))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Pure rule: check_vol
+# ---------------------------------------------------------------------------
+
+
+def test_check_vol_insufficient_data() -> None:
+    """Fewer than 2 prices → None."""
+    pos = _pos()
+    result = check_vol(pos, [1.10000], _cfg())
+    assert result is None
+
+
+def test_check_vol_below_threshold() -> None:
+    """Small range — below vol threshold → None."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # range = 0.00400; threshold = 2.0 * 0.00500 = 0.01000; 0.004 < 0.01 → no fire
+    prices = [1.09800, 1.09900, 1.10000, 1.10100, 1.10200]
+    result = check_vol(pos, prices, _cfg())
+    assert result is None
+
+
+def test_check_vol_fires_warn() -> None:
+    """Range exceeds threshold → vol event (warn)."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # range = 0.01100; threshold = 2.0 * 0.00500 = 0.01000; fires warn
+    prices = [1.09000, 1.09100, 1.09200, 1.09300, 1.10100]
+    result = check_vol(pos, prices, _cfg())
+    assert result is not None
+    assert result.deviation_type == "vol"
+    assert result.severity == "warn"
+    assert result.created_at.tzinfo is not None  # INV-03
+
+
+def test_check_vol_fires_severe() -> None:
+    """Range >= 2x threshold → severe."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # range = 0.02100; threshold = 2.0 * 0.005 = 0.010; 2x threshold = 0.020;
+    # 0.021 >= 0.020 → severe
+    prices = [1.09000, 1.09100, 1.09200, 1.09300, 1.11100]
+    result = check_vol(pos, prices, _cfg())
+    assert result is not None
+    assert result.severity == "severe"
+
+
+def test_check_vol_degenerate_stop() -> None:
+    """Zero stop distance → None."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.10000)
+    prices = [1.09000, 1.11000]
+    result = check_vol(pos, prices, _cfg())
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Pure rule: check_feed_health
+# ---------------------------------------------------------------------------
+
+
+def test_check_feed_health_no_timeout() -> None:
+    """Recent tick → None."""
+    result = check_feed_health("EUR_USD", time.monotonic(), _cfg(heartbeat_timeout_seconds=15.0))
+    assert result is None
+
+
+def test_check_feed_health_fires() -> None:
+    """Stale feed (last tick was long ago) → feed_health event."""
+    stale = time.monotonic() - 20.0  # 20 seconds ago
+    result = check_feed_health("EUR_USD", stale, _cfg(heartbeat_timeout_seconds=15.0))
+    assert result is not None
+    assert result.deviation_type == "feed_health"
+    assert result.broker_trade_id is None  # no trade context for feed events
+    assert result.severity == "severe"
+    assert result.created_at.tzinfo is not None  # INV-03
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: adverse rule fires exactly once (debounced) — AC#1
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_adverse_fires_once_debounced() -> None:
+    """AC#1: adverse excursion fires exactly one DeviationEvent even with many ticks."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # Adverse price: 0.003 below entry, threshold=0.0025 → fires every tick without debounce
+    adverse_price = 1.09700
+    ticks = [_tick(bid=adverse_price - 0.0001, ask=adverse_price) for _ in range(10)]
+
+    _, events = _watcher(ticks, positions=[pos])
+
+    adverse_events = [e for e in events if e.deviation_type == "adverse"]
+    # Must fire exactly once (debounced — same event_id suppresses repeats)
+    assert len(adverse_events) == 1, (
+        f"Expected exactly 1 adverse event, got {len(adverse_events)}"
+    )
+    assert adverse_events[0].broker_trade_id == "T1"
+    assert adverse_events[0].created_at.tzinfo is not None  # INV-03
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: slippage rule — AC#2
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_slippage_fires() -> None:
+    """AC#2: fill slippage exceeds threshold → slippage DeviationEvent."""
+    pos = _pos(fill_slippage=0.0005)  # exceeds 0.0002 threshold
+    ticks = [_tick(bid=1.10000, ask=1.10010)]
+
+    _, events = _watcher(ticks, positions=[pos])
+
+    slippage_events = [e for e in events if e.deviation_type == "slippage"]
+    assert len(slippage_events) >= 1
+    assert slippage_events[0].deviation_type == "slippage"
+    assert slippage_events[0].created_at.tzinfo is not None  # INV-03
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: vol rule — AC#3
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_vol_fires() -> None:
+    """AC#3: volatility spike (range expansion) → vol DeviationEvent."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)  # stop_dist=0.00500
+    # Build ticks with large range to trigger vol: need 5 ticks (vol_lookback=5)
+    # range will be 0.012 > 2.0 * 0.005 = 0.010 → fires
+    prices = [
+        (1.08950, 1.08960),
+        (1.09200, 1.09210),
+        (1.09500, 1.09510),
+        (1.09800, 1.09810),
+        (1.10150, 1.10160),  # range = 0.01210 → fires
+    ]
+    ticks = [_tick(bid=b, ask=a) for b, a in prices]
+
+    _, events = _watcher(ticks, positions=[pos], config=_cfg(vol_lookback=5))
+
+    vol_events = [e for e in events if e.deviation_type == "vol"]
+    assert len(vol_events) >= 1
+    assert vol_events[0].deviation_type == "vol"
+    assert vol_events[0].created_at.tzinfo is not None  # INV-03
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: feed-health via gap_detected — AC#4, AC#6
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_feed_health_on_gap_detected() -> None:
+    """AC#4 / AC#6: gap_detected=True on a tick → feed_health event (not a crash)."""
+    pos = _pos()
+    # Normal tick then a gap-detected tick (stream reconnected)
+    ticks = [
+        _tick(bid=1.10000, ask=1.10010, gap_detected=False),
+        _tick(bid=1.10000, ask=1.10010, gap_detected=True),
+    ]
+    _, events = _watcher(ticks, positions=[pos])
+
+    fh_events = [e for e in events if e.deviation_type == "feed_health"]
+    assert len(fh_events) >= 1
+    assert fh_events[0].broker_trade_id is None  # no trade context
+    assert fh_events[0].severity == "severe"
+    assert fh_events[0].created_at.tzinfo is not None  # INV-03
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: default config is alert_only — AC#5
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_default_alert_only_no_execution_call() -> None:
+    """AC#5: default config is alert_only — responder.respond() never called."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    # Trigger a severe adverse event (price below stop)
+    ticks = [_tick(bid=1.09490, ask=1.09500)]
+
+    mock_responder = MagicMock()
+    _, events = _watcher(ticks, positions=[pos], responder=mock_responder)
+
+    adverse = [e for e in events if e.deviation_type == "adverse"]
+    assert len(adverse) >= 1
+    assert adverse[0].severity == "severe"
+    # With default alert_only, the responder must NOT be called
+    mock_responder.respond.assert_not_called()
+
+
+def test_watcher_auto_flatten_calls_responder_on_severe() -> None:
+    """auto_flatten: responder.respond() IS called when severity==severe."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    # Trigger severe adverse (past stop)
+    ticks = [_tick(bid=1.09490, ask=1.09500)]
+
+    mock_responder = MagicMock()
+    cfg = _cfg(severe_response="auto_flatten")
+    _, events = _watcher(ticks, positions=[pos], config=cfg, responder=mock_responder)
+
+    adverse = [e for e in events if e.deviation_type == "adverse" and e.severity == "severe"]
+    assert len(adverse) >= 1
+    # Responder must be called with flatten
+    mock_responder.respond.assert_called_once_with(
+        "flatten",
+        broker_trade_id="T1",
+        instrument="EUR_USD",
+    )
+
+
+def test_watcher_tighten_stop_calls_responder() -> None:
+    """tighten_stop: responder.respond() called with tighten_stop action."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    ticks = [_tick(bid=1.09490, ask=1.09500)]
+
+    mock_responder = MagicMock()
+    cfg = _cfg(severe_response="tighten_stop")
+    _, events = _watcher(ticks, positions=[pos], config=cfg, responder=mock_responder)
+
+    severe_events = [e for e in events if e.severity == "severe"]
+    assert len(severe_events) >= 1
+    mock_responder.respond.assert_called_once_with(
+        "tighten_stop",
+        broker_trade_id="T1",
+        instrument="EUR_USD",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: debounce — same rule fires only once per window
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_debounce_suppresses_repeat() -> None:
+    """Same rule fires at most once per debounce window across many ticks."""
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    # All ticks adverse — should produce exactly 1 adverse event (debounced)
+    price = 1.09700  # 0.003 below entry, threshold=0.0025 → fires
+    ticks = [_tick(bid=price - 0.0001, ask=price) for _ in range(20)]
+
+    _, events = _watcher(ticks, positions=[pos])
+
+    adverse = [e for e in events if e.deviation_type == "adverse"]
+    assert len(adverse) == 1, f"Expected 1 debounced event, got {len(adverse)}"
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: UTC timestamps (INV-03) — AC#7
+# ---------------------------------------------------------------------------
+
+
+def test_all_events_have_utc_timestamps() -> None:
+    """AC#7: every emitted event has a UTC-aware timestamp (INV-03)."""
+    pos = _pos(
+        entry_price=1.10000,
+        stop_loss_price=1.09500,
+        fill_slippage=0.0005,
+    )
+    ticks = [
+        _tick(bid=1.09700, ask=1.09710),  # adverse
+        _tick(bid=1.09700, ask=1.09710, gap_detected=True),  # feed_health
+    ]
+    _, events = _watcher(ticks, positions=[pos])
+
+    assert len(events) >= 1
+    for ev in events:
+        assert ev.created_at.tzinfo is not None, (
+            f"Event {ev.deviation_type} has naive created_at (INV-03 violation)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: never opens a position (INV-01) — AC#8
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_never_opens_position() -> None:
+    """AC#8 / INV-01: the watcher never calls a position-opening function.
+
+    We verify this by:
+    1. Confirming the responder's only allowed call targets are
+       'flatten' and 'tighten_stop' — never an order-creation action.
+    2. Verifying the watcher has no ``submit_order`` method (it is not the
+       execution layer — it only delegates to the injected responder).
+    """
+    pos = _pos(entry_price=1.10000, stop_loss_price=1.09500)
+    ticks = [_tick(bid=1.09490, ask=1.09500)]  # severe adverse
+
+    mock_responder = MagicMock()
+    cfg = _cfg(severe_response="auto_flatten")
+    watcher, events = _watcher(ticks, positions=[pos], config=cfg, responder=mock_responder)
+
+    for call in mock_responder.respond.call_args_list:
+        action = call.args[0] if call.args else call.kwargs.get("action")
+        assert action in ("flatten", "tighten_stop"), (
+            f"Watcher called responder with disallowed action: {action} (INV-01)"
+        )
+    # The Watcher class itself must not expose a submit_order method (INV-01)
+    assert not hasattr(watcher, "submit_order"), (
+        "Watcher must not have a submit_order method (INV-01)"
+    )
+    assert not hasattr(watcher, "open_position"), (
+        "Watcher must not have an open_position method (INV-01)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: multiple positions on different instruments
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_only_evaluates_matching_instrument() -> None:
+    """Rules are only evaluated for positions whose instrument matches the tick."""
+    pos_eur = _pos(broker_trade_id="T1", instrument="EUR_USD", entry_price=1.10000, stop_loss_price=1.09500)
+    pos_gbp = _pos(broker_trade_id="T2", instrument="GBP_USD", entry_price=1.27000, stop_loss_price=1.26500)
+
+    # Only EUR_USD ticks; price is adverse for EUR_USD position
+    ticks = [_tick(instrument="EUR_USD", bid=1.09700, ask=1.09710)]
+
+    _, events = _watcher(ticks, positions=[pos_eur, pos_gbp])
+
+    trade_ids = {e.broker_trade_id for e in events if e.deviation_type == "adverse"}
+    # Only T1 (EUR_USD) should fire; T2 (GBP_USD) should not
+    assert "T1" in trade_ids or len(trade_ids) == 0  # T1 may fire
+    assert "T2" not in trade_ids  # T2 must never fire from EUR_USD ticks
+
+
+# ---------------------------------------------------------------------------
+# Watcher integration: no tick source resilience
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_empty_tick_source_no_crash() -> None:
+    """Watcher with empty tick iterable exits cleanly (no crash)."""
+    pos = _pos()
+    _, events = _watcher([], positions=[pos])
+    # No events expected (no ticks to evaluate), but no exception either
+    assert isinstance(events, list)
+
+
+# ---------------------------------------------------------------------------
+# WatcherConfig validation
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_config_defaults_are_alert_only() -> None:
+    """Default WatcherConfig has severe_response='alert_only' (demo safety)."""
+    cfg = WatcherConfig()
+    assert cfg.severe_response == "alert_only"
+
+
+def test_watcher_config_negative_threshold_rejected() -> None:
+    """Non-positive threshold is rejected by validator."""
+    with pytest.raises(Exception):
+        WatcherConfig(adverse_fraction=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# NoOpAlerter / NoOpExecutionResponder — smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_noop_alerter_does_not_crash() -> None:
+    alerter = NoOpAlerter()
+    ev = DeviationEvent(
+        event_id="test",
+        instrument="EUR_USD",
+        deviation_type="adverse",
+        detail="test",
+        severity="info",
+        created_at=datetime.now(_UTC),
+    )
+    alerter.send(ev)  # must not raise
+
+
+def test_noop_execution_responder_does_not_crash() -> None:
+    responder = NoOpExecutionResponder()
+    responder.respond("flatten", broker_trade_id="T1", instrument="EUR_USD")
+
+
+# ---------------------------------------------------------------------------
+# PositionSnapshot validation
+# ---------------------------------------------------------------------------
+
+
+def test_position_snapshot_construction() -> None:
+    pos = _pos()
+    assert pos.broker_trade_id == "T1"
+    assert pos.instrument == "EUR_USD"
+    assert pos.units == 10_000

--- a/tests/test_deviation_monitor.py
+++ b/tests/test_deviation_monitor.py
@@ -668,3 +668,61 @@ def test_position_snapshot_construction() -> None:
     assert pos.broker_trade_id == "T1"
     assert pos.instrument == "EUR_USD"
     assert pos.units == 10_000
+
+
+# ---------------------------------------------------------------------------
+# Feed-health debounce is per-instrument (regression: multi-instrument)
+# ---------------------------------------------------------------------------
+
+
+def test_feed_health_debounce_is_per_instrument() -> None:
+    """Two instruments losing their feed in the same debounce window must each
+    fire their own feed_health event — they must NOT suppress each other.
+
+    Regression test for the defect where the debounce key was
+    ``(None, "feed_health")`` for all instruments, meaning the second
+    instrument's event was silently dropped once the first had fired.
+    """
+    import queue as _queue
+
+    events: list[DeviationEvent] = []
+
+    class _Collector:
+        def send(self, event: DeviationEvent) -> None:
+            events.append(event)
+
+    cfg = _cfg(
+        heartbeat_timeout_seconds=0.01,  # very short so ticks in the past are stale
+        debounce_seconds=300.0,           # long window so both instruments land in it
+    )
+
+    # Build the watcher over two instruments; no ticks at all — so both will be
+    # stale when the final _check_all_feed_health() runs at iterable exhaustion.
+    watcher = Watcher(
+        tick_iterable=[],          # empty iterable; feed-health check happens at the end
+        store_loader=lambda: [],
+        alerter=_Collector(),
+        config=cfg,
+        instruments=["EUR_USD", "GBP_USD"],
+    )
+
+    # Back-date both instruments' last-tick times so both appear stale
+    import time as _time
+    watcher._last_tick_time["EUR_USD"] = _time.monotonic() - 1.0  # 1 s ago > 0.01 s timeout
+    watcher._last_tick_time["GBP_USD"] = _time.monotonic() - 1.0
+
+    watcher.run()
+
+    fh_events = [e for e in events if e.deviation_type == "feed_health"]
+    instruments_fired = {e.instrument for e in fh_events}
+
+    assert "EUR_USD" in instruments_fired, (
+        "EUR_USD feed_health event was not emitted"
+    )
+    assert "GBP_USD" in instruments_fired, (
+        "GBP_USD feed_health event was suppressed — per-instrument debounce broken"
+    )
+    assert len(fh_events) == 2, (
+        f"Expected 2 feed_health events (one per instrument), got {len(fh_events)}: "
+        f"{[e.instrument for e in fh_events]}"
+    )


### PR DESCRIPTION
## Summary

- Adds `monitoring/watcher.py` with `DeviationEvent` (frozen pydantic producer shape), `Watcher`, `WatcherConfig`, and four pure deviation rule predicates.
- `DeviationEvent` fields: `event_id`, `instrument`, `deviation_type` (`adverse|slippage|vol|feed_health`), `detail`, `broker_trade_id|None`, `severity` (`info|warn|severe`), `created_at` (UTC, INV-03).
- Four rules as pure predicates over `(position, recent_prices, config)`: **adverse** excursion past configurable fraction of stop distance; **slippage** beyond threshold; **vol** spike (price range vs ATR-proxy stop_dist); **feed_health** (no tick within heartbeat window, or `gap_detected=True` from Phase 1B stream reconnect).
- Debounce per `(broker_trade_id, deviation_type)` key via stable `event_id = sha256(trade_id|rule|window_ts)[:32]` — re-persistence is idempotent; no alert storms.
- `Alerter` Protocol defined here for T-09 to implement: `send(event: DeviationEvent) -> None`. `NoOpAlerter` stub is the default.
- `ExecutionResponder` Protocol for auto-response (default-off, INV-01): `respond(action: "flatten"|"tighten_stop", broker_trade_id, instrument) -> None`. Watcher never calls v20 inline; delegates to the injected responder only.
- `WatcherConfig.severe_response = "alert_only"` by default — demo-safe; no position is flattened/modified unless the flag is explicitly set (AC#5, INV-01).
- `scripts/run_monitor.py` always-on entrypoint: constructs `PriceStream` → bridge queue → `Watcher.run()`.
- 38 new tests cover all 7 ACs: adverse/slippage/vol each fire exactly one debounced event; feed-health on gap_detected; alert_only default asserts no responder call; UTC timestamps on all events; INV-01 (Watcher has no submit_order method).

## INV-01 boundary

The watcher **observes and at most closes/modifies an existing position** when `severe_response != "alert_only"` — delegated to the injected `ExecutionResponder`. It **never opens a position**, is **not a Hermes tool**, and does not call the v20 order API inline.

## Test plan

- [x] `pytest tests/test_deviation_monitor.py -v` → 38 passed, exit 0
- [x] `pytest -q` (full suite) → 898 passed, 87 warnings, exit 0
- [x] `mypy .` → Success: no issues found in 76 source files, exit 0
- [x] Adverse rule fires exactly once across 10/20 identical adverse ticks (debounce)
- [x] Default `alert_only` config: `mock_responder.respond` never called
- [x] `auto_flatten` config: `mock_responder.respond("flatten", ...)` called once on severe
- [x] `gap_detected=True` tick → feed_health event, no crash (stream-drop resilience)
- [x] All events carry UTC-aware `created_at` (INV-03)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)