### PR TITLE
P3-T-09: monitor-alerts (DiscordWebhookClient + deviation_log)

### DIFF
--- a/.claude/context/monitoring.md
+++ b/.claude/context/monitoring.md
@@ -95,3 +95,74 @@ Per `(broker_trade_id, deviation_type)` key; suppresses repeats within the same
 - No new CLI command.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P3-T-09 — monitor-alerts — 2026-05-29 (feat/p3-T-09-alerts)
+
+**What was done:**
+
+Added the deviation monitor delivery layer:
+- `monitoring/alerts.py` — `DiscordWebhookClient` (thin `httpx` POST wrapper), `format_alert`
+  (pure formatter), `Alerter` (persist-then-deliver with retry), `build_alerter_from_settings`
+  factory. Satisfies the `monitoring.watcher.Alerter` Protocol duck-typed.
+- `data/store.py` — `_CREATE_DEVIATION_LOG_SQL`, `_INSERT_DEVIATION_LOG_SQL`,
+  `_MARK_DELIVERED_SQL` + three methods: `write_deviation_event`, `mark_deviation_delivered`,
+  `load_deviation_log`. Table created in `_create_tables()` alongside existing tables.
+- `config/settings.py` — Added `discord_webhook_url: Optional[SecretStr] = None` (INV-08).
+- `.env.example` — Added `DISCORD_WEBHOOK_URL=your-discord-webhook-url-here` placeholder.
+- `tests/test_monitor_alerts.py` — 33 new tests (all green).
+
+**deviation_log table schema (pinned by docs/features/monitor-alerts.md DRIFT-08):**
+```sql
+CREATE TABLE IF NOT EXISTS deviation_log (
+    event_id         TEXT NOT NULL PRIMARY KEY,  -- idempotent on INSERT OR IGNORE
+    instrument       TEXT NOT NULL,
+    deviation_type   TEXT NOT NULL,              -- adverse|slippage|vol|feed_health
+    detail           TEXT NOT NULL,
+    broker_trade_id  TEXT,                       -- NULL for feed_health events
+    severity         TEXT NOT NULL,              -- info|warn|severe
+    created_at       TEXT NOT NULL,              -- UTC RFC-3339 (INV-03)
+    delivered        INTEGER NOT NULL DEFAULT 0  -- set to 1 after successful POST
+)
+```
+
+**Persist-then-deliver contract:**
+1. `write_deviation_event(event)` — `INSERT OR IGNORE` on `event_id`; row exists before HTTP.
+2. `format_alert(event)` → `"⚠️ <instrument> <type> | <detail> | <UTC RFC-3339>"` (one line).
+3. `webhook.post(message)` — retried up to `max_retries` times with exponential backoff (`backoff_base × 2^attempt`).
+4. On success: `mark_deviation_delivered(event_id)` sets `delivered=1`.
+5. On full retry exhaustion: log WARNING, return without raising (loop never crashes).
+
+**DRIFT-06 resolution:**
+The monitor is a standalone Python process (`scripts/run_monitor.py`), NOT a Hermes job.
+It posts directly to `DISCORD_WEBHOOK_URL` via `DiscordWebhookClient`. No "Hermes gateway"
+Python object exists. Same channel as Phase 2 watchlist (same `DISCORD_WEBHOOK_URL`).
+
+**Key patterns / gotchas:**
+- `DiscordWebhookClient.__init__` accepts the raw URL string (caller extracts from
+  `SecretStr.get_secret_value()`). The URL is stored in `_url` (private) and NEVER logged.
+- `Alerter` constructor accepts `backoff_base=0.0` for tests (no real `time.sleep` in tests).
+- `WebhookClientProtocol` is a structural Protocol — tests inject stub classes without
+  inheriting from it. `DiscordWebhookClient` also does not inherit (duck-typed).
+- `build_alerter_from_settings(store)` is the live factory; raises `ValueError` if
+  `DISCORD_WEBHOOK_URL` is absent from `.env` at runtime.
+- `store.write_deviation_event` returns `True` (new insert) or `False` (idempotent no-op).
+- `store.load_deviation_log(undelivered_only=True)` enables catch-up delivery passes.
+- The `TYPE_CHECKING`-guarded `from monitoring.watcher import DeviationEvent` in `store.py`
+  avoids a runtime cycle while enabling the type annotation on `write_deviation_event`.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_monitor_alerts.py -v` → **33 passed**, exit 0
+- `python -m pytest -q` (full suite) → **932 passed, 87 warnings**, exit 0
+- `python -m mypy .` → **"Success: no issues found in 78 source files"**, exit 0
+
+**New dependency added to pyproject.toml?** NO — `httpx` was already in deps.
+`DISCORD_WEBHOOK_URL` added to `config/settings.py` (Optional[SecretStr]) + `.env.example`.
+
+**CLAUDE.md trigger-table check:**
+- `discord_webhook_url` added to Settings → `.env.example` updated (drift-guard test passes).
+- No new library dep. No new CLI command.
+- CLAUDE.md Stack: no update needed (httpx already listed).
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ OANDA_ACCOUNT_ID=your-oanda-account-id-here
 # "live" targets https://api-fxtrade.oanda.com
 # OANDA_BASE_URL is derived automatically from ENV — you do not need to set it.
 ENV=demo
+
+# Discord webhook URL for alert delivery (deviation monitor T-09 + Phase 2 watchlist).
+# Required at runtime by the deviation monitor and the Hermes watchlist job.
+# Leave blank (or omit) for backtest-only runs that do not need Discord delivery.
+# INV-08: never commit the real URL — this is a placeholder only.
+DISCORD_WEBHOOK_URL=your-discord-webhook-url-here

--- a/config/settings.py
+++ b/config/settings.py
@@ -9,7 +9,7 @@ Usage:
     token = settings.oanda_api_token.get_secret_value()  # explicit secret access
 """
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -30,6 +30,11 @@ class Settings(BaseSettings):
     Optional fields (have sensible defaults):
         ENV               — "demo" (default) or "live"
         OANDA_BASE_URL    — auto-derived from ENV; only override if you know what you're doing
+        DISCORD_WEBHOOK_URL — Discord webhook URL for alert/watchlist delivery (SecretStr);
+                              required at runtime by the deviation monitor alerter (T-09) and
+                              the Phase 2 Hermes watchlist job.  Optional here so the Settings
+                              model can be constructed in contexts that do not need Discord
+                              (e.g. backtest-only runs). INV-08: stored as SecretStr, never logged.
     """
 
     model_config = SettingsConfigDict(
@@ -42,6 +47,7 @@ class Settings(BaseSettings):
     oanda_api_token: SecretStr
     oanda_account_id: str
     oanda_base_url: str = ""
+    discord_webhook_url: Optional[SecretStr] = None
 
     @model_validator(mode="after")
     def derive_base_url(self) -> "Settings":

--- a/data/store.py
+++ b/data/store.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from backtest.walkforward import ApprovedSetEntry
     from signals.ranker import Candidate
     from execution.models import Fill, Order, Position
+    from monitoring.watcher import DeviationEvent
 
 
 # ---------------------------------------------------------------------------
@@ -301,6 +302,48 @@ class Store:
             (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
 
+    # ------------------------------------------------------------------
+    # deviation_log table (Phase 3 — monitor-alerts T-09 owns this migration).
+    # Column list is pinned by docs/features/monitor-alerts.md (DRIFT-08).
+    # ``event_id`` is the stable PK so re-persisting the same event is
+    # idempotent (INSERT OR IGNORE).  All timestamps are UTC RFC 3339 (INV-03).
+    # ``delivered`` is stored as INTEGER (0/1); set to 1 after a successful POST.
+    # ------------------------------------------------------------------
+
+    #: SQL to create the ``deviation_log`` table if it does not already exist.
+    #: Column list is pinned by docs/features/monitor-alerts.md.
+    _CREATE_DEVIATION_LOG_SQL: str = """
+        CREATE TABLE IF NOT EXISTS deviation_log (
+            event_id         TEXT    NOT NULL PRIMARY KEY,
+            instrument       TEXT    NOT NULL,
+            deviation_type   TEXT    NOT NULL,
+            detail           TEXT    NOT NULL,
+            broker_trade_id  TEXT,
+            severity         TEXT    NOT NULL,
+            created_at       TEXT    NOT NULL,
+            delivered        INTEGER NOT NULL DEFAULT 0
+        )
+    """
+
+    #: Insert one deviation_log row.  ``INSERT OR IGNORE`` is the idempotency
+    #: guarantee: re-persisting the same ``event_id`` is a no-op (the existing
+    #: row is kept as-is, preserving the original ``created_at`` / ``delivered``
+    #: state from the first persistence — the watcher's "durable truth" posture).
+    _INSERT_DEVIATION_LOG_SQL: str = """
+        INSERT OR IGNORE INTO deviation_log
+            (event_id, instrument, deviation_type, detail,
+             broker_trade_id, severity, created_at, delivered)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    #: Mark a deviation_log row as delivered after a successful Discord POST.
+    _MARK_DELIVERED_SQL: str = """
+        UPDATE deviation_log
+        SET    delivered = 1
+        WHERE  event_id  = ?
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
     _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
@@ -353,8 +396,9 @@ class Store:
     # ------------------------------------------------------------------
 
     def _create_tables(self) -> None:
-        """Create the ``candles``, ``instruments``, ``approved_set``, and
-        ``watchlist`` tables if they do not already exist."""
+        """Create all tables (candles, instruments, approved_set, watchlist,
+        orders, fills, positions, account_state, deviation_log) if they do
+        not already exist."""
         self._conn.execute(self._CREATE_CANDLES_SQL)
         self._conn.execute(self._CREATE_INSTRUMENTS_SQL)
         self._conn.execute(self._CREATE_APPROVED_SET_SQL)
@@ -363,6 +407,7 @@ class Store:
         self._conn.execute(self._CREATE_FILLS_SQL)
         self._conn.execute(self._CREATE_POSITIONS_SQL)
         self._conn.execute(self._CREATE_ACCOUNT_STATE_SQL)
+        self._conn.execute(self._CREATE_DEVIATION_LOG_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -1239,6 +1284,112 @@ class Store:
             (float(start_of_day_equity), float(day_pl), _to_rfc3339(as_of)),
         )
         self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # deviation_log table (Phase 3 — monitor-alerts T-09; DRIFT-08)
+    # ------------------------------------------------------------------
+
+    def write_deviation_event(self, event: "DeviationEvent") -> bool:
+        """Persist a ``DeviationEvent`` to ``deviation_log`` (idempotent).
+
+        Uses ``INSERT OR IGNORE`` on the ``event_id`` PK: re-persisting the
+        same event is a no-op — the first persistence wins (the durable truth).
+        This is the "persist FIRST" guarantee: callers must invoke this before
+        any delivery attempt so the event is durable even if Discord is down.
+
+        Args:
+            event: The ``DeviationEvent`` to persist.
+
+        Returns:
+            ``True`` if the row was newly inserted; ``False`` if the event was
+            already present (idempotent no-op).  Callers can use this to skip
+            re-delivery of already-persisted events, but the primary use is
+            simply to guarantee durability.
+        """
+        cursor = self._conn.execute(
+            self._INSERT_DEVIATION_LOG_SQL,
+            (
+                event.event_id,
+                event.instrument,
+                event.deviation_type,
+                event.detail,
+                event.broker_trade_id,  # nullable — None stored as NULL
+                event.severity,
+                _to_rfc3339(event.created_at),  # UTC RFC 3339 (INV-03)
+                0,  # delivered=False until a successful POST
+            ),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def mark_deviation_delivered(self, event_id: str) -> None:
+        """Set ``delivered=True`` on a ``deviation_log`` row after successful POST.
+
+        Idempotent: marking the same event delivered twice is a no-op.
+
+        Args:
+            event_id: The stable PK of the deviation event to mark.
+        """
+        self._conn.execute(self._MARK_DELIVERED_SQL, (event_id,))
+        self._conn.commit()
+
+    def load_deviation_log(
+        self,
+        *,
+        undelivered_only: bool = False,
+        limit: int | None = None,
+    ) -> list[dict[str, object]]:
+        """Load deviation log rows as plain dicts.
+
+        Args:
+            undelivered_only: If ``True``, return only rows where
+                ``delivered=0``.  Useful for a catch-up delivery pass.
+            limit: Maximum number of rows to return (most recent first by
+                ``created_at`` descending).  ``None`` returns all rows.
+
+        Returns:
+            A list of dicts with keys matching the ``deviation_log`` column
+            names (``event_id``, ``instrument``, ``deviation_type``,
+            ``detail``, ``broker_trade_id``, ``severity``, ``created_at``,
+            ``delivered`` as ``bool``).  Empty list when no rows match.
+        """
+        where_clause = "WHERE delivered = 0" if undelivered_only else ""
+        limit_clause = f"LIMIT {limit}" if limit is not None else ""
+        cursor = self._conn.execute(
+            f"""
+            SELECT event_id, instrument, deviation_type, detail,
+                   broker_trade_id, severity, created_at, delivered
+            FROM   deviation_log
+            {where_clause}
+            ORDER  BY created_at DESC
+            {limit_clause}
+            """
+        )
+        result: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            (
+                event_id,
+                instrument,
+                deviation_type,
+                detail,
+                broker_trade_id,
+                severity,
+                created_at,
+                delivered_int,
+            ) = row
+            result.append(
+                {
+                    "event_id": event_id,
+                    "instrument": instrument,
+                    "deviation_type": deviation_type,
+                    "detail": detail,
+                    "broker_trade_id": broker_trade_id,  # None if NULL
+                    "severity": severity,
+                    "created_at": created_at,
+                    "delivered": bool(delivered_int),
+                }
+            )
+        return result
 
     # ------------------------------------------------------------------
     # Parquet archive

--- a/monitoring/alerts.py
+++ b/monitoring/alerts.py
@@ -1,0 +1,318 @@
+"""Deviation monitor delivery layer — DiscordWebhookClient + Alerter (P3-T-09).
+
+Turns a ``DeviationEvent`` (from ``monitoring/watcher.py``) into a one-line
+Discord alert posted directly to ``DISCORD_WEBHOOK_URL``.  This is the same
+channel the Phase 2 watchlist uses (DRIFT-06 resolution: the monitor is a
+standalone Python process, not a Hermes job — it posts directly via
+``DiscordWebhookClient``, no Hermes gateway).
+
+Invariants
+----------
+* **INV-01** — outbound notification only; this module exposes no order /
+  execution capability and is NOT registered as a Hermes tool.  The Alerter
+  sends a Discord message and nothing else.
+* **INV-03** — every alert contains a UTC RFC 3339 timestamp; ``created_at``
+  is formatted with ``Z`` suffix.
+* **INV-08** — ``DISCORD_WEBHOOK_URL`` is read via ``Settings.discord_webhook_url``
+  (a ``SecretStr``).  The raw URL is NEVER printed, logged, or included in
+  the alert text.
+
+Delivery contract (DRIFT-06 + monitor-alerts spec)
+---------------------------------------------------
+1. **Persist FIRST** — ``Alerter.send`` writes the event to ``deviation_log``
+   before any HTTP attempt.  The event is durable even if Discord is down.
+2. **POST** — after persistence, POST the one-line formatted message to Discord.
+3. **Retry with backoff** — on HTTP failure, retry up to ``max_retries`` times
+   with exponential backoff (no jitter for simplicity; deterministic in tests).
+4. **Never raise into the caller** — a down Discord must not crash the monitor
+   loop.  Delivery failures are logged at WARNING; the event remains in
+   ``deviation_log`` with ``delivered=False`` for a catch-up pass.
+5. **Idempotent persistence** — ``write_deviation_event`` uses
+   ``INSERT OR IGNORE`` on ``event_id``; re-sending the same event is a no-op
+   at the store layer.
+6. **Mark delivered** — after a successful POST, ``mark_deviation_delivered``
+   sets ``delivered=True`` on the row.
+
+Alert format
+------------
+One line::
+
+    ⚠️ <instrument> <deviation_type> | <detail> | <UTC RFC-3339 time>
+
+Example::
+
+    ⚠️ EUR_USD adverse | adverse excursion 0.00300 (threshold 0.00250) | 2026-05-29T15:10:00Z
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Protocol
+
+import httpx
+
+from data.store import Store, _to_rfc3339
+from monitoring.watcher import DeviationEvent
+
+logger = logging.getLogger("fathom.monitoring.alerts")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Default number of retry attempts on delivery failure.
+DEFAULT_MAX_RETRIES: int = 3
+
+#: Base backoff in seconds; doubles on each retry (exponential, no jitter).
+DEFAULT_BACKOFF_BASE: float = 1.0
+
+#: httpx timeout for the Discord webhook POST.
+_HTTP_TIMEOUT: float = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Alert formatter — pure function, unit-testable
+# ---------------------------------------------------------------------------
+
+
+def format_alert(event: DeviationEvent) -> str:
+    """Format a ``DeviationEvent`` as a one-line Discord alert.
+
+    Format::
+
+        ⚠️ <instrument> <deviation_type> | <detail> | <UTC RFC-3339 time>
+
+    The UTC timestamp uses ``Z`` suffix (INV-03).  No secret appears in the
+    output (INV-08).
+
+    Args:
+        event: The deviation event to format.
+
+    Returns:
+        A single-line string suitable for a Discord webhook message.
+
+    Examples
+    --------
+    >>> from datetime import datetime, timezone
+    >>> from monitoring.watcher import DeviationEvent
+    >>> ev = DeviationEvent(
+    ...     event_id="abc123",
+    ...     instrument="EUR_USD",
+    ...     deviation_type="adverse",
+    ...     detail="adverse excursion 0.00300",
+    ...     severity="warn",
+    ...     created_at=datetime(2026, 5, 29, 15, 10, 0, tzinfo=timezone.utc),
+    ... )
+    >>> format_alert(ev)
+    '⚠️ EUR_USD adverse | adverse excursion 0.00300 | 2026-05-29T15:10:00Z'
+    """
+    ts = _to_rfc3339(event.created_at)
+    return f"⚠️ {event.instrument} {event.deviation_type} | {event.detail} | {ts}"
+
+
+# ---------------------------------------------------------------------------
+# WebhookClient protocol — lets tests inject a stub without live HTTP
+# ---------------------------------------------------------------------------
+
+
+class WebhookClientProtocol(Protocol):
+    """Minimal webhook client interface.  Tests inject a stub."""
+
+    def post(self, message: str) -> None:
+        """POST ``message`` to the configured webhook endpoint.
+
+        Raises:
+            httpx.HTTPStatusError: on a 4xx/5xx response (after raising_for_status).
+            httpx.RequestError: on a network / timeout error.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# DiscordWebhookClient — thin httpx POST wrapper (INV-08: URL never logged)
+# ---------------------------------------------------------------------------
+
+
+class DiscordWebhookClient:
+    """Thin ``httpx`` POST wrapper around ``DISCORD_WEBHOOK_URL``.
+
+    The webhook URL is accepted as a plain string (already extracted from
+    ``Settings.discord_webhook_url.get_secret_value()`` by the caller, so
+    this class never imports ``Settings`` itself — it is purely a transport
+    layer).
+
+    INV-08: the URL is stored in a private attribute and is NEVER logged,
+    printed, or included in alert text.
+
+    Args:
+        webhook_url: The raw Discord webhook URL (extracted from
+            ``Settings.discord_webhook_url.get_secret_value()``).
+        timeout: HTTP timeout in seconds (default: 10.0).
+    """
+
+    def __init__(self, webhook_url: str, *, timeout: float = _HTTP_TIMEOUT) -> None:
+        self._url = webhook_url  # INV-08: never log this
+        self._timeout = timeout
+
+    def post(self, message: str) -> None:
+        """POST ``message`` to Discord as ``{"content": message}``.
+
+        Raises:
+            httpx.HTTPStatusError: on a 4xx/5xx Discord response.
+            httpx.RequestError: on a network / timeout failure.
+        """
+        with httpx.Client(timeout=self._timeout) as client:
+            resp = client.post(self._url, json={"content": message})
+            resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# Alerter — implements the watcher's Alerter protocol with persist-then-deliver
+# ---------------------------------------------------------------------------
+
+
+class Alerter:
+    """Concrete ``Alerter`` implementing persist-then-deliver with retry.
+
+    Satisfies the ``monitoring.watcher.Alerter`` protocol (duck-typed —
+    no explicit inheritance needed, just ``send(event: DeviationEvent) -> None``).
+
+    Delivery contract:
+    1. Persist the event to ``deviation_log`` via ``store.write_deviation_event``
+       BEFORE any HTTP attempt (durable even if Discord is down).
+    2. Format the one-line alert via ``format_alert``.
+    3. POST via the injected ``webhook_client``.
+    4. On failure: retry with exponential backoff up to ``max_retries`` times.
+    5. After all retries exhausted: log a warning and return (never raise).
+    6. On success: call ``store.mark_deviation_delivered`` to set
+       ``delivered=True``.
+
+    Idempotency: ``write_deviation_event`` uses ``INSERT OR IGNORE`` on
+    ``event_id`` — re-calling ``send`` with the same event is a no-op at the
+    persistence layer (the first persistence wins).
+
+    INV-01: no order / execution capability exposed.
+    INV-08: no secret in logs (the webhook client holds the URL privately).
+
+    Args:
+        webhook_client: Any object with ``post(message: str) -> None``.
+            Use ``DiscordWebhookClient`` in production; inject a stub in tests.
+        store: The ``Store`` instance used to persist events.
+        max_retries: Maximum POST retry attempts (default: 3).
+        backoff_base: Base backoff seconds; doubles on each retry
+            (default: 1.0).  Pass 0.0 in tests to skip real sleeps.
+    """
+
+    def __init__(
+        self,
+        webhook_client: WebhookClientProtocol,
+        store: Store,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        backoff_base: float = DEFAULT_BACKOFF_BASE,
+    ) -> None:
+        self._webhook = webhook_client
+        self._store = store
+        self._max_retries = max_retries
+        self._backoff_base = backoff_base
+
+    def send(self, event: DeviationEvent) -> None:
+        """Persist and deliver one ``DeviationEvent`` (INV-01, INV-03, INV-08).
+
+        Step 1: persist to ``deviation_log`` (durable; idempotent on event_id).
+        Step 2: format the one-line alert.
+        Step 3: POST to Discord with retry + backoff.
+        Step 4: mark ``delivered=True`` on success; log warning on exhaustion.
+
+        Never raises into the caller — a down Discord must not crash the monitor
+        loop (the watcher calls ``send`` on every emitted deviation event).
+
+        Args:
+            event: The ``DeviationEvent`` to persist and deliver.
+        """
+        # --- Step 1: persist FIRST (durability guarantee) ---
+        self._store.write_deviation_event(event)
+
+        # --- Step 2: format the alert (INV-03: UTC RFC-3339 ts; INV-08: no URL) ---
+        message = format_alert(event)
+
+        # --- Step 3: POST with retry + exponential backoff ---
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                self._webhook.post(message)
+                # --- Step 4: mark delivered after successful POST ---
+                self._store.mark_deviation_delivered(event.event_id)
+                logger.info(
+                    "alerts.Alerter: delivered event_id=%s instrument=%s type=%s",
+                    event.event_id,
+                    event.instrument,
+                    event.deviation_type,
+                )
+                return
+            except Exception as exc:
+                last_exc = exc
+                backoff = self._backoff_base * (2 ** attempt)
+                logger.warning(
+                    "alerts.Alerter: delivery attempt %d/%d failed for event_id=%s: %s"
+                    " — retrying in %.1fs",
+                    attempt + 1,
+                    self._max_retries,
+                    event.event_id,
+                    type(exc).__name__,
+                    backoff,
+                )
+                if attempt < self._max_retries - 1:
+                    time.sleep(backoff)
+
+        # All retries exhausted — log and return without raising (INV-01: never crash loop)
+        logger.warning(
+            "alerts.Alerter: all %d delivery attempts failed for event_id=%s"
+            " (instrument=%s type=%s). Event remains in deviation_log with delivered=False."
+            " Last error: %s",
+            self._max_retries,
+            event.event_id,
+            event.instrument,
+            event.deviation_type,
+            last_exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory helper — build a live Alerter from Settings (INV-08)
+# ---------------------------------------------------------------------------
+
+
+def build_alerter_from_settings(store: Store) -> Alerter:
+    """Construct a live ``Alerter`` from ``Settings.discord_webhook_url``.
+
+    INV-08: the URL is read via ``SecretStr.get_secret_value()`` and passed
+    directly to ``DiscordWebhookClient``, which stores it privately.  It is
+    never logged, printed, or otherwise exposed.
+
+    Args:
+        store: The open ``Store`` instance for deviation_log persistence.
+
+    Returns:
+        A fully-wired ``Alerter`` using ``DiscordWebhookClient``.
+
+    Raises:
+        ValueError: If ``DISCORD_WEBHOOK_URL`` is not set in ``.env`` /
+            environment (required at runtime by the monitor).
+    """
+    from config.settings import Settings  # local import — avoids top-level coupling
+
+    settings = Settings()
+    if settings.discord_webhook_url is None:
+        raise ValueError(
+            "DISCORD_WEBHOOK_URL is not set in .env / environment.  "
+            "The deviation monitor alerter requires it.  "
+            "Add DISCORD_WEBHOOK_URL=<url> to .env (never commit the value — INV-08)."
+        )
+    # Extract the secret URL once; pass to the client (which stores it privately).
+    # INV-08: we do NOT log, print, or store the URL outside the client object.
+    webhook_url: str = settings.discord_webhook_url.get_secret_value()
+    client = DiscordWebhookClient(webhook_url)
+    return Alerter(webhook_client=client, store=store)

--- a/tests/test_monitor_alerts.py
+++ b/tests/test_monitor_alerts.py
@@ -1,0 +1,700 @@
+"""Tests for monitoring/alerts.py — deviation monitor delivery layer (P3-T-09).
+
+Coverage (per ACs from monitor-alerts spec):
+
+1. Each DeviationEvent is persisted to deviation_log BEFORE the delivery
+   attempt (durable even if Discord is down).
+2. The formatted alert is one line, includes instrument, deviation_type,
+   detail, and a UTC RFC-3339 timestamp (INV-03); no secret appears (INV-08).
+3. Delivery POSTs to the webhook; a delivery failure is retried with backoff
+   and does NOT raise into the monitor loop.
+4. Alerts are outbound-only — the module exposes no order/execution capability
+   and is not a Hermes tool (INV-01).
+5. A duplicate event_id is not double-logged (idempotent persistence).
+
+Implementation notes:
+- All tests inject a stub webhook client (no live HTTP).
+- Store is an in-memory SQLite (:memory:) instance.
+- ``backoff_base=0.0`` in Alerter so retries are instantaneous in tests.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Iterator
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+import pytest
+
+from data.store import Store
+from monitoring.alerts import (
+    DEFAULT_MAX_RETRIES,
+    Alerter,
+    DiscordWebhookClient,
+    format_alert,
+)
+from monitoring.watcher import DeviationEvent
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+
+
+def _make_event(
+    *,
+    event_id: str = "evt001",
+    instrument: str = "EUR_USD",
+    deviation_type: str = "adverse",
+    detail: str = "adverse excursion 0.00300 (threshold 0.00250)",
+    broker_trade_id: str | None = "T1",
+    severity: str = "warn",
+    ts: datetime | None = None,
+) -> DeviationEvent:
+    return DeviationEvent(
+        event_id=event_id,
+        instrument=instrument,
+        deviation_type=deviation_type,
+        detail=detail,
+        broker_trade_id=broker_trade_id,
+        severity=severity,
+        created_at=ts or datetime(2026, 5, 29, 15, 10, 0, tzinfo=_UTC),
+    )
+
+
+@pytest.fixture
+def store() -> Iterator[Store]:
+    """In-memory Store with deviation_log table."""
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+class _OkWebhook:
+    """Stub webhook client that always succeeds (no HTTP)."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def post(self, message: str) -> None:
+        self.calls.append(message)
+
+
+class _FailingWebhook:
+    """Stub webhook client that always raises httpx.RequestError."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    def post(self, message: str) -> None:
+        self.call_count += 1
+        raise httpx.RequestError("simulated network failure")
+
+
+class _FailThenSucceedWebhook:
+    """Stub webhook client that fails N times then succeeds."""
+
+    def __init__(self, fail_count: int) -> None:
+        self.fail_count = fail_count
+        self._calls = 0
+        self.success_messages: list[str] = []
+
+    def post(self, message: str) -> None:
+        self._calls += 1
+        if self._calls <= self.fail_count:
+            raise httpx.RequestError("simulated transient failure")
+        self.success_messages.append(message)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: format_alert — one line, correct fields, UTC RFC-3339, no secret
+# ---------------------------------------------------------------------------
+
+
+def test_format_alert_one_line() -> None:
+    """Alert must be exactly one line (no newlines)."""
+    ev = _make_event()
+    result = format_alert(ev)
+    assert "\n" not in result, f"Alert must be one line, got: {result!r}"
+
+
+def test_format_alert_includes_instrument() -> None:
+    """Alert must contain the instrument name."""
+    ev = _make_event(instrument="GBP_USD")
+    assert "GBP_USD" in format_alert(ev)
+
+
+def test_format_alert_includes_deviation_type() -> None:
+    """Alert must contain the deviation type."""
+    ev = _make_event(deviation_type="slippage", detail="fill slippage 0.0005")
+    result = format_alert(ev)
+    assert "slippage" in result
+
+
+def test_format_alert_includes_detail() -> None:
+    """Alert must contain the detail string."""
+    ev = _make_event(detail="some detail text")
+    assert "some detail text" in format_alert(ev)
+
+
+def test_format_alert_utc_rfc3339_timestamp() -> None:
+    """Alert must contain a UTC RFC-3339 timestamp (INV-03): ends with Z."""
+    ev = _make_event(ts=datetime(2026, 5, 29, 15, 10, 0, tzinfo=_UTC))
+    result = format_alert(ev)
+    # Must contain the RFC-3339 UTC string
+    assert "2026-05-29T15:10:00Z" in result, (
+        f"Expected UTC RFC-3339 timestamp in alert, got: {result!r}"
+    )
+
+
+def test_format_alert_no_secret_in_text() -> None:
+    """Alert text must NOT contain a webhook URL or any secret (INV-08).
+
+    We verify this by checking that the format function does not accept
+    or use a URL, and the output only contains event fields.
+    """
+    ev = _make_event()
+    result = format_alert(ev)
+    # A webhook URL would look like https://discord.com/api/...
+    assert "https://" not in result, (
+        f"Alert must not contain a URL (INV-08), got: {result!r}"
+    )
+    # Verify expected structure
+    assert result.startswith("⚠️"), f"Alert should start with warning emoji: {result!r}"
+
+
+def test_format_alert_pipe_delimited() -> None:
+    """Alert fields are separated by ' | '."""
+    ev = _make_event(
+        instrument="EUR_USD",
+        deviation_type="vol",
+        detail="vol range 0.01100",
+        ts=datetime(2026, 5, 29, 15, 10, 0, tzinfo=_UTC),
+    )
+    result = format_alert(ev)
+    expected = "⚠️ EUR_USD vol | vol range 0.01100 | 2026-05-29T15:10:00Z"
+    assert result == expected, f"Expected {expected!r}, got {result!r}"
+
+
+def test_format_alert_feed_health_no_broker_id() -> None:
+    """Feed-health events (no broker_trade_id) must still format correctly."""
+    ev = _make_event(
+        deviation_type="feed_health",
+        detail="no tick for 20.0s",
+        broker_trade_id=None,
+        ts=datetime(2026, 5, 29, 12, 0, 0, tzinfo=_UTC),
+    )
+    result = format_alert(ev)
+    assert "feed_health" in result
+    assert "2026-05-29T12:00:00Z" in result
+    assert "\n" not in result
+
+
+# ---------------------------------------------------------------------------
+# AC-1: event persisted BEFORE delivery attempt (durable even if POST fails)
+# ---------------------------------------------------------------------------
+
+
+def test_event_persisted_before_delivery_on_success(store: Store) -> None:
+    """Event row exists in deviation_log even when delivery succeeds (basic case)."""
+    ev = _make_event()
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev)
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == ev.event_id
+
+
+def test_event_persisted_before_delivery_when_post_fails(store: Store) -> None:
+    """Event row must be in deviation_log even when Discord POST fails.
+
+    This is the core 'durable even if Discord is down' guarantee: the
+    persist step happens before any HTTP attempt.  We verify by checking
+    that after a fully-failed send (all retries exhausted), the row is
+    present in deviation_log with delivered=False.
+    """
+    ev = _make_event()
+    failing_webhook = _FailingWebhook()
+    alerter = Alerter(
+        webhook_client=failing_webhook,
+        store=store,
+        max_retries=2,
+        backoff_base=0.0,
+    )
+
+    # Must not raise even with a failing webhook
+    alerter.send(ev)
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 1, "Event must be persisted even when delivery fails"
+    assert rows[0]["event_id"] == ev.event_id
+    assert rows[0]["delivered"] is False, (
+        "delivered must remain False after all retries fail"
+    )
+
+
+def test_persist_before_delivery_ordering(store: Store) -> None:
+    """Verify persist happens before POST by using a spy that records order.
+
+    The sequence must be: write_deviation_event → post, not post → write.
+    We verify this by a webhook stub that checks the store on first call.
+    """
+    ev = _make_event()
+
+    class _OrderCheckWebhook:
+        """Verifies the row is already in store when post() is called."""
+
+        def __init__(self, store: Store) -> None:
+            self._store = store
+            self.row_existed_at_post_time: bool = False
+
+        def post(self, message: str) -> None:
+            rows = self._store.load_deviation_log()
+            self.row_existed_at_post_time = any(
+                r["event_id"] == ev.event_id for r in rows
+            )
+
+    webhook = _OrderCheckWebhook(store)
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+    alerter.send(ev)
+
+    assert webhook.row_existed_at_post_time, (
+        "deviation_log row must exist BEFORE the POST attempt (durable-first guarantee)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: delivery failure retried with backoff; does NOT raise
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_failure_does_not_raise(store: Store) -> None:
+    """A fully-failing webhook must NOT raise into the caller (INV-01)."""
+    ev = _make_event()
+    alerter = Alerter(
+        webhook_client=_FailingWebhook(),
+        store=store,
+        max_retries=3,
+        backoff_base=0.0,
+    )
+    # Must complete without raising
+    alerter.send(ev)
+
+
+def test_delivery_retried_on_failure(store: Store) -> None:
+    """Webhook POST is retried up to max_retries times on failure."""
+    ev = _make_event()
+    webhook = _FailingWebhook()
+    max_retries = 3
+    alerter = Alerter(
+        webhook_client=webhook,
+        store=store,
+        max_retries=max_retries,
+        backoff_base=0.0,
+    )
+    alerter.send(ev)
+    assert webhook.call_count == max_retries, (
+        f"Expected {max_retries} POST attempts, got {webhook.call_count}"
+    )
+
+
+def test_delivery_succeeds_after_transient_failures(store: Store) -> None:
+    """Webhook succeeds on the 3rd attempt (2 transient failures first)."""
+    ev = _make_event()
+    webhook = _FailThenSucceedWebhook(fail_count=2)
+    alerter = Alerter(
+        webhook_client=webhook,
+        store=store,
+        max_retries=3,
+        backoff_base=0.0,
+    )
+    alerter.send(ev)
+
+    # Delivery was eventually successful
+    assert len(webhook.success_messages) == 1
+
+    # Row is marked delivered=True
+    rows = store.load_deviation_log()
+    assert len(rows) == 1
+    assert rows[0]["delivered"] is True
+
+
+def test_delivered_flag_true_after_success(store: Store) -> None:
+    """After a successful POST, delivered=True in deviation_log."""
+    ev = _make_event()
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev)
+
+    rows = store.load_deviation_log()
+    assert rows[0]["delivered"] is True
+
+
+def test_delivered_flag_false_after_exhausted_retries(store: Store) -> None:
+    """After all retries fail, delivered=False remains in deviation_log."""
+    ev = _make_event()
+    alerter = Alerter(
+        webhook_client=_FailingWebhook(),
+        store=store,
+        max_retries=2,
+        backoff_base=0.0,
+    )
+    alerter.send(ev)
+
+    rows = store.load_deviation_log()
+    assert rows[0]["delivered"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC-5: idempotent on event_id — duplicate not double-logged
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_persistence_same_event_id(store: Store) -> None:
+    """Re-sending the same event_id must not create a second deviation_log row."""
+    ev = _make_event(event_id="dup001")
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev)
+    alerter.send(ev)  # same event_id — second call must be a no-op at store
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 1, (
+        f"Expected exactly 1 row for event_id='dup001', got {len(rows)}"
+    )
+
+
+def test_idempotent_different_event_ids_creates_two_rows(store: Store) -> None:
+    """Two events with different event_ids create two separate rows."""
+    ev1 = _make_event(event_id="evt001")
+    ev2 = _make_event(event_id="evt002")
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev1)
+    alerter.send(ev2)
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 2
+    ids = {r["event_id"] for r in rows}
+    assert ids == {"evt001", "evt002"}
+
+
+# ---------------------------------------------------------------------------
+# AC-4 / INV-01: outbound-only — no order / execution capability
+# ---------------------------------------------------------------------------
+
+
+def test_alerter_has_no_order_capability() -> None:
+    """Alerter must not expose any order / execution / position-opening method."""
+    store_mock = MagicMock(spec=Store)
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store_mock, backoff_base=0.0)
+
+    for forbidden in (
+        "submit_order",
+        "place_order",
+        "open_position",
+        "close_position",
+        "execute",
+        "flatten",
+    ):
+        assert not hasattr(alerter, forbidden), (
+            f"Alerter must not have method '{forbidden}' (INV-01)"
+        )
+
+
+def test_discord_webhook_client_has_no_order_capability() -> None:
+    """DiscordWebhookClient exposes only 'post' — no order capability (INV-01)."""
+    client = DiscordWebhookClient("https://example.com/webhook")
+    for forbidden in ("submit_order", "place_order", "open_position", "execute"):
+        assert not hasattr(client, forbidden), (
+            f"DiscordWebhookClient must not have '{forbidden}' (INV-01)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-08: no secret in alert text or logs
+# ---------------------------------------------------------------------------
+
+
+def test_no_secret_in_alert_text() -> None:
+    """The formatted alert must not contain the webhook URL (INV-08)."""
+    secret_url = "https://discord.com/api/webhooks/1234567890/FAKE_SECRET_TOKEN"
+    ev = _make_event()
+    message = format_alert(ev)
+    assert secret_url not in message
+    assert "discord.com" not in message
+    assert "FAKE_SECRET_TOKEN" not in message
+
+
+def test_discord_webhook_client_does_not_log_url(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """DiscordWebhookClient must not log the webhook URL (INV-08).
+
+    We verify this by attempting a POST to a non-existent endpoint (which
+    raises an error), then confirming the URL does not appear in any log record.
+    """
+    import logging
+
+    secret_url = "https://discord.com/api/webhooks/9999/SUPER_SECRET_TOKEN"
+    client = DiscordWebhookClient(secret_url, timeout=0.001)
+
+    with caplog.at_level(logging.DEBUG, logger="fathom"):
+        try:
+            client.post("test message")
+        except Exception:
+            pass  # Expected — URL is invalid / unreachable
+
+    for record in caplog.records:
+        assert "SUPER_SECRET_TOKEN" not in record.getMessage(), (
+            f"Webhook URL secret appeared in log: {record.getMessage()!r}"
+        )
+
+
+def test_alerter_warning_does_not_log_url(
+    store: Store,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alerter retry-failure log messages must not contain the webhook URL."""
+    import logging
+
+    secret_url = "https://discord.com/api/webhooks/9999/ANOTHER_SECRET"
+
+    class _SecretFailing:
+        """Failing webhook that would expose the URL if the alerter logged it."""
+
+        def post(self, message: str) -> None:
+            raise httpx.RequestError("network error")
+
+    ev = _make_event()
+    alerter = Alerter(
+        webhook_client=_SecretFailing(),
+        store=store,
+        max_retries=2,
+        backoff_base=0.0,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="fathom.monitoring.alerts"):
+        alerter.send(ev)
+
+    # The secret URL must not appear in any warning log record
+    for record in caplog.records:
+        assert "ANOTHER_SECRET" not in record.getMessage(), (
+            f"Secret appeared in alert log: {record.getMessage()!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store: deviation_log read/write (unit tests for the store layer itself)
+# ---------------------------------------------------------------------------
+
+
+def test_store_write_and_load_deviation_event(store: Store) -> None:
+    """write_deviation_event persists the event; load_deviation_log returns it."""
+    ev = _make_event(
+        event_id="store_test_001",
+        instrument="USD_JPY",
+        deviation_type="vol",
+        detail="vol range test",
+        broker_trade_id="T99",
+        severity="severe",
+        ts=datetime(2026, 5, 29, 10, 0, 0, tzinfo=_UTC),
+    )
+    inserted = store.write_deviation_event(ev)
+    assert inserted is True
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["event_id"] == "store_test_001"
+    assert row["instrument"] == "USD_JPY"
+    assert row["deviation_type"] == "vol"
+    assert row["detail"] == "vol range test"
+    assert row["broker_trade_id"] == "T99"
+    assert row["severity"] == "severe"
+    assert row["created_at"] == "2026-05-29T10:00:00Z"  # RFC-3339 UTC (INV-03)
+    assert row["delivered"] is False
+
+
+def test_store_write_idempotent_same_event_id(store: Store) -> None:
+    """Re-writing the same event_id returns False (no-op)."""
+    ev = _make_event(event_id="idem_001")
+    first = store.write_deviation_event(ev)
+    second = store.write_deviation_event(ev)
+
+    assert first is True
+    assert second is False  # INSERT OR IGNORE → 0 rowcount
+
+    rows = store.load_deviation_log()
+    assert len(rows) == 1, "Duplicate event_id must not create a second row"
+
+
+def test_store_mark_delivered(store: Store) -> None:
+    """mark_deviation_delivered sets delivered=True on the row."""
+    ev = _make_event(event_id="mark_del_001")
+    store.write_deviation_event(ev)
+
+    rows_before = store.load_deviation_log()
+    assert rows_before[0]["delivered"] is False
+
+    store.mark_deviation_delivered("mark_del_001")
+
+    rows_after = store.load_deviation_log()
+    assert rows_after[0]["delivered"] is True
+
+
+def test_store_load_undelivered_only(store: Store) -> None:
+    """load_deviation_log(undelivered_only=True) returns only undelivered rows."""
+    ev1 = _make_event(event_id="del_001")
+    ev2 = _make_event(event_id="del_002")
+    store.write_deviation_event(ev1)
+    store.write_deviation_event(ev2)
+    store.mark_deviation_delivered("del_001")
+
+    undelivered = store.load_deviation_log(undelivered_only=True)
+    ids = {r["event_id"] for r in undelivered}
+    assert "del_001" not in ids, "Delivered event must not appear in undelivered_only"
+    assert "del_002" in ids, "Undelivered event must appear"
+
+
+def test_store_feed_health_event_null_broker_trade_id(store: Store) -> None:
+    """feed_health events with broker_trade_id=None store NULL correctly."""
+    ev = _make_event(
+        event_id="fh_001",
+        deviation_type="feed_health",
+        broker_trade_id=None,
+    )
+    store.write_deviation_event(ev)
+
+    rows = store.load_deviation_log()
+    assert rows[0]["broker_trade_id"] is None
+
+
+def test_store_load_with_limit(store: Store) -> None:
+    """load_deviation_log(limit=N) returns at most N rows."""
+    for i in range(5):
+        ev = _make_event(event_id=f"lim_{i:03d}")
+        store.write_deviation_event(ev)
+
+    rows = store.load_deviation_log(limit=3)
+    assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: Alerter sends correct message text to the webhook
+# ---------------------------------------------------------------------------
+
+
+def test_alerter_sends_formatted_message(store: Store) -> None:
+    """The message POSTed to the webhook matches format_alert output."""
+    ev = _make_event(
+        instrument="GBP_USD",
+        deviation_type="slippage",
+        detail="fill slippage 0.00050",
+        ts=datetime(2026, 5, 29, 12, 30, 0, tzinfo=_UTC),
+    )
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev)
+
+    expected = format_alert(ev)
+    assert webhook.calls == [expected], (
+        f"Expected webhook called with {expected!r}, got {webhook.calls!r}"
+    )
+
+
+def test_alerter_message_contains_utc_timestamp(store: Store) -> None:
+    """The POSTed message must contain a UTC RFC-3339 timestamp (INV-03)."""
+    ts = datetime(2026, 5, 29, 9, 45, 0, tzinfo=_UTC)
+    ev = _make_event(ts=ts)
+    webhook = _OkWebhook()
+    alerter = Alerter(webhook_client=webhook, store=store, backoff_base=0.0)
+
+    alerter.send(ev)
+
+    assert len(webhook.calls) == 1
+    message = webhook.calls[0]
+    # Must contain the RFC-3339 string with Z suffix
+    assert "2026-05-29T09:45:00Z" in message, (
+        f"UTC RFC-3339 timestamp not found in message: {message!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DiscordWebhookClient — unit test the HTTP layer (mocked httpx)
+# ---------------------------------------------------------------------------
+
+
+def test_discord_webhook_client_posts_json_content() -> None:
+    """DiscordWebhookClient POSTs {"content": message} to the webhook URL."""
+    captured: list[dict[str, object]] = []
+
+    class _MockClient:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> "_MockClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def post(self, url: str, json: dict[str, object]) -> "_MockResponse":
+            captured.append({"url": url, "json": json})
+            return _MockResponse()
+
+    class _MockResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+    with patch("monitoring.alerts.httpx.Client", _MockClient):
+        client = DiscordWebhookClient("https://fake-webhook.example.com/hook")
+        client.post("test alert message")
+
+    assert len(captured) == 1
+    assert captured[0]["json"] == {"content": "test alert message"}
+
+
+def test_discord_webhook_client_raises_on_http_error() -> None:
+    """DiscordWebhookClient propagates httpx.HTTPStatusError on 4xx/5xx."""
+
+    class _MockClientBad:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> "_MockClientBad":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def post(self, url: str, json: dict[str, object]) -> "_MockBadResponse":
+            return _MockBadResponse()
+
+    class _MockBadResponse:
+        def raise_for_status(self) -> None:
+            # Simulate httpx raising on a 4xx/5xx response
+            mock_request = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            raise httpx.HTTPStatusError(
+                "429 Too Many Requests",
+                request=mock_request,
+                response=mock_response,
+            )
+
+    with patch("monitoring.alerts.httpx.Client", _MockClientBad):
+        client = DiscordWebhookClient("https://fake-webhook.example.com/hook")
+        with pytest.raises(httpx.HTTPStatusError):
+            client.post("test")


### PR DESCRIPTION
## Summary

- **persist-then-deliver**: `Alerter.send` writes to `deviation_log` (durable, `INSERT OR IGNORE` on `event_id` PK) **before** any HTTP attempt — events survive a Discord outage. After a successful POST, `delivered` is set to `True`. After all retries are exhausted, the row remains with `delivered=False` for a catch-up pass; the call never raises into the monitor loop.
- **retry with backoff**: exponential (`backoff_base × 2^attempt`, up to `max_retries=3`); `backoff_base=0.0` in tests means no real sleeps.
- **idempotent**: `write_deviation_event` uses `INSERT OR IGNORE` — re-persisting the same `event_id` is a no-op (first write wins).
- **DRIFT-06 (direct webhook, no Hermes gateway)**: the monitor is a standalone Python process (`scripts/run_monitor.py`), not a Hermes job; it posts directly to `DISCORD_WEBHOOK_URL` (same channel as Phase 2 watchlist) via `DiscordWebhookClient`. No Python "Hermes gateway" object exists.
- **INV-01**: `Alerter` and `DiscordWebhookClient` expose no order/execution capability; not registered as a Hermes tool.
- **INV-03**: alert text and `created_at` column use UTC RFC-3339 (`Z` suffix).
- **INV-08**: `DISCORD_WEBHOOK_URL` stored as `SecretStr` in `Settings`; raw URL passed to `DiscordWebhookClient._url` (private, never logged or included in alert text).

## Files changed

- `monitoring/alerts.py` — new: `DiscordWebhookClient`, `format_alert`, `Alerter`, `build_alerter_from_settings`
- `data/store.py` — adds `deviation_log` table + `write_deviation_event`, `mark_deviation_delivered`, `load_deviation_log`
- `config/settings.py` — adds `discord_webhook_url: Optional[SecretStr] = None`
- `.env.example` — adds `DISCORD_WEBHOOK_URL` placeholder (drift-guard test)
- `tests/test_monitor_alerts.py` — 33 new tests
- `.claude/context/monitoring.md` — session entry appended

## Test plan

- [x] `pytest tests/test_monitor_alerts.py -v` → 33 passed, exit 0
- [x] `pytest -q` (full suite) → 932 passed (899 existing + 33 new), 0 failed, exit 0
- [x] `mypy .` → Success: no issues found in 78 source files, exit 0
- [x] Persist-before-deliver ordering verified by `_OrderCheckWebhook` spy (row in store at `post()` call time)
- [x] Retry count verified: `_FailingWebhook.call_count == max_retries`
- [x] Idempotency: two `send(ev)` calls → exactly 1 row in `deviation_log`
- [x] No secret in alert text or logs: `test_no_secret_in_alert_text`, `test_discord_webhook_client_does_not_log_url`, `test_alerter_warning_does_not_log_url`
- [x] INV-01: `test_alerter_has_no_order_capability` checks for forbidden method names

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)