### PR TITLE
P3-T-10: execution-cli (fathom execute, the INV-01 gate join)

### DIFF
--- a/.claude/context/runner.md
+++ b/.claude/context/runner.md
@@ -287,3 +287,77 @@ CREATE TABLE IF NOT EXISTS watchlist (
   arg list.
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P3-T-10 — 2026-05-29 (feat/p3-T-10-cli) — execution-cli (the INV-01 gate join)
+
+**What was done:**
+- Extended `cli.py` with three Phase 3 subcommands: `execute`, `positions`, `reconcile`.
+  **This is the ONLY Phase 3 task that edits `cli.py`** (join point per task graph).
+- **This is the canonical INV-01 enforcement point**: `fathom execute` is a human-run
+  CLI command, NEVER a Hermes tool. The Phase 2 daily.md allow-list (scan/watchlist/chart)
+  is unchanged.
+
+**`fathom execute <candidate-ref>`** (`cmd_execute`) — gate ordering:
+1. Load candidate from latest watchlist via `_load_candidate(ref, db_path)` (INV-13).
+   Ref format: `instrument:timeframe:strategy_name` (DRIFT-04). Error + exit ≠ 0 if not found.
+2. Fresh reconcile (`reconcile(client, store, now)`) BEFORE limits (AMBIGUOUS-03).
+   Refreshes `account_state` (day_pl, start_of_day_equity) + open positions from broker.
+3. Pretrade check (`pretrade_check(candidate)`) → `block` → exit ≠ 0.
+4. Sizing (`size_position(..., risk_fraction=DEFAULT_RISK_FRACTION)`) — **always 0.0025,
+   never above the INV-05 cap**. `units=0` → exit ≠ 0.
+5. `build_bracket(candidate, units, execution_date, precision)` → produces the full `Order`
+   (used for both the limits check AND the eventual submit).
+6. Limits check (`check_limits(order, ..., order_risk=sizing_result.risk_amount)`) →
+   reject → exit ≠ 0; kill-switch active → prints reset-at time.
+7. `--dry-run`: prints `[DRY-RUN] Would submit the following order:` + JSON, **no v20 call**.
+8. `--yes`: skips the interactive confirm prompt. Default: `Confirm submit? [y/N]`.
+9. Submit (`submit_order(order, client, store, entry_ref, precision, now)`) → prints Fill JSON.
+
+**`fathom positions`** (`cmd_positions`): DB-only read (`store.load_open_positions()`), prints
+`Position[]` as JSON. No live HTTP.
+
+**`fathom reconcile`** (`cmd_reconcile`): Calls `reconcile(client, store, now)` once, prints
+`ReconcileReport` as JSON (adopted/closed/matched/drift_flags/day_pl/start_of_day_equity).
+
+**Module-level imports for testability:**
+- Execution module imports (`Settings`, `OandaClient`, `build_bracket`, `OrderRejected`,
+  `submit_order`, `reconcile`, `pretrade_check`, `LimitsConfig`, `check_limits`,
+  `kill_switch_status`, `DEFAULT_RISK_FRACTION`, `size_position`) are at the module level
+  in a `try/except ImportError` block so they're patchable as `cli.<name>`.
+  Tests use `patch("cli.reconcile", ...)`, `patch("cli.size_position", ...)` etc.
+
+**INV-01 boundary tested in two places:**
+1. `tests/test_execution_cli.py::TestInv01Boundary` — scans `hermes_integration/` for
+   `"fathom execute"`, `"fathom positions"`, `"fathom reconcile"` (exact command strings).
+2. `tests/test_cli_commands.py::TestNoOrderPath` — updated from the Phase 2 check (which
+   forbade "execution" in cli.py — now outdated since P3-T-10 legitimately adds it) to
+   the correct boundary: checks that `hermes_integration/` has none of the Phase 3 commands.
+
+**Key patterns / gotchas:**
+- `build_bracket` is called BEFORE `check_limits` so the limits gate receives a fully-formed
+  `Order` (with correct bracket prices). This is still within "step 5 (limits)" — the order
+  is NOT submitted yet; it is just constructed for the limits input.
+- `load_account_state()` returns `dict[str, object] | None`. To pass `day_pl`/
+  `start_of_day_equity` to `float()`, use `# type: ignore[arg-type]` (the dict values
+  are float at runtime, but the type annotation is `object`).
+- `equity = start_of_day_equity + day_pl` — this is the current NAV (snapshot + today's delta).
+- `quote_to_account_rate`: defaults to 1.0 for `_USD`-quoted instruments; for others, loads
+  the latest `close_mid` from the candle store and derives `rate = 1/mid`. Falls back to 1.0
+  with a WARNING if candles are unavailable.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_execution_cli.py -v` → **23 passed**, exit 0
+- `python -m pytest tests/test_cli_commands.py tests/test_execution_cli.py -v` → **40 passed**, exit 0
+- `python -m pytest -q` (full suite) → **955 passed, 87 warnings**, exit 0
+- `python -m mypy .` → **"Success: no issues found in 79 source files"**, exit 0
+- `fathom --help` → lists `execute`, `positions`, `reconcile` alongside `backtest`, `scan`,
+  `watchlist`, `chart`.
+
+**No new dependencies.** No changes to pyproject.toml.
+
+**CLAUDE.md trigger-table check:** New CLI commands `fathom execute`, `fathom positions`,
+`fathom reconcile` → CLAUDE.md Commands section updated (YES).
+
+**Merge plan:** `gh pr merge 85 --squash --delete-branch` (lead action after reviewer pass).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,19 @@ fathom watchlist              # output latest persisted watchlist as Candidate[]
 fathom chart <instrument>     # render candidate chart PNG, print path (Hermes tool)
 #   fathom chart EUR_USD [--timeframe H1] [--db-path PATH] [--out-dir DIR] [--history-years N]
 
+# Phase 3 (current) — P3-T-10 — INV-01 gate (operator-only, NEVER Hermes tools)
+fathom execute <candidate-ref>  # run full Phase 3 gate (pretrade → sizing → limits → submit)
+#   fathom execute EUR_USD:H1:macrossover_10_50 [--db-path PATH] [--dry-run] [--yes]
+#   candidate-ref format: instrument:timeframe:strategy_name (must be on latest watchlist)
+#   --dry-run: runs gate steps 1-5, prints would-be order without any v20 submission
+#   --yes: skip the interactive confirm prompt
+
+fathom positions              # print open Position[] JSON from the store
+#   fathom positions [--db-path PATH]
+
+fathom reconcile              # run one broker-truth reconcile pass, print ReconcileReport JSON
+#   fathom reconcile [--db-path PATH]
+
 # PoC (superseded by `fathom backtest`)
 python scripts/poc_run.py     # end-to-end PoC: fetch candles → backtest → approved-set table
 

--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,7 @@
-"""Fathom CLI — ``fathom backtest`` (P1A-T-08, the Phase 1A capstone).
+"""Fathom CLI — multi-phase operator entrypoint.
 
+Phase 1A: ``fathom backtest`` (P1A-T-08)
+-----------------------------------------
 The full-universe backtest runner: it walk-forward-validates **every**
 requested (strategy × instrument × timeframe) combination and persists the
 resulting approved-set table to SQLite.  That table is the **INV-10 gate** —
@@ -58,6 +60,30 @@ Usage
 
 An empty approved set is a valid, exit-0 result (INV-10: empty means "no
 signals", not "all signals").
+
+Phase 3: ``fathom execute`` / ``fathom positions`` / ``fathom reconcile`` (P3-T-10)
+------------------------------------------------------------------------------------
+The canonical **INV-01 enforcement point**: ``fathom execute`` is the
+human-run CLI command that turns an approved watchlist candidate into a trade.
+It is NEVER a Hermes tool — execution authority belongs to the operator.
+
+Gate ordering (pretrade → sizing → limits → submit):
+1. Load candidate from the latest persisted watchlist (INV-13).
+2. Fresh reconcile → refresh account_state + positions (AMBIGUOUS-03).
+3. Pretrade check → ``block`` aborts (exit ≠ 0, reason).
+4. Sizing (risk_fraction=0.0025, INV-05 cap) → reject aborts.
+5. Limits / kill switch → reject aborts with kill-switch status.
+6. Build bracket + submit order → print Fill.
+
+``--dry-run`` runs steps 1–5 and prints the would-be order WITHOUT any v20
+submission.  ``--yes`` skips the interactive confirm before a real submit.
+
+``fathom positions`` and ``fathom reconcile`` are read-only operator helpers.
+
+INV-01: execute/positions/reconcile are NEVER registered as Hermes tools.
+INV-07: practice endpoint only (INV-09 one-code-path).
+INV-03: all timestamps UTC.
+INV-08: no secret logged.
 """
 
 from __future__ import annotations
@@ -80,6 +106,28 @@ from strategies.breakout import SessionRangeBreakout
 from strategies.mean_reversion import BollingerReversion, RSIReversion
 from strategies.momentum import ROCMomentum
 from strategies.trend import DonchianBreakout, MACrossover
+
+# ---------------------------------------------------------------------------
+# Phase 3 execution imports (P3-T-10) — module-level for testability.
+# INV-01: these are imported for the operator CLI gate, NEVER registered as
+# Hermes tools.  The Hermes allow-list (scan/watchlist/chart) is unchanged.
+# ---------------------------------------------------------------------------
+# Lazy fallback: these may not be importable in minimal test envs without the
+# full stack installed.  They are only used inside the Phase 3 command
+# functions (cmd_execute, cmd_positions, cmd_reconcile), never at import time.
+try:
+    from config.settings import Settings
+    from data.oanda_client import OandaClient
+    from execution.models import build_bracket
+    from execution.orders import OrderRejected, submit_order
+    from execution.reconcile import reconcile
+    from hermes_integration.pretrade_check import pretrade_check
+    from risk.limits import LimitsConfig, check_limits, kill_switch_status
+    from risk.sizing import DEFAULT_RISK_FRACTION, size_position
+except ImportError:  # pragma: no cover
+    # During module-level import in environments where execution deps are
+    # absent, defer to runtime so the non-execution subcommands still work.
+    pass
 
 # ---------------------------------------------------------------------------
 # Logging — UTC RFC 3339 timestamps (INV-03)
@@ -753,6 +801,79 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Years of candle history to load for the chart window.",
     )
 
+    # ---- execute ------------------------------------------------------------
+    # INV-01: this subcommand is NEVER registered as a Hermes tool.
+    # The canonical human-operator execution gate (P3-T-10).
+    ex = sub.add_parser(
+        "execute",
+        help=(
+            "Run a watchlist candidate through the full Phase 3 gate "
+            "(pretrade → sizing → limits → submit). INV-01: operator-only, "
+            "never a Hermes tool."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    ex.add_argument(
+        "candidate_ref",
+        help=(
+            "Candidate reference: instrument:timeframe:strategy_name, "
+            "e.g. EUR_USD:H1:macrossover_10_50_eur_usd_h1. "
+            "Must be present on the latest persisted watchlist (INV-13)."
+        ),
+    )
+    ex.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store.",
+    )
+    ex.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Run gate steps 1–5 and print the would-be order WITHOUT "
+            "submitting to OANDA. Safe rehearsal."
+        ),
+    )
+    ex.add_argument(
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Skip the interactive confirm prompt before a real submit.",
+    )
+
+    # ---- positions ----------------------------------------------------------
+    # INV-01: read-only operator helper; never a Hermes tool.
+    pos = sub.add_parser(
+        "positions",
+        help=(
+            "Print open Position[] JSON from the store. "
+            "INV-01: operator-only, never a Hermes tool."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    pos.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store.",
+    )
+
+    # ---- reconcile ----------------------------------------------------------
+    # INV-01: operator-initiated broker-truth sync; never a Hermes tool.
+    rec = sub.add_parser(
+        "reconcile",
+        help=(
+            "Run one reconciliation pass against the OANDA broker and print "
+            "the ReconcileReport. INV-01: operator-only, never a Hermes tool."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    rec.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store.",
+    )
+
     return parser
 
 
@@ -1163,6 +1284,519 @@ def cmd_chart(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Phase 3 — execute, positions, reconcile commands (P3-T-10)
+# ---------------------------------------------------------------------------
+# INV-01: these three subcommands are operator-only CLI commands.  They are
+# NEVER registered as Hermes tools.  The Phase 2 daily.md allow-list is
+# scan/watchlist/chart and remains unchanged.
+#
+# Gate ordering for ``execute`` (exactly as specced):
+#   1. Load candidate from latest watchlist (INV-13).
+#   2. Fresh reconcile → refresh account_state + open positions (AMBIGUOUS-03).
+#   3. Pretrade check  → ``block`` aborts (exit ≠ 0).
+#   4. Sizing (risk_fraction=0.0025, INV-05 cap) → reject (units=0) aborts.
+#   5. Limits / kill switch → reject aborts with kill-switch status.
+#   6. ``--dry-run``? print would-be order, return 0.  Otherwise confirm +
+#      build_bracket + submit_order → print Fill.
+
+
+def _load_candidate(
+    candidate_ref: str,
+    db_path: str,
+) -> "tuple[Optional[object], Optional[tuple[str, int]]]":
+    """Load a Candidate from the latest persisted watchlist.
+
+    Returns ``(candidate, None)`` on success or ``(None, (error_msg, exit_code))``
+    on failure.  Never executes off-watchlist input (INV-13, first AC).
+
+    The ref format is ``instrument:timeframe:strategy_name`` (DRIFT-04).
+    """
+    from signals.ranker import Candidate  # lazy — no HTTP in tests
+
+    parts = candidate_ref.split(":", 2)
+    if len(parts) != 3:
+        return (
+            None,
+            (
+                f"Invalid candidate ref {candidate_ref!r}: expected "
+                "instrument:timeframe:strategy_name "
+                "(e.g. EUR_USD:H1:macrossover_10_50).",
+                2,
+            ),
+        )
+    instrument, timeframe, strategy_name = parts
+
+    store = Store(db_path)
+    try:
+        rows = store.load_watchlist()  # latest run, run_timestamp=None
+    finally:
+        store.close()
+
+    if not rows:
+        return (
+            None,
+            ("No watchlist found in store. Run 'fathom scan' first.", 1),
+        )
+
+    matches = [
+        r for r in rows
+        if (
+            r["instrument"] == instrument
+            and r["timeframe"] == timeframe
+            and r["strategy_name"] == strategy_name
+        )
+    ]
+    if not matches:
+        all_refs = [
+            f"{r['instrument']}:{r['timeframe']}:{r['strategy_name']}"
+            for r in rows
+        ]
+        return (
+            None,
+            (
+                f"Candidate {candidate_ref!r} not found on the latest "
+                f"watchlist. Available refs: {all_refs}",
+                1,
+            ),
+        )
+
+    candidate = Candidate(**matches[0])
+    return (candidate, None)
+
+
+def cmd_execute(args: argparse.Namespace) -> int:
+    """Execute the ``fathom execute <candidate-ref>`` command.
+
+    Phase 3 gate (P3-T-10) — the canonical INV-01 enforcement point.
+    This command is NEVER a Hermes tool.
+
+    Gate ordering: load → reconcile → pretrade → sizing → limits → submit.
+
+    Returns the process exit code (0 = success / dry-run success,
+    non-zero = abort at any gate stage).
+    """
+    run_dt = datetime.now(tz=timezone.utc)
+    _log.info(
+        "fathom execute started at %s (dry_run=%s, yes=%s, candidate_ref=%r)",
+        run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        args.dry_run,
+        args.yes,
+        args.candidate_ref,
+    )
+
+    db_path: str = args.db_path
+    dry_run: bool = args.dry_run
+    skip_confirm: bool = args.yes
+
+    # ------------------------------------------------------------------
+    # Step 1: Load candidate from latest persisted watchlist (INV-13).
+    # ------------------------------------------------------------------
+    candidate_or_none, err = _load_candidate(args.candidate_ref, db_path)
+    if err is not None:
+        err_msg, exit_code = err
+        _log.error("execute: candidate resolution failed: %s", err_msg)
+        print(f"ERROR: {err_msg}", file=sys.stderr)
+        return exit_code
+
+    from signals.ranker import Candidate as _Candidate
+
+    if not isinstance(candidate_or_none, _Candidate):
+        # Should never happen: _load_candidate returns (Candidate, None) on success.
+        print("ERROR: unexpected internal error in candidate resolution.", file=sys.stderr)
+        return 1
+
+    candidate = candidate_or_none
+
+    _log.info(
+        "execute: loaded candidate %s/%s/%s from watchlist.",
+        candidate.instrument,
+        candidate.timeframe,
+        candidate.strategy_name,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Fresh reconcile BEFORE limits (AMBIGUOUS-03).
+    # Refresh account_state (day_pl, start_of_day_equity) and open
+    # positions from the broker so the kill switch reads current data.
+    # ------------------------------------------------------------------
+    settings = Settings()
+    _log.info("execute: connecting to OANDA (env=%s).", settings.env)  # INV-08: no token
+    client = OandaClient(settings)
+    store = Store(db_path)
+    try:
+        recon_report = reconcile(client=client, store=store, now=run_dt)
+    except Exception as exc:  # noqa: BLE001
+        _log.error("execute: reconcile failed: %s", exc)
+        print(f"ERROR: reconciliation failed: {exc}", file=sys.stderr)
+        store.close()
+        return 1
+    _log.info(
+        "execute: reconcile complete — adopted=%d closed=%d matched=%d "
+        "day_pl=%.4f start_of_day_equity=%.4f",
+        len(recon_report.adopted),
+        len(recon_report.closed),
+        len(recon_report.matched),
+        recon_report.day_pl,
+        recon_report.start_of_day_equity,
+    )
+
+    # Read the freshly-reconciled state.
+    account_state = store.load_account_state()
+    open_positions = store.load_open_positions()
+    store.close()
+
+    if account_state is None:
+        _log.error("execute: no account_state after reconcile — cannot continue.")
+        print(
+            "ERROR: account_state not available after reconcile.",
+            file=sys.stderr,
+        )
+        return 1
+
+    day_pl: float = float(account_state["day_pl"])  # type: ignore[arg-type]
+    start_of_day_equity: float = float(account_state["start_of_day_equity"])  # type: ignore[arg-type]
+    # NAV from the reconcile broker fetch is the current equity for sizing.
+    equity: float = start_of_day_equity + day_pl  # nav = snapshot + today's delta
+
+    # ------------------------------------------------------------------
+    # Step 3: Pretrade check.
+    # ``block`` aborts with a clear reason and non-zero exit.
+    # ------------------------------------------------------------------
+    verdict = pretrade_check(candidate)
+    if verdict.decision == "block":
+        _log.warning(
+            "execute: pretrade-check blocked: %s", verdict.reason
+        )
+        print(
+            f"BLOCKED by pretrade check: {verdict.reason}",
+            file=sys.stderr,
+        )
+        return 1
+
+    _log.info("execute: pretrade check → proceed (%s).", verdict.reason)
+
+    # ------------------------------------------------------------------
+    # Step 4: Sizing (risk_fraction = DEFAULT_RISK_FRACTION = 0.0025,
+    # the INV-05 cap — never above it).
+    # ``units == 0`` rejects with a reason; abort.
+    # ------------------------------------------------------------------
+    # Resolve instrument metadata from the cached store for min_trade_size
+    # and display_precision.
+    store2 = Store(db_path)
+    try:
+        instrument_metas = {m.name: m for m in store2.load_instruments()}
+    finally:
+        store2.close()
+
+    inst_meta = instrument_metas.get(candidate.instrument)
+    if inst_meta is None:
+        _log.error(
+            "execute: no InstrumentMeta cached for %s — run 'fathom backtest' "
+            "or 'fathom scan' (live) first.",
+            candidate.instrument,
+        )
+        print(
+            f"ERROR: no instrument metadata for {candidate.instrument}. "
+            "Run 'fathom scan' (live) first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # quote_to_account_rate: for pairs where the quote currency is USD
+    # (e.g. EUR_USD) rate = 1.0; for others (e.g. USD_JPY) rate = 1/mid.
+    # Simple heuristic: if instrument ends in "_USD", rate = 1.0; otherwise
+    # load the latest close_mid from the candle store as the proxy rate.
+    # If unavailable, fall back to 1.0 with a warning (safe — sizing still runs,
+    # may reject on the minimum-trade-size floor if the rate is very wrong).
+    rate: float = 1.0
+    if not candidate.instrument.endswith("_USD"):
+        store3 = Store(db_path)
+        try:
+            end_dt = datetime.now(tz=timezone.utc)
+            start_dt = end_dt - timedelta(days=3)
+            candles = store3.load_candles(
+                instrument=candidate.instrument,
+                granularity=candidate.timeframe,
+                start=start_dt,
+                end=end_dt,
+            )
+            if not candles.empty and "close_mid" in candles.columns:
+                last_mid = float(candles["close_mid"].iloc[-1])
+                if last_mid > 0:
+                    rate = 1.0 / last_mid
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "execute: could not derive quote→account rate for %s "
+                "(using 1.0 fallback): %s",
+                candidate.instrument,
+                exc,
+            )
+        finally:
+            store3.close()
+
+    sizing_result = size_position(
+        candidate,
+        equity,
+        instrument_meta=inst_meta,
+        rate=rate,
+        risk_fraction=DEFAULT_RISK_FRACTION,  # 0.0025 — never above INV-05 cap
+    )
+    if sizing_result.units == 0:
+        _log.warning("execute: sizing rejected: %s", sizing_result.reason)
+        print(
+            f"REJECTED by sizing: {sizing_result.reason}",
+            file=sys.stderr,
+        )
+        return 1
+
+    _log.info(
+        "execute: sizing approved — units=%d risk_amount=%.6g.",
+        sizing_result.units,
+        sizing_result.risk_amount,
+    )
+
+    # ------------------------------------------------------------------
+    # Build the bracketed Order (INV-04, INV-15).
+    # build_bracket is called here — before the limits check — so the
+    # fully-formed Order (with correct bracket prices) is passed to
+    # check_limits.  This is still within step 5: the Order is NOT
+    # submitted yet; it is used as the limits-gate input.
+    # ------------------------------------------------------------------
+    order = build_bracket(
+        candidate,
+        sizing_result.units,
+        execution_date=run_dt,
+        precision=inst_meta.display_precision,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 5: Limits / kill switch.
+    # Any rejection aborts with a clear reason and non-zero exit.
+    # ------------------------------------------------------------------
+    limits_config = LimitsConfig()
+    limit_decision = check_limits(
+        order,
+        open_positions=open_positions,
+        day_pl=day_pl,
+        equity=equity,
+        start_of_day_equity=start_of_day_equity,
+        config=limits_config,
+        now=run_dt,
+        order_risk=sizing_result.risk_amount,
+    )
+
+    if not limit_decision.allowed:
+        if limit_decision.kill_switch_active:
+            ks = kill_switch_status(
+                day_pl=day_pl,
+                start_of_day_equity=start_of_day_equity,
+                config=limits_config,
+                now=run_dt,
+            )
+            _log.warning(
+                "execute: kill switch ACTIVE — day_pl=%.6g cap_amount=%.6g "
+                "reset_at=%s",
+                ks.day_pl,
+                ks.cap_amount,
+                ks.reset_at.isoformat(),
+            )
+            print(
+                f"REJECTED by limits (kill switch ACTIVE): {limit_decision.reason}\n"
+                f"Kill switch resets at {ks.reset_at.isoformat()}.",
+                file=sys.stderr,
+            )
+        else:
+            _log.warning("execute: limits rejected: %s", limit_decision.reason)
+            print(
+                f"REJECTED by limits: {limit_decision.reason}",
+                file=sys.stderr,
+            )
+        return 1
+
+    _log.info("execute: limits check → allowed.")
+
+    # ------------------------------------------------------------------
+    # --dry-run: print the would-be order and exit 0 (no v20 call).
+    # ------------------------------------------------------------------
+    if dry_run:
+        order_dict = order.model_dump()
+        # Convert non-serialisable types for display.
+        order_dict["created_at"] = order.created_at.isoformat()
+        order_dict["direction"] = str(order.direction.value)
+        order_dict["entry_type"] = str(order.entry_type.value)
+        print("[DRY-RUN] Would submit the following order (no v20 call made):")
+        print(json.dumps(order_dict, indent=2, default=str))
+        _log.info(
+            "execute --dry-run: gate passed, order NOT submitted "
+            "(client_order_id=%s).",
+            order.client_order_id,
+        )
+        return 0
+
+    # ------------------------------------------------------------------
+    # Step 6: Interactive confirm (unless --yes) + submit.
+    # ------------------------------------------------------------------
+    if not skip_confirm:
+        summary = (
+            f"  Instrument : {order.instrument}\n"
+            f"  Direction  : {order.direction.value}\n"
+            f"  Units      : {order.units}\n"
+            f"  Stop       : {order.stop_loss_price}\n"
+            f"  Target     : {order.take_profit_price}\n"
+            f"  ID         : {order.client_order_id}\n"
+        )
+        print(f"\nAbout to submit order to OANDA ({settings.env}):\n{summary}")
+        try:
+            answer = input("Confirm submit? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.", file=sys.stderr)
+            return 1
+        if answer not in ("y", "yes"):
+            print("Aborted by operator.", file=sys.stderr)
+            return 1
+
+    store_submit = Store(db_path)
+    try:
+        fill = submit_order(
+            order,
+            client=client,
+            store=store_submit,
+            entry_ref=candidate.entry_ref,
+            precision=inst_meta.display_precision,
+            now=run_dt,
+        )
+    except OrderRejected as exc:
+        _log.error("execute: broker rejected order: %s", exc)
+        print(f"ORDER REJECTED by broker: {exc}", file=sys.stderr)
+        store_submit.close()
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _log.error("execute: order submission failed: %s", exc)
+        print(f"ERROR: order submission failed: {exc}", file=sys.stderr)
+        store_submit.close()
+        return 1
+    finally:
+        store_submit.close()
+
+    # Print the Fill to stdout (INV-14 contract).
+    fill_dict = {
+        "client_order_id": fill.client_order_id,
+        "broker_trade_id": fill.broker_trade_id,
+        "fill_price": fill.fill_price,
+        "units_filled": fill.units_filled,
+        "slippage": fill.slippage,
+        "status": str(fill.status.value),
+        "filled_at": fill.filled_at.isoformat(),
+    }
+    print(json.dumps(fill_dict, indent=2))
+    _log.info(
+        "fathom execute finished at %s. Fill: %s/%s price=%.5f slippage=%.5f.",
+        _utc_now_rfc3339(),
+        fill.broker_trade_id,
+        fill.status.value,
+        fill.fill_price,
+        fill.slippage,
+    )
+    return 0
+
+
+def cmd_positions(args: argparse.Namespace) -> int:
+    """Execute the ``fathom positions`` command.
+
+    Prints the store's open ``Position[]`` as JSON (INV-14 shape).
+    No live HTTP — pure DB read.
+
+    INV-01: never a Hermes tool.
+    """
+    _log.info("fathom positions started at %s.", _utc_now_rfc3339())
+
+    db_path: str = args.db_path
+    store = Store(db_path)
+    try:
+        open_positions = store.load_open_positions()
+    finally:
+        store.close()
+
+    output_list = []
+    for pos in open_positions:
+        pos_dict = {
+            "broker_trade_id": pos.broker_trade_id,
+            "instrument": pos.instrument,
+            "units": pos.units,
+            "entry_price": pos.entry_price,
+            "stop_loss_price": pos.stop_loss_price,
+            "take_profit_price": pos.take_profit_price,
+            "opened_at": pos.opened_at.isoformat(),
+            "unrealized_pl": pos.unrealized_pl,
+            "closed_at": pos.closed_at.isoformat() if pos.closed_at else None,
+            "realized_pl": pos.realized_pl,
+            "candidate_ref": pos.candidate_ref,
+        }
+        output_list.append(pos_dict)
+
+    print(json.dumps(output_list, indent=2, default=str))
+    _log.info(
+        "fathom positions finished at %s. Open positions: %d.",
+        _utc_now_rfc3339(),
+        len(open_positions),
+    )
+    return 0
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    """Execute the ``fathom reconcile`` command.
+
+    Runs one broker-truth reconciliation pass and prints the
+    ``ReconcileReport`` as JSON.
+
+    INV-01: never a Hermes tool.
+    INV-07: practice endpoint only (settings.env).
+    INV-08: no token logged.
+    INV-03: all timestamps UTC.
+    """
+    run_dt = datetime.now(tz=timezone.utc)
+    _log.info("fathom reconcile started at %s.", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    db_path: str = args.db_path
+    settings = Settings()
+    _log.info("reconcile: connecting to OANDA (env=%s).", settings.env)  # INV-08
+
+    client = OandaClient(settings)
+    store = Store(db_path)
+    try:
+        report = reconcile(client=client, store=store, now=run_dt)
+    except Exception as exc:  # noqa: BLE001
+        _log.error("reconcile: failed: %s", exc)
+        print(f"ERROR: reconcile failed: {exc}", file=sys.stderr)
+        store.close()
+        return 1
+    finally:
+        store.close()
+
+    report_dict = {
+        "adopted": report.adopted,
+        "closed": report.closed,
+        "matched": report.matched,
+        "drift_flags": report.drift_flags,
+        "start_of_day_equity": report.start_of_day_equity,
+        "day_pl": report.day_pl,
+        "snapshotted_today": report.snapshotted_today,
+        "as_of": run_dt.isoformat(),
+    }
+    print(json.dumps(report_dict, indent=2))
+    _log.info(
+        "fathom reconcile finished at %s. adopted=%d closed=%d matched=%d "
+        "day_pl=%.4f.",
+        _utc_now_rfc3339(),
+        len(report.adopted),
+        len(report.closed),
+        len(report.matched),
+        report.day_pl,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -1179,6 +1813,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         return cmd_watchlist(args)
     if args.command == "chart":
         return cmd_chart(args)
+    if args.command == "execute":
+        return cmd_execute(args)
+    if args.command == "positions":
+        return cmd_positions(args)
+    if args.command == "reconcile":
+        return cmd_reconcile(args)
     parser.error(f"Unknown command: {args.command}")
     return 2  # unreachable — parser.error exits
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -127,36 +127,55 @@ def _make_namespace(**kwargs: object) -> argparse.Namespace:
 
 
 # ---------------------------------------------------------------------------
-# INV-01 guard — no execution import path
+# INV-01 guard — hermes_integration must never reference execute/positions/reconcile
 # ---------------------------------------------------------------------------
 
 
 class TestNoOrderPath:
-    def test_cli_has_no_execution_import(self) -> None:
-        """cli.py must contain no reference to execution/orders/risk.sizing paths
-        anywhere — module-level OR inside function bodies (INV-01).
+    def test_hermes_integration_has_no_execution_commands(self) -> None:
+        """hermes_integration/ must not register or grant access to fathom execute,
+        fathom positions, or fathom reconcile — the Phase 2 allow-list is
+        scan/watchlist/chart only (INV-01).
 
-        The previous approach only inspected ``cli.__dict__`` module attributes,
-        which misses lazy ``from execution import ...`` inside function bodies.
-        This version does a direct source grep so both import styles are caught.
+        P3-T-10 added execute/positions/reconcile to cli.py, which is correct
+        and intentional — cli.py is the canonical INV-01 enforcement point.
+        The invariant is that Hermes (hermes_integration/) must NEVER be given
+        access to order/execution commands.  We scan every text file under
+        hermes_integration/ to assert the allow-list boundary is upheld.
+
+        Patterns checked are the CLI tool/command strings that Hermes would need
+        to reference to gain access: "fathom execute", "fathom positions",
+        "fathom reconcile".  Discussion of why NOT to grant access (as in daily.md)
+        is fine and is not caught by these exact patterns.
         """
-        import inspect
-        import importlib
+        import pathlib
 
-        module = sys.modules.get("cli") or importlib.import_module("cli")
-        source = inspect.getsource(module)
-
+        hermes_dir = pathlib.Path(__file__).parent.parent / "hermes_integration"
+        # These are the exact command strings a Hermes job definition would use
+        # to invoke the forbidden commands.  We do NOT match bare "execute" or
+        # "positions" to avoid flagging legitimate negative mentions (e.g.
+        # "Do not grant execute access").
         forbidden_patterns = [
-            "execution",
-            "orders",
-            "risk.sizing",
             "fathom execute",
+            "fathom positions",
+            "fathom reconcile",
         ]
-        for pattern in forbidden_patterns:
-            assert pattern not in source, (
-                f"cli.py contains a reference to forbidden pattern {pattern!r} "
-                f"(INV-01: no execution/order path in the scan surface)"
-            )
+        for file_path in hermes_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            # Only inspect text/code/markdown files; skip .pyc and __pycache__.
+            if file_path.suffix in (".pyc",) or "__pycache__" in file_path.parts:
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            for pattern in forbidden_patterns:
+                assert pattern not in content, (
+                    f"hermes_integration/{file_path.name} contains forbidden "
+                    f"pattern {pattern!r} — INV-01: Hermes must NOT have access "
+                    "to order/execution commands (allow-list: scan/watchlist/chart)."
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_execution_cli.py
+++ b/tests/test_execution_cli.py
@@ -1,0 +1,960 @@
+"""Tests for P3-T-10 execution CLI subcommands: execute, positions, reconcile.
+
+Design (NO live HTTP)
+---------------------
+* All tests drive ``cli.cmd_execute``, ``cli.cmd_positions``, ``cli.cmd_reconcile``
+  and ``cli.main`` directly — no subprocess.
+* OANDA client, Settings, reconcile, pretrade_check, submit_order are all stubbed
+  via ``unittest.mock.patch`` / injected fakes.  No live HTTP, no token in tests.
+* Tests exercise the EXACT gate ordering (pretrade → sizing → limits → submit)
+  and verify that any stage rejection aborts with non-zero exit and no order placed.
+
+Coverage
+--------
+1. Unknown candidate ref → exit ≠ 0 (no watchlist entry = no execution).
+2. Pretrade block → exit ≠ 0, no order placed.
+3. Sizing reject (equity 0 / stop 0) → exit ≠ 0, no order placed.
+4. Limits reject (kill switch active) → exit ≠ 0, reason + kill-switch status.
+5. Limits reject (max concurrent) → exit ≠ 0, reason.
+6. ``--dry-run`` runs steps 1–5 and prints would-be order WITHOUT calling submit.
+7. Successful path (mocked submit) → exit 0, Fill JSON on stdout.
+8. ``fathom positions`` → prints open Position[] JSON.
+9. ``fathom reconcile`` → calls reconcile once, prints report JSON.
+10. INV-01 boundary: ``hermes_integration/`` never references the execution commands.
+11. fathom --help lists execute/positions/reconcile.
+12. risk_fraction is always DEFAULT_RISK_FRACTION (0.0025) — never above the cap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from contextlib import redirect_stdout, redirect_stderr
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+import cli
+from data.store import Store
+from data.oanda_client import InstrumentMeta
+from signals.ranker import Candidate
+from execution.models import Fill, FillStatus, Position
+from execution.reconcile import ReconcileReport
+from risk.sizing import DEFAULT_RISK_FRACTION
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _make_candidate(
+    instrument: str = "EUR_USD",
+    timeframe: str = "H1",
+    strategy_name: str = "macrossover_10_50",
+    direction: str = "LONG",
+    entry_ref: float = 1.1050,
+    stop_distance: float = 0.0020,
+    target_distance: float = 0.0030,
+) -> Candidate:
+    return Candidate(
+        instrument=instrument,
+        timeframe=timeframe,
+        strategy_name=strategy_name,
+        direction=direction,
+        entry_ref=entry_ref,
+        stop_distance=stop_distance,
+        target_distance=target_distance,
+        oos_sharpe_mean=1.5,
+        quality_score=0.75,
+        rank=1,
+        spread_ok=True,
+        session_ok=True,
+        news_flag=False,
+        generated_at="2026-04-10T12:00:00Z",
+    )
+
+
+def _make_instrument_meta(name: str = "EUR_USD") -> InstrumentMeta:
+    return InstrumentMeta(
+        name=name,
+        pip_location=-4,
+        min_trade_size=1.0,
+        margin_rate=0.02,
+        display_precision=5,
+        long_rate=0.0001,
+        short_rate=-0.0002,
+        financing_days_of_week=[2],  # Wednesday
+    )
+
+
+def _make_fill(
+    client_order_id: str = "abc123",
+    broker_trade_id: str = "T001",
+    fill_price: float = 1.1052,
+    units_filled: int = 1000,
+) -> Fill:
+    return Fill(
+        client_order_id=client_order_id,
+        broker_trade_id=broker_trade_id,
+        fill_price=fill_price,
+        units_filled=units_filled,
+        slippage=0.0002,
+        filled_at=_utc(2026, 4, 10, 12, 1),
+        status=FillStatus.FILLED,
+    )
+
+
+def _make_position(
+    broker_trade_id: str = "T001",
+    instrument: str = "EUR_USD",
+    units: int = 1000,
+) -> Position:
+    return Position(
+        broker_trade_id=broker_trade_id,
+        instrument=instrument,
+        units=units,
+        entry_price=1.1052,
+        stop_loss_price=1.1030,
+        take_profit_price=1.1082,
+        opened_at=_utc(2026, 4, 10, 12, 1),
+        unrealized_pl=0.5,
+        closed_at=None,
+        realized_pl=None,
+        candidate_ref="EUR_USD:H1:macrossover_10_50",
+    )
+
+
+def _make_namespace(**kwargs: object) -> argparse.Namespace:
+    """Build an argparse.Namespace with execute/positions/reconcile defaults."""
+    defaults = {
+        "command": "execute",
+        "candidate_ref": "EUR_USD:H1:macrossover_10_50",
+        "db_path": "/tmp/fathom_execute_test_not_used.db",
+        "dry_run": False,
+        "yes": True,  # skip interactive confirm in tests
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _seed_watchlist(store: Store, candidate: Candidate) -> None:
+    """Persist one candidate to the watchlist table (latest run)."""
+    run_dt = _utc(2026, 4, 10, 10)
+    store.write_watchlist([candidate], run_timestamp=run_dt)
+
+
+def _seed_account_state(
+    store: Store,
+    start_of_day_equity: float = 100_000.0,
+    day_pl: float = 0.0,
+) -> None:
+    store.write_account_state(
+        start_of_day_equity=start_of_day_equity,
+        day_pl=day_pl,
+        as_of=_utc(2026, 4, 10, 10),
+    )
+
+
+def _make_reconcile_report(
+    start_of_day_equity: float = 100_000.0,
+    day_pl: float = 0.0,
+) -> ReconcileReport:
+    report = ReconcileReport()
+    report.start_of_day_equity = start_of_day_equity
+    report.day_pl = day_pl
+    return report
+
+
+# ---------------------------------------------------------------------------
+# 1. Unknown candidate ref → exit ≠ 0 (INV-13 gate)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteUnknownRef:
+    def test_unknown_ref_exits_nonzero(self, tmp_path: object) -> None:
+        """An unknown candidate_ref errors with exit ≠ 0 without placing an order."""
+        assert isinstance(tmp_path, type(tmp_path))  # hint for mypy
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+
+        # Seed an empty watchlist (no candidates) in the DB.
+        store = Store(db_path)
+        store.close()
+
+        args = _make_namespace(
+            candidate_ref="EUR_USD:H1:does_not_exist",
+            db_path=db_path,
+            dry_run=True,
+        )
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            code = cli.cmd_execute(args)
+        assert code != 0, "Should exit non-zero for unknown candidate ref"
+        assert "ERROR" in buf.getvalue() or code != 0
+
+    def test_wrong_ref_format_exits_nonzero(self, tmp_path: object) -> None:
+        """A malformed ref (not instrument:timeframe:strategy) errors exit ≠ 0."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        store.close()
+
+        args = _make_namespace(
+            candidate_ref="BADINPUT",
+            db_path=db_path,
+            dry_run=True,
+        )
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            code = cli.cmd_execute(args)
+        assert code not in (0,)
+
+    def test_ref_not_on_watchlist_exits_nonzero(self, tmp_path: object) -> None:
+        """A ref present in the watchlist for a different candidate ref is rejected."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        # Seed a EUR_USD candidate but ask for GBP_USD.
+        _seed_watchlist(store, _make_candidate(instrument="EUR_USD"))
+        store.close()
+
+        args = _make_namespace(
+            candidate_ref="GBP_USD:H1:macrossover_10_50",
+            db_path=db_path,
+            dry_run=True,
+        )
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            code = cli.cmd_execute(args)
+        assert code != 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Pretrade block → exit ≠ 0, no order placed
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePretradeBlock:
+    def test_pretrade_block_aborts(self, tmp_path: object) -> None:
+        """A pretrade 'block' verdict aborts with exit ≠ 0 (no order placed)."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        block_verdict = PretradeVerdict(decision="block", reason="high-impact news event")
+
+        mock_recon_report = _make_reconcile_report()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=block_verdict),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0, "Pretrade block must produce non-zero exit"
+        assert "BLOCKED" in buf_err.getvalue() or code != 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Sizing reject → exit ≠ 0, no order placed
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSizingReject:
+    def test_sizing_reject_aborts(self, tmp_path: object) -> None:
+        """When sizing returns units=0, execute aborts with non-zero exit."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        # Use a very tiny stop_distance so the size is 0 at this equity.
+        # Actually, use equity = 0 by setting day_pl = -start_of_day_equity.
+        # Easier: make equity extremely small so we cannot fund min trade size.
+        candidate = _make_candidate(stop_distance=1000.0)  # huge stop → 0 units
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=1.0, day_pl=0.0)  # $1 equity
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="all clear")
+        mock_recon_report = _make_reconcile_report(
+            start_of_day_equity=1.0, day_pl=0.0
+        )
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0, "Sizing reject must produce non-zero exit"
+        assert "REJECTED" in buf_err.getvalue() or code != 0
+
+    def test_risk_fraction_is_exactly_default_cap(self, tmp_path: object) -> None:
+        """risk_fraction passed to size_position must be DEFAULT_RISK_FRACTION (0.0025)."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        mock_recon_report = _make_reconcile_report()
+
+        captured_kwargs: dict[str, object] = {}
+
+        from risk.sizing import SizingResult
+
+        def spy_size_position(candidate, equity, *, instrument_meta, rate=1.0, risk_fraction=DEFAULT_RISK_FRACTION):  # type: ignore[no-untyped-def]
+            captured_kwargs["risk_fraction"] = risk_fraction
+            # Return a rejection so the test stops early (no limits/submit needed).
+            return SizingResult(units=0, risk_amount=0.0, reason="spy stop")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", side_effect=spy_size_position),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            with redirect_stderr(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert "risk_fraction" in captured_kwargs, "size_position was not called"
+        assert captured_kwargs["risk_fraction"] == DEFAULT_RISK_FRACTION, (
+            f"risk_fraction must be {DEFAULT_RISK_FRACTION} (the INV-05 cap), "
+            f"got {captured_kwargs['risk_fraction']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Limits reject — kill switch active
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteLimitsReject:
+    def test_kill_switch_active_aborts(self, tmp_path: object) -> None:
+        """Kill switch active → exit ≠ 0, reason + kill-switch status printed."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        # day_pl is -1500 on $100k equity → 1.5% loss > 1% cap → kill switch trips.
+        _seed_account_state(store, start_of_day_equity=100_000.0, day_pl=-1500.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        sizing_ok = SizingResult(units=10000, risk_amount=2.0, reason=None)
+        mock_recon_report = _make_reconcile_report(
+            start_of_day_equity=100_000.0, day_pl=-1500.0
+        )
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", return_value=sizing_ok),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0, "Kill switch must produce non-zero exit"
+        err_output = buf_err.getvalue()
+        assert "kill switch" in err_output.lower() or "REJECTED" in err_output
+
+    def test_max_concurrent_aborts(self, tmp_path: object) -> None:
+        """Max concurrent positions exceeded → exit ≠ 0."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        # Seed 5 open positions (the default limit).
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        for i in range(5):
+            pos = Position(
+                broker_trade_id=f"T00{i}",
+                instrument="GBP_USD",
+                units=1000 * (1 if i % 2 == 0 else -1),
+                entry_price=1.2500,
+                stop_loss_price=1.2480,
+                take_profit_price=1.2530,
+                opened_at=_utc(2026, 4, 10, 10),
+                unrealized_pl=0.0,
+                candidate_ref=f"GBP_USD:H1:strat{i}",
+            )
+            store.write_position(pos)
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        sizing_ok = SizingResult(units=1000, risk_amount=2.0, reason=None)
+        mock_recon_report = _make_reconcile_report()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", return_value=sizing_ok),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0, "Max concurrent exceeded must produce non-zero exit"
+
+
+# ---------------------------------------------------------------------------
+# 5. --dry-run: steps 1–5 only, no v20 call
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDryRun:
+    def test_dry_run_prints_order_no_submit(self, tmp_path: object) -> None:
+        """--dry-run prints the would-be order and exits 0 without calling submit_order."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        sizing_ok = SizingResult(units=5000, risk_amount=10.0, reason=None)
+        mock_recon_report = _make_reconcile_report()
+
+        submit_mock = MagicMock(name="submit_order")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", return_value=sizing_ok),
+            patch("cli.submit_order", submit_mock),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            buf_out = io.StringIO()
+            with redirect_stdout(buf_out):
+                code = cli.cmd_execute(args)
+
+        assert code == 0, f"--dry-run should exit 0, got {code}"
+        submit_mock.assert_not_called()  # submit_order must NOT be called under --dry-run
+        out = buf_out.getvalue()
+        assert "[DRY-RUN]" in out
+        # Should contain a JSON blob with order fields.
+        assert "client_order_id" in out
+
+    def test_dry_run_gate_order(self, tmp_path: object) -> None:
+        """--dry-run: reconcile is called BEFORE pretrade, which is BEFORE sizing."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        call_order: list[str] = []
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        def track_reconcile(**kwargs: object) -> ReconcileReport:
+            call_order.append("reconcile")
+            return _make_reconcile_report()
+
+        def track_pretrade(candidate: object, **kwargs: object) -> "PretradeVerdict":
+            call_order.append("pretrade")
+            return PretradeVerdict(decision="proceed", reason="ok")
+
+        def track_sizing(candidate: object, equity: object, **kwargs: object) -> "SizingResult":
+            call_order.append("sizing")
+            return SizingResult(units=1000, risk_amount=2.0)
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", side_effect=track_reconcile),
+            patch("cli.pretrade_check", side_effect=track_pretrade),
+            patch("cli.size_position", side_effect=track_sizing),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            with redirect_stdout(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        # reconcile before pretrade before sizing.
+        assert call_order[0] == "reconcile", f"reconcile must be first, got {call_order}"
+        assert call_order[1] == "pretrade", f"pretrade must be second, got {call_order}"
+        assert call_order[2] == "sizing", f"sizing must be third, got {call_order}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Successful path (mocked submit) → exit 0, Fill JSON on stdout
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    def test_success_prints_fill_json(self, tmp_path: object) -> None:
+        """A fully passing gate with --yes skips confirm and prints Fill JSON."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        fill = _make_fill()
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed = PretradeVerdict(decision="proceed", reason="ok")
+        sizing_ok = SizingResult(units=5000, risk_amount=10.0)
+        mock_recon_report = _make_reconcile_report()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed),
+            patch("cli.size_position", return_value=sizing_ok),
+            patch("cli.submit_order", return_value=fill),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            buf_out = io.StringIO()
+            with redirect_stdout(buf_out):
+                code = cli.cmd_execute(args)
+
+        assert code == 0, f"Successful gate should exit 0, got {code}"
+        out = buf_out.getvalue()
+        # Should be valid JSON with fill fields.
+        fill_data = json.loads(out)
+        assert fill_data["broker_trade_id"] == fill.broker_trade_id
+        assert fill_data["fill_price"] == fill.fill_price
+        assert fill_data["units_filled"] == fill.units_filled
+
+    def test_broker_rejection_exits_nonzero(self, tmp_path: object) -> None:
+        """An OrderRejected exception from submit_order exits non-zero."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from execution.orders import OrderRejected
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed = PretradeVerdict(decision="proceed", reason="ok")
+        sizing_ok = SizingResult(units=5000, risk_amount=10.0)
+        mock_recon_report = _make_reconcile_report()
+
+        def reject_order(order: object, **kwargs: object) -> Fill:
+            raise OrderRejected("abc123", "INSUFFICIENT_MARGIN")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_recon_report),
+            patch("cli.pretrade_check", return_value=proceed),
+            patch("cli.size_position", return_value=sizing_ok),
+            patch("cli.submit_order", side_effect=reject_order),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0
+        assert "REJECTED" in buf_err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 7. fathom positions
+# ---------------------------------------------------------------------------
+
+
+class TestPositionsCommand:
+    def test_positions_empty(self, tmp_path: object) -> None:
+        """``fathom positions`` prints an empty JSON array when no positions exist."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        store.close()
+
+        args = argparse.Namespace(command="positions", db_path=db_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cli.cmd_positions(args)
+
+        assert code == 0
+        data = json.loads(buf.getvalue())
+        assert data == []
+
+    def test_positions_with_open_positions(self, tmp_path: object) -> None:
+        """``fathom positions`` prints open Position[] JSON."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        pos = _make_position()
+        store.write_position(pos)
+        store.close()
+
+        args = argparse.Namespace(command="positions", db_path=db_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cli.cmd_positions(args)
+
+        assert code == 0
+        data = json.loads(buf.getvalue())
+        assert len(data) == 1
+        assert data[0]["broker_trade_id"] == pos.broker_trade_id
+        assert data[0]["instrument"] == pos.instrument
+        assert data[0]["units"] == pos.units
+
+    def test_positions_via_main(self, tmp_path: object) -> None:
+        """``fathom positions`` is reachable via ``cli.main``."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        store.close()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cli.main(["positions", "--db-path", db_path])
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. fathom reconcile
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileCommand:
+    def test_reconcile_prints_report(self, tmp_path: object) -> None:
+        """``fathom reconcile`` calls reconcile once and prints the report JSON."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        store.close()
+
+        mock_report = _make_reconcile_report(
+            start_of_day_equity=100_000.0, day_pl=-50.0
+        )
+        mock_report.adopted = ["T001"]
+        mock_report.closed = []
+        mock_report.matched = ["T002"]
+        mock_report.drift_flags = ["some drift"]
+
+        args = argparse.Namespace(command="reconcile", db_path=db_path)
+        buf = io.StringIO()
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=mock_report),
+            redirect_stdout(buf),
+        ):
+            code = cli.cmd_reconcile(args)
+
+        assert code == 0
+        data = json.loads(buf.getvalue())
+        assert data["adopted"] == ["T001"]
+        assert data["matched"] == ["T002"]
+        assert data["day_pl"] == -50.0
+        assert "drift_flags" in data
+
+    def test_reconcile_failure_exits_nonzero(self, tmp_path: object) -> None:
+        """Reconcile HTTP failure exits non-zero."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        store = Store(db_path)
+        store.close()
+
+        args = argparse.Namespace(command="reconcile", db_path=db_path)
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", side_effect=RuntimeError("broker down")),
+            redirect_stderr(io.StringIO()),
+        ):
+            code = cli.cmd_reconcile(args)
+        assert code != 0
+
+
+# ---------------------------------------------------------------------------
+# 9. INV-01 boundary: hermes_integration/ never references execution commands
+# ---------------------------------------------------------------------------
+
+
+class TestInv01Boundary:
+    def test_hermes_integration_has_no_execute_command_references(self) -> None:
+        """hermes_integration/ must not reference 'fathom execute',
+        'fathom positions', or 'fathom reconcile' — INV-01 enforcement."""
+        import pathlib
+
+        hermes_dir = pathlib.Path(__file__).parent.parent / "hermes_integration"
+        forbidden_patterns = [
+            "fathom execute",
+            "fathom positions",
+            "fathom reconcile",
+        ]
+        for file_path in hermes_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            if file_path.suffix in (".pyc",) or "__pycache__" in file_path.parts:
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            for pattern in forbidden_patterns:
+                assert pattern not in content, (
+                    f"{file_path} contains forbidden pattern {pattern!r} — "
+                    "INV-01: Hermes must NOT have access to order/execution "
+                    "commands (allow-list: scan/watchlist/chart only)."
+                )
+
+    def test_daily_md_allowlist_unchanged(self) -> None:
+        """hermes_integration/jobs/daily.md allow-list is still scan/watchlist/chart."""
+        import pathlib
+
+        daily_path = (
+            pathlib.Path(__file__).parent.parent
+            / "hermes_integration" / "jobs" / "daily.md"
+        )
+        if not daily_path.exists():
+            pytest.skip("daily.md not found")
+
+        content = daily_path.read_text(encoding="utf-8")
+        # The allow-list must remain scan/watchlist/chart.
+        assert "fathom scan" in content, "fathom scan must be in the allow-list"
+        assert "fathom watchlist" in content, "fathom watchlist must be in the allow-list"
+        assert "fathom chart" in content, "fathom chart must be in the allow-list"
+
+
+# ---------------------------------------------------------------------------
+# 10. fathom --help lists execute/positions/reconcile
+# ---------------------------------------------------------------------------
+
+
+class TestCliHelp:
+    def test_fathom_help_lists_all_subcommands(self, capsys: object) -> None:
+        """fathom --help lists execute/positions/reconcile alongside backtest/scan."""
+        import subprocess
+        result = subprocess.run(
+            [".venv/bin/fathom", "--help"],
+            capture_output=True,
+            text=True,
+            cwd="/home/sam-baby/development/fathom",
+        )
+        output = result.stdout + result.stderr
+        assert "execute" in output
+        assert "positions" in output
+        assert "reconcile" in output
+        assert "backtest" in output
+        assert "scan" in output
+        assert "watchlist" in output
+        assert "chart" in output
+
+
+# ---------------------------------------------------------------------------
+# 11. Gate ordering: pretrade must come BEFORE sizing, sizing BEFORE limits
+# (already partially tested in test_dry_run_gate_order — explicit limits check)
+# ---------------------------------------------------------------------------
+
+
+class TestGateOrdering:
+    def test_pretrade_before_sizing_before_limits(self, tmp_path: object) -> None:
+        """Gate order: reconcile → pretrade → sizing → limits (→ submit)."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        call_order: list[str] = []
+        fill = _make_fill()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+        from risk.limits import LimitDecision
+
+        def track_reconcile(**kwargs: object) -> ReconcileReport:
+            call_order.append("reconcile")
+            return _make_reconcile_report()
+
+        def track_pretrade(c: object, **kwargs: object) -> "PretradeVerdict":
+            call_order.append("pretrade")
+            return PretradeVerdict(decision="proceed", reason="ok")
+
+        def track_sizing(c: object, eq: object, **kwargs: object) -> "SizingResult":
+            call_order.append("sizing")
+            return SizingResult(units=1000, risk_amount=2.0)
+
+        def track_check_limits(*args: object, **kwargs: object) -> "LimitDecision":
+            call_order.append("limits")
+            return LimitDecision(allowed=True)
+
+        def track_submit(order: object, **kwargs: object) -> Fill:
+            call_order.append("submit")
+            return fill
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", side_effect=track_reconcile),
+            patch("cli.pretrade_check", side_effect=track_pretrade),
+            patch("cli.size_position", side_effect=track_sizing),
+            patch("cli.check_limits", side_effect=track_check_limits),
+            patch("cli.submit_order", side_effect=track_submit),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            with redirect_stdout(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert call_order == [
+            "reconcile",
+            "pretrade",
+            "sizing",
+            "limits",
+            "submit",
+        ], f"Wrong gate order: {call_order}"
+
+    def test_pretrade_block_prevents_sizing(self, tmp_path: object) -> None:
+        """A pretrade block must short-circuit: sizing must NOT be called."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+
+        sizing_mock = MagicMock(name="size_position")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=_make_reconcile_report()),
+            patch(
+                "cli.pretrade_check",
+                return_value=PretradeVerdict(decision="block", reason="news"),
+            ),
+            patch("cli.size_position", sizing_mock),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            with redirect_stderr(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert code != 0
+        sizing_mock.assert_not_called()  # size_position must NOT be called after pretrade block
+
+    def test_sizing_reject_prevents_limits(self, tmp_path: object) -> None:
+        """A sizing reject must short-circuit: check_limits must NOT be called."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate()
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        limits_mock = MagicMock(name="check_limits")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=_make_reconcile_report()),
+            patch(
+                "cli.pretrade_check",
+                return_value=PretradeVerdict(decision="proceed", reason="ok"),
+            ),
+            patch(
+                "cli.size_position",
+                return_value=SizingResult(units=0, risk_amount=0.0, reason="tiny equity"),
+            ),
+            patch("cli.check_limits", limits_mock),
+        ):
+            args = _make_namespace(db_path=db_path, dry_run=True)
+            with redirect_stderr(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert code != 0
+        limits_mock.assert_not_called()  # check_limits must NOT be called after sizing reject


### PR DESCRIPTION
## Summary

- Adds `fathom execute <instrument:timeframe:strategy>` as the canonical Phase 3 operator gate — the INV-01 enforcement point that turns a watchlist candidate into a trade. This is a CLI command run by the operator, **never a Hermes tool**.
- Gate ordering (exactly as specced): load-from-watchlist → fresh-reconcile (AMBIGUOUS-03) → pretrade-check → sizing (risk_fraction=0.0025, INV-05 cap) → build_bracket → limits/kill-switch → [dry-run or confirm+submit].
- Any stage rejection → non-zero exit with clear reason, no order placed.
- `--dry-run` runs steps 1–5 and prints the would-be order **without any v20 submission**.
- `--yes` skips the interactive confirm prompt.
- `fathom positions` (read-only open Position[] JSON) and `fathom reconcile` (one broker-truth pass) added as operator helpers.

## INV-01 boundary test

`TestInv01Boundary` in `tests/test_execution_cli.py` scans every file under `hermes_integration/` for `"fathom execute"`, `"fathom positions"`, `"fathom reconcile"` (exact command strings a Hermes job definition would need). The Phase 2 `daily.md` allow-list (scan/watchlist/chart) is unchanged.

`TestNoOrderPath` in `tests/test_cli_commands.py` was updated from the Phase 2 guard (which forbade "execution" in cli.py — now outdated since cli.py is the legitimate join point) to the correct boundary check on `hermes_integration/`.

## Test plan

- [ ] `pytest tests/test_execution_cli.py` — 23 new tests (gate ordering, each stage rejection, dry-run, INV-01 boundary, help output, risk_fraction cap)
- [ ] `pytest tests/test_cli_commands.py` — existing 17 tests still pass (scan/watchlist/chart/backtest unbroken)
- [ ] `pytest -q` — 955 total, all pass
- [ ] `mypy .` — 0 errors (79 files)
- [ ] `fathom --help` — lists execute/positions/reconcile alongside backtest/scan/watchlist/chart

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)