### PR TITLE
docs(phase-4): draft 3 feature specs (admin panel)

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -66,8 +66,18 @@ Maps to product-spec Phase 4. The phase where Fathom gains order authority — k
 | monitor-alerts | format + deliver `DeviationEvent` to Discord via Hermes gateway; durable deviation log | [monitor-alerts.md](monitor-alerts.md) | ready |
 | execution-cli | `fathom execute <candidate>` operator join (the INV-01 enforcement point); `positions`/`reconcile` helpers | [execution-cli.md](execution-cli.md) | ready |
 
-## Later — admin panel & hardening (impl-Phase 4+)
+## Phase 4 — admin panel & hardening, demo only (specs drafted; cross-spec audit pending)
+
+Maps to product-spec Phase 5. A **read-only** Streamlit dashboard over the existing store + TradingView Lightweight Charts; the only action is a scan-refresh (no order/execute — INV-01; execution stays the CLI). See [phase-4.md](../phases/phase-4.md).
+
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| equity-snapshots | `equity_snapshots` table + reconcile appends a timestamped `(equity, day_pl)` point (backend enabler for the equity curve) | [equity-snapshots.md](equity-snapshots.md) | draft |
+| panel-data-layer | `panel/data.py` read-only accessors + view models (blotter, equity series + drawdown, watchlist, deviation log, chart data); the tested seam | [panel-data-layer.md](panel-data-layer.md) | draft |
+| admin-panel | Streamlit app: 5 views + Lightweight Charts overlays + scan-refresh button; INV-01 read-only boundary | [admin-panel.md](admin-panel.md) | draft |
+
+## Later — go-live (impl-Phase 5)
 
 | Feature | Summary | Status |
 |---|---|---|
-| admin-panel | Streamlit + Lightweight Charts dashboard (charts, blotter, equity, watchlist, deviation log) | planned |
+| go-live | live-endpoint switch + small-size deliberate go-live decision (product-spec Phase 6, INV-07) | planned |

--- a/docs/features/admin-panel.md
+++ b/docs/features/admin-panel.md
@@ -1,0 +1,121 @@
+# Feature: admin-panel
+
+**Status.** draft
+**Phase.** Phase 4
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The self-hosted Streamlit dashboard — the single screen for everything the system
+is doing. It renders the five views over `panel/data.py`'s view models: per-pair
+candle charts (TradingView Lightweight Charts™ with our entry/stop/target/signal
+overlays), an equity curve + drawdown, a live blotter, the ranked watchlist, and
+the deviation log. Its only mutating action is a **refresh button** that runs
+`fathom scan`. It is **read-only over execution** — no order/approve/execute action;
+order authority stays the operator CLI (INV-01).
+
+## User-facing behaviour
+
+`panel/app.py`, launched with `streamlit run panel/app.py` (optionally
+`-- --db-path PATH`). A tabbed/sidebar layout:
+
+1. **Charts** — pick an instrument/timeframe → candles via the Lightweight Charts
+   component, overlaid with the active/proposed entry (from the open position or
+   watchlist candidate), stop, target, and the signal marker. Apache-2.0
+   attribution shown (the component's attribution logo).
+2. **Equity** — equity curve + drawdown from `equity_series()`.
+3. **Blotter** — open positions, unrealized P&L, today's realized `day_pl`, and
+   risk-in-use vs `max_book_risk`.
+4. **Watchlist** — the latest ranked `Candidate[]` (mirrors the Discord watchlist).
+5. **Deviation log** — the monitor's alerts, newest first.
+
+A **Refresh** button (sidebar) runs `fathom scan` synchronously (spinner) and
+re-reads the store. No other action mutates anything; there is **no execute/approve
+control**.
+
+## Acceptance criteria
+
+- [ ] `streamlit run panel/app.py` launches and renders all five views against a seeded demo store (no separate datastore — same SQLite file).
+- [ ] Charts render candles via the Lightweight Charts component with entry/stop/target/signal overlays and the required attribution.
+- [ ] Equity view plots the curve + drawdown; blotter shows positions + unrealized P&L + `day_pl` + risk-in-use vs limit; watchlist shows the latest `Candidate[]` (INV-13); deviation log shows entries newest-first.
+- [ ] The **Refresh** button runs `fathom scan` (the non-order path) and re-reads; **no order/execute path is reachable from the UI**.
+- [ ] **INV-01 read-only boundary:** `panel/` imports nothing from `execution/orders.py` or `risk/` sizing/placement, never calls `fathom execute`/`submit_order`/`build_bracket`, and exposes no execute/approve action. A test asserts the panel modules expose no order/execution capability.
+- [ ] All displayed timestamps are UTC (INV-03); no secret (OANDA token, webhook URL, API key) is rendered or logged (INV-08); reads the demo store only (INV-07).
+- [ ] The view code is thin over `panel/data.py` — the rendering layer holds no business logic that isn't covered by the data-layer tests.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    actor OP as Operator (browser)
+    participant APP as panel/app.py (Streamlit)
+    participant PD as panel/data.py
+    participant ST as store (SQLite)
+    participant SCAN as fathom scan
+
+    OP->>APP: open dashboard
+    APP->>PD: equity_series / blotter / watchlist / deviation_log / chart_data
+    PD->>ST: read-only loaders
+    ST-->>PD: rows
+    PD-->>APP: view models
+    APP-->>OP: rendered views (read-only)
+    opt Refresh button
+        OP->>APP: click Refresh
+        APP->>SCAN: run fathom scan (non-order)
+        SCAN->>ST: refresh candles / re-rank watchlist
+        APP->>PD: re-read
+        APP-->>OP: updated views
+    end
+    Note over APP: no execute/approve control — INV-01
+```
+
+## Component design
+
+`panel/app.py` is a thin Streamlit view over `panel/data.py`. The Lightweight
+Charts integration uses a Streamlit component (`streamlit-lightweight-charts` or
+equivalent — pinned at spec time), fed the `ChartData` view model. The refresh
+button calls the existing scan entrypoint (the `cmd_scan` code path / a thin
+wrapper) — **not** any execution function. The app imports `panel.data` and
+Streamlit only; it must not import `execution.orders` or `risk` placement/sizing.
+Because Streamlit apps resist unit testing, correctness lives in `panel/data.py`'s
+tests; the app's own test is a thin import-time/boundary test (renders without
+error against a seeded store via Streamlit's testing harness if available, plus the
+INV-01 no-order-capability assertion).
+
+## Non-goals
+
+- No order/approve/execute action from the UI (INV-01) — execution stays the CLI.
+- No auth/multi-user (single private-server operator; bind locally / server-level access control).
+- No FastAPI/React rewrite (Streamlit first, per the product spec's "graduate later").
+- No new data — renders only what the store already holds.
+
+## Touches
+
+- [INV-01] — the panel monitors only; the one action is the non-order scan-refresh; no order-authority surface.
+- [INV-03] — UTC timestamps displayed.
+- [INV-07] — demo store only.
+- [INV-08] — no secret rendered/logged.
+- [INV-13] — watchlist view renders the frozen `Candidate` unchanged.
+
+## Depends on
+
+- [[panel-data-layer]] (the view models), [[equity-snapshots]] (the equity series), the scan entrypoint (`cli.py cmd_scan`, shipped), `streamlit` + a Lightweight Charts component (new deps — coordinator edit).
+
+## Approach
+
+Drafted last (the join). Build the shell + the 5 views over the tested data layer;
+wire the Lightweight Charts component; add the refresh button; assert the INV-01
+boundary with a test. Manual acceptance (operator runs the panel against the demo
+store) is the phase gate.
+
+## Open questions
+
+- Lightweight Charts component package + version (maintenance check) — pin here;
+  fallback to a minimal custom component if the community one is stale.
+- Refresh UX: synchronous (spinner) for demo; revisit background refresh later.
+- App-level auth: none for demo (private server) — documented.
+
+## Out of scope
+
+- The data/query layer ([[panel-data-layer]]), the snapshot capture ([[equity-snapshots]]), go-live (impl-Phase 5, INV-07).

--- a/docs/features/equity-snapshots.md
+++ b/docs/features/equity-snapshots.md
@@ -1,0 +1,78 @@
+# Feature: equity-snapshots
+
+**Status.** draft
+**Phase.** Phase 4
+**Owner.** saambaby
+**Last updated.** 2026-05-29
+
+## Summary
+
+The backend enabler for the panel's equity curve: a new `equity_snapshots` table
+that records a timestamped `(equity, day_pl)` point on every reconcile pass. Today
+`account_state` is a singleton row (the *current* day's figures, overwritten each
+reconcile) — there is no history to plot. This feature has the already-periodic
+`reconcile` append one immutable snapshot per pass, giving the panel a true
+broker-sourced equity time series with no new moving parts.
+
+## User-facing behaviour
+
+No CLI surface of its own (the panel reads it; `fathom reconcile` writes it as a
+side effect). Two pieces:
+
+- `data/store.py` gains an `equity_snapshots` table and:
+  - `write_equity_snapshot(*, as_of: str, equity: float, day_pl: float) -> None` — append-only insert.
+  - `load_equity_snapshots(*, since: str | None = None) -> list[dict]` — ordered by `as_of` ascending, optional lower bound.
+- `execution/reconcile.py` — immediately after it computes `nav` and
+  `day_pl = nav − start_of_day_equity` (the existing lines), it appends one
+  snapshot `(as_of=now (RFC-3339 Z), equity=nav, day_pl=day_pl)`. This is purely
+  additive — it does not change the reconcile diff, the `account_state` update, or
+  the `ReconcileReport`.
+
+## Acceptance criteria
+
+- [ ] `equity_snapshots` columns: `as_of` (TEXT, UTC RFC-3339, INV-03), `equity` (REAL), `day_pl` (REAL). Append-only (no overwrite); migration is additive (`CREATE TABLE IF NOT EXISTS`, consistent with the existing store).
+- [ ] `reconcile` appends exactly **one** snapshot per pass, with `equity == broker.nav` and `day_pl == nav − start_of_day_equity` (the same figures it writes to `account_state`). Verified against a mocked v20 reconcile.
+- [ ] The snapshot append is **additive and non-fatal**: it does not alter the reconcile diff/adopt/close/refresh behaviour, the `account_state` update, or the `ReconcileReport`. All existing Phase 3 reconciliation tests still pass unchanged.
+- [ ] `load_equity_snapshots()` returns rows ordered by `as_of` ascending; `since` filters to `as_of >= since`. A two-reconcile fixture yields two ordered points.
+- [ ] All timestamps UTC RFC-3339 (INV-03); practice-only context (INV-07); no secret persisted (INV-08).
+
+## Component design
+
+A minimal extension. The table + the two store methods mirror the existing store
+migration/accessor style. In `reconcile`, the append is a single
+`store.write_equity_snapshot(...)` call after `day_pl` is computed (reconcile.py
+~line 535), guarded so a write failure logs WARNING but never aborts the reconcile
+(the reconcile's broker-truth job is more important than the snapshot). Because the
+write reuses already-computed `nav`/`day_pl`, the snapshot can never disagree with
+`account_state`.
+
+## Non-goals
+
+- No retention/pruning policy (keep-all for demo; revisit later).
+- No equity-curve rendering — that is [[admin-panel]] via [[panel-data-layer]].
+- No new broker calls — reuses the figures reconcile already fetched.
+
+## Touches
+
+- [INV-16] — the snapshot is the broker-truth `nav` reconcile already trusts.
+- [INV-03] — UTC RFC-3339 `as_of`.
+- [INV-07] — demo/practice context only.
+
+## Depends on
+
+- `execution/reconcile.py` + `data/store.py` (shipped, Phase 3) — this is an additive edit to both (coordinator-serialized — touches shipped files).
+
+## Approach
+
+Add the table + accessors to `data/store.py`; add the one-line append (with a
+non-fatal guard) to `reconcile`. Re-run the Phase 3 reconciliation suite to prove
+the append is behaviour-preserving for everything else.
+
+## Open questions
+
+- Snapshot cadence = reconcile cadence (startup + 5 min). Retention: keep-all for
+  demo (a row every 5 min is ~288/day — fine for SQLite); add pruning later if needed.
+
+## Out of scope
+
+- The panel data layer ([[panel-data-layer]]) and the app ([[admin-panel]]).

--- a/docs/features/panel-data-layer.md
+++ b/docs/features/panel-data-layer.md
@@ -1,0 +1,85 @@
+# Feature: panel-data-layer
+
+**Status.** draft
+**Phase.** Phase 4
+**Owner.** saambaby
+
+**Last updated.** 2026-05-29
+
+## Summary
+
+The read-only query + view-model layer the admin panel renders. `panel/data.py`
+composes the store's loaders into the exact shapes each panel view needs — blotter
+rows, the equity series, watchlist rows, deviation-log rows, and per-pair chart
+data. Keeping this separate from the Streamlit app gives the data logic real unit
+tests (the Streamlit view code is hard to test), and makes the app a thin view over
+tested view models. **Read-only** — it never writes, never places orders, never
+imports `execution/orders.py` or `risk/` sizing/placement (it may *read* the limits
+book-risk sum).
+
+## User-facing behaviour
+
+Backend module `panel/data.py`. A `PanelData(store)` (or module functions) exposing
+pydantic/dataclass view models + loaders:
+
+- `equity_series(since=None) -> list[EquityPoint]` — from `load_equity_snapshots`; each point `(as_of, equity, day_pl)` + a computed running `drawdown` (peak-to-current).
+- `blotter() -> BlotterView` — open positions (`load_open_positions`), each with `unrealized_pl`; plus `day_pl` + `start_of_day_equity` (`load_account_state`) and **risk-in-use vs the limit** (the book-risk sum, read-only-reused from `risk/limits.py`, against `max_book_risk`).
+- `watchlist() -> list[Candidate]` — the latest persisted `load_watchlist()` (INV-13 shape, unchanged).
+- `deviation_log(limit=...) -> list[DeviationRow]` — from `load_deviation_log`.
+- `chart_data(instrument, timeframe) -> ChartData` — candles (`load_candles`) + the active/proposed entry/stop/target + signal marker for that instrument (from the open position and/or the watchlist candidate), shaped for the Lightweight Charts component.
+
+Also adds any missing store loaders this needs: `load_fills` (recent fills, for the
+blotter's fill/slippage context) and consumes the new `load_equity_snapshots`
+([[equity-snapshots]]).
+
+## Acceptance criteria
+
+- [ ] Every accessor is **read-only** — `panel/data.py` performs no writes and imports no order/execution/sizing/placement capability (no `execution.orders`, no `risk.sizing`, no `submit_order`/`build_bracket`). A test asserts this.
+- [ ] `equity_series` returns points ordered by `as_of` with a correct running `drawdown` (peak-to-current); verified on a seeded snapshot fixture (incl. a drawdown after a new peak).
+- [ ] `blotter()` returns open positions with `unrealized_pl`, today's `day_pl`, and `risk_in_use` computed from the same stop-distance book-risk sum the kill switch uses (read-only reuse), plus the `max_book_risk` limit for the vs-limit display.
+- [ ] `watchlist()` returns the latest run's `Candidate[]` unchanged (INV-13 shape; a round-trip against a seeded watchlist).
+- [ ] `deviation_log()` returns rows newest-first with UTC timestamps; `chart_data()` returns candles plus the entry/stop/target/signal overlay values for the instrument.
+- [ ] All timestamps surfaced are UTC RFC-3339 (INV-03); no secret is read into a view model or logged (INV-08); reads the demo store only (INV-07).
+- [ ] Unit-tested against a **seeded SQLite store** (no Streamlit, no live HTTP) — the view models are the tested seam.
+
+## Component design
+
+`panel/data.py` depends only on `data/store.py` (loaders), `signals/ranker.Candidate`,
+`execution/models` (`Position`/`Fill`), and a **read-only** call into
+`risk/limits.py` for the book-risk sum (no `check_limits` order construction — just
+the exposure figure). View models are small frozen dataclasses/pydantic. Pure
+functions over loaded rows so each is unit-testable with a seeded store fixture.
+Missing loaders (`load_fills`, and `load_equity_snapshots` from [[equity-snapshots]])
+are added to `data/store.py` in the store's existing style.
+
+## Non-goals
+
+- No Streamlit / rendering — that is [[admin-panel]].
+- No writes, no scan trigger (the app owns the refresh button), no order path (INV-01).
+
+## Touches
+
+- [INV-01] — read-only; no order/execution capability.
+- [INV-03] — UTC timestamps in every view model.
+- [INV-13] — renders the frozen `Candidate` unchanged.
+- [INV-14/16] — reads the frozen `Position`/`Fill` + reconciled equity as broker-truth.
+
+## Depends on
+
+- [[equity-snapshots]] (the `equity_snapshots` table + `load_equity_snapshots`), shipped store loaders (`load_open_positions`, `load_account_state`, `load_watchlist`, `load_deviation_log`, `load_candles`), `risk/limits.py` (read-only book-risk sum), `signals/ranker.Candidate`, `execution/models`.
+
+## Approach
+
+Build `panel/data.py` + the two missing store loaders; unit-test every view model
+against a seeded store. The drawdown computation and the risk-in-use reuse are the
+two bits with real logic — test them hardest.
+
+## Open questions
+
+- Risk-in-use: extract the book-risk sum from `risk/limits.py` into a small shared
+  read-only helper, or recompute in `panel/data.py`? Propose a read-only reuse of
+  the existing sum so the panel figure matches the kill switch exactly.
+
+## Out of scope
+
+- The Streamlit app + charts component ([[admin-panel]]).


### PR DESCRIPTION
## Summary

Layer-4 feature specs for **impl-Phase 4** (= product-spec Phase 5 — admin panel & hardening, demo). Status **draft** — the cross-spec audit promotes to `ready`.

### Specs (drafting order = dependency order)
1. **equity-snapshots** — new `equity_snapshots` table + `reconcile` appends a timestamped `(equity, day_pl)` snapshot (additive, behaviour-preserving; `account_state` is a singleton today). Backend enabler for the equity curve.
2. **panel-data-layer** — `panel/data.py` read-only accessors + view models (blotter incl. risk-in-use, equity series + drawdown, watchlist, deviation log, chart data). The tested seam; INV-01 read-only (no order/execution import).
3. **admin-panel** — the Streamlit app: 5 views + Lightweight Charts overlays + attribution + the scan-refresh button; the **INV-01 read-only boundary** (no order/approve/execute action; a test asserts no order capability).

Each carries acceptance criteria, component design, touches, deps, proposed defaults; `admin-panel` has a sequence diagram. `INDEX.md` Phase 4 section replaces the old planned stub; go-live noted as impl-Phase 5.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)