### PR TITLE
docs(phase-4): cross-spec audit + fixes

### DIFF
--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -12,7 +12,8 @@ Single Python repo (not a monorepo) — "areas" are package directories.
 | `data` | `data/oanda_client.py`, `data/candles.py`, `data/store.py`, `data/stream.py`, `data/calendar.py` | OANDA access, candle fetch/cache, storage, live stream, calendar | partial (PoC: client+candles+store) |
 | `strategies` | `strategies/base.py`, `strategies/_indicators.py`, `strategies/trend.py`, `strategies/mean_reversion.py`, `strategies/momentum.py`, `strategies/breakout.py` | strategy interface + shared indicators (`atr()`) + implementations | partial (PoC: base + trend/MACrossover) |
 | `backtest` | `backtest/engine.py`, `backtest/costs.py`, `backtest/walkforward.py`, `backtest/metrics.py` | event-driven engine, cost model, walk-forward, metrics | shipped (PoC); `costs.py` extended in Phase 1 |
-| `signals` | `signals/ranker.py`, `signals/portfolio.py`, `signals/charts.py`, `signals/correlation.py` | ranker, portfolio caps, chart PNG; `correlation.py` = shared Pearson primitive **extracted from `portfolio.py` in Phase 3** | shipped (Phase 2); `correlation.py` new in Phase 3 |
+| `signals` | `signals/ranker.py`, `signals/portfolio.py`, `signals/charts.py`, `signals/correlation.py`, `signals/scan.py` | ranker, portfolio caps, chart PNG; `correlation.py` shared Pearson (Phase 3); `scan.py` = order-free `run_scan` **extracted from `cli.cmd_scan` in Phase 4** | shipped (Phase 2); `correlation.py` P3, `scan.py` P4 |
+| `panel` | `panel/app.py`, `panel/data.py` | read-only Streamlit dashboard + view models (charts/equity/blotter/watchlist/deviation log); INV-01 transitive boundary | Phase 4 |
 | `hermes_integration` | `hermes_integration/news_risk.py`, `narration.py`, `pretrade_check.py`, `prompts/`, `jobs/` | Claude response models+validators (INV-02); `pretrade_check.py` = in-process pre-trade veto (Phase 3) | shipped (Phase 2); `pretrade_check.py` new in Phase 3 |
 | `risk` | `risk/sizing.py`, `risk/limits.py` | stop-derived sizing (INV-05), exposure/correlation caps + daily-loss kill switch | Phase 3 |
 | `execution` | `execution/models.py`, `execution/orders.py`, `execution/reconcile.py` | frozen Order/Fill/Position (INV-14), bracket submit + idempotency (INV-04/15), broker reconciliation (INV-16) | Phase 3 |
@@ -80,3 +81,16 @@ Edits to these go through the **coordinator branch** or are **serialized** — n
 | monitor pair | `monitoring/watcher.py` (+ `scripts/run_monitor.py`) vs `monitoring/alerts.py` | distinct files → parallel-safe; `watcher` defines `DeviationEvent`, `alerts` consumes it (sequence watcher→alerts logically). |
 
 **Drafting/dispatch order for Phase 3:** coordinator pre-steps (`signals/correlation.py` extract, `anthropic` dep) → `order-model-and-brackets` (lock) → `{position-sizing, risk-limits-kill-switch, pretrade-check}` ∥ → `{order-placement, reconciliation}` (serialize `store.py`/`oanda_client.py` edits) → `{deviation-monitor, monitor-alerts}` ∥ → `execution-cli` (join). `data/store.py` and `data/oanda_client.py` are shipped files touched by multiple Phase 3 tasks → **serialize, don't parallelize** those edits.
+
+## Phase 4 dispatch implications (pre-resolved collisions)
+
+| Collision | Files | Resolution |
+|---|---|---|
+| **Coordinator pre-step: extract order-free scan** | `cli.py` (shipped) → new `signals/scan.py` | DRIFT-01 / INV-01. `cli.py` imports `execution.orders`/`risk` at module level, so the panel can't import `cmd_scan`. Extract `run_scan(...)` (order-free) into `signals/scan.py`; `cmd_scan` becomes a thin argparse adapter. **Coordinator-serialized** (shipped `cli.py`), before `admin-panel`. |
+| **Coordinator pre-step: extract book-risk sum** | `risk/limits.py` (shipped) | DRIFT-02. Extract `book_risk_sum(open_positions)` + `book_risk_budget(equity, cfg)`; `check_limits` calls them back (behaviour-preserving; re-run P3 limits tests). **Coordinator-serialized**, before `panel-data-layer`. |
+| **Coordinator pre-step: charts dep** | `pyproject.toml` + `CLAUDE.md` | `streamlit` + a Lightweight Charts Streamlit component → coordinator edit before `admin-panel`. |
+| `equity-snapshots` owns the snapshot migration | `data/store.py` + `execution/reconcile.py` (shipped) | additive: `equity_snapshots` table + 2 accessors; reconcile appends after `write_account_state`. **Lands first** on `store.py`. |
+| `panel-data-layer` adds `load_fills` | `data/store.py` (shipped) | **Serialized after** `equity-snapshots` (same file — never parallel). Owns `load_fills`; consumes `load_equity_snapshots`. |
+| `admin-panel` | `panel/app.py` | the join; depends on `panel-data-layer` + `equity-snapshots` + `run_scan` + the charts dep. Transitive INV-01 boundary test. |
+
+**Safe-parallel set for Phase 4:** minimal parallelism — the chain is mostly serial (`store.py` is touched by `equity-snapshots` then `panel-data-layer`; the two extractions are coordinator pre-steps). `panel/data.py` and `panel/app.py` are new isolated files. **Drafting/dispatch order:** coordinator pre-steps `{run_scan extract, book_risk_sum extract, streamlit+lightweight-charts dep}` → `equity-snapshots` (store + reconcile) → `panel-data-layer` (load_fills + view models) → `admin-panel` (join). `data/store.py` edits serialized across `equity-snapshots` → `panel-data-layer`.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -66,15 +66,15 @@ Maps to product-spec Phase 4. The phase where Fathom gains order authority — k
 | monitor-alerts | format + deliver `DeviationEvent` to Discord via Hermes gateway; durable deviation log | [monitor-alerts.md](monitor-alerts.md) | ready |
 | execution-cli | `fathom execute <candidate>` operator join (the INV-01 enforcement point); `positions`/`reconcile` helpers | [execution-cli.md](execution-cli.md) | ready |
 
-## Phase 4 — admin panel & hardening, demo only (specs drafted; cross-spec audit pending)
+## Phase 4 — admin panel & hardening, demo only (specs ready; cross-spec audit passed 2026-05-29)
 
-Maps to product-spec Phase 5. A **read-only** Streamlit dashboard over the existing store + TradingView Lightweight Charts; the only action is a scan-refresh (no order/execute — INV-01; execution stays the CLI). See [phase-4.md](../phases/phase-4.md).
+Maps to product-spec Phase 5. A **read-only** Streamlit dashboard over the existing store + TradingView Lightweight Charts; the only action is a scan-refresh (no order/execute — INV-01, transitive-import enforced; execution stays the CLI). See [phase-4.md](../phases/phase-4.md) + [phase-4-spec-audit-2026-05-29.md](../phases/phase-4-spec-audit-2026-05-29.md). Two coordinator pre-step extractions surfaced: `signals/scan.py::run_scan` (order-free scan) and `risk/limits.py::book_risk_sum`/`book_risk_budget`.
 
 | Feature | Summary | Spec file | Status |
 |---|---|---|---|
-| equity-snapshots | `equity_snapshots` table + reconcile appends a timestamped `(equity, day_pl)` point (backend enabler for the equity curve) | [equity-snapshots.md](equity-snapshots.md) | draft |
-| panel-data-layer | `panel/data.py` read-only accessors + view models (blotter, equity series + drawdown, watchlist, deviation log, chart data); the tested seam | [panel-data-layer.md](panel-data-layer.md) | draft |
-| admin-panel | Streamlit app: 5 views + Lightweight Charts overlays + scan-refresh button; INV-01 read-only boundary | [admin-panel.md](admin-panel.md) | draft |
+| equity-snapshots | `equity_snapshots` table + reconcile appends a timestamped `(equity, day_pl)` point (backend enabler for the equity curve) | [equity-snapshots.md](equity-snapshots.md) | ready |
+| panel-data-layer | `panel/data.py` read-only accessors + view models (blotter incl. risk-in-use, equity series + drawdown, watchlist, deviation log, chart data); the tested seam | [panel-data-layer.md](panel-data-layer.md) | ready |
+| admin-panel | Streamlit app: 5 views + Lightweight Charts overlays + scan-refresh button; INV-01 transitive read-only boundary | [admin-panel.md](admin-panel.md) | ready |
 
 ## Later — go-live (impl-Phase 5)
 

--- a/docs/features/admin-panel.md
+++ b/docs/features/admin-panel.md
@@ -30,17 +30,31 @@ order authority stays the operator CLI (INV-01).
 4. **Watchlist** — the latest ranked `Candidate[]` (mirrors the Discord watchlist).
 5. **Deviation log** — the monitor's alerts, newest first.
 
-A **Refresh** button (sidebar) runs `fathom scan` synchronously (spinner) and
-re-reads the store. No other action mutates anything; there is **no execute/approve
-control**.
+A **Refresh** button (sidebar) runs the scan synchronously (spinner) and re-reads
+the store. No other action mutates anything; there is **no execute/approve control**.
+
+**Scan entrypoint (DRIFT-01 resolution).** The refresh button calls an **order-free,
+kwargs-callable** `run_scan(...)` extracted into `signals/scan.py` (a coordinator
+pre-step) — **not** `cli.cmd_scan`. Importing `cli` is forbidden here: `cli.py`
+imports `execution.orders.submit_order` / `execution.models.build_bracket` /
+`risk.*` at module level, so `from cli import cmd_scan` would drag the order path
+into the panel's import graph and break the INV-01 boundary. `run_scan` imports
+only the ranker/portfolio/store/data path; `cli.cmd_scan` becomes a thin argparse
+adapter over it. The INV-01 boundary test below is **transitive** (it walks the
+panel's import graph, not just direct imports).
+
+**Chart overlay precedence (AMBIGUOUS-02 resolution).** When an instrument has both
+an open `Position` and a fresh watchlist `Candidate`, draw **both**: the open
+position as the **"active"** overlay (one style) and the watchlist candidate as the
+**"proposed"** overlay (a distinct style). Neither hides the other.
 
 ## Acceptance criteria
 
 - [ ] `streamlit run panel/app.py` launches and renders all five views against a seeded demo store (no separate datastore — same SQLite file).
 - [ ] Charts render candles via the Lightweight Charts component with entry/stop/target/signal overlays and the required attribution.
 - [ ] Equity view plots the curve + drawdown; blotter shows positions + unrealized P&L + `day_pl` + risk-in-use vs limit; watchlist shows the latest `Candidate[]` (INV-13); deviation log shows entries newest-first.
-- [ ] The **Refresh** button runs `fathom scan` (the non-order path) and re-reads; **no order/execute path is reachable from the UI**.
-- [ ] **INV-01 read-only boundary:** `panel/` imports nothing from `execution/orders.py` or `risk/` sizing/placement, never calls `fathom execute`/`submit_order`/`build_bracket`, and exposes no execute/approve action. A test asserts the panel modules expose no order/execution capability.
+- [ ] The **Refresh** button runs `signals.scan.run_scan(...)` (the order-free scan path) and re-reads; **no order/execute path is reachable from the UI** — it does NOT import `cli` (which carries the order path at module level).
+- [ ] **INV-01 read-only boundary (transitive):** the panel's import graph never reaches `execution.orders`, `execution.models.build_bracket`, or `risk` sizing/placement; it never calls `fathom execute`/`submit_order`/`build_bracket`; it exposes no execute/approve action. A test walks the **transitive** imports of `panel.app`/`panel.data` and asserts none of those modules appear (INV-01 enforcement clause).
 - [ ] All displayed timestamps are UTC (INV-03); no secret (OANDA token, webhook URL, API key) is rendered or logged (INV-08); reads the demo store only (INV-07).
 - [ ] The view code is thin over `panel/data.py` — the rendering layer holds no business logic that isn't covered by the data-layer tests.
 
@@ -75,9 +89,11 @@ sequenceDiagram
 `panel/app.py` is a thin Streamlit view over `panel/data.py`. The Lightweight
 Charts integration uses a Streamlit component (`streamlit-lightweight-charts` or
 equivalent — pinned at spec time), fed the `ChartData` view model. The refresh
-button calls the existing scan entrypoint (the `cmd_scan` code path / a thin
-wrapper) — **not** any execution function. The app imports `panel.data` and
-Streamlit only; it must not import `execution.orders` or `risk` placement/sizing.
+button calls `signals.scan.run_scan(...)` (the order-free extraction) — **not**
+`cli.cmd_scan` and **not** any execution function. The app imports `panel.data`,
+`signals.scan`, and Streamlit only; it must not import `cli`, `execution.orders`,
+`execution.models.build_bracket`, or `risk` placement/sizing — directly or
+transitively.
 Because Streamlit apps resist unit testing, correctness lives in `panel/data.py`'s
 tests; the app's own test is a thin import-time/boundary test (renders without
 error against a seeded store via Streamlit's testing harness if available, plus the
@@ -100,7 +116,7 @@ INV-01 no-order-capability assertion).
 
 ## Depends on
 
-- [[panel-data-layer]] (the view models), [[equity-snapshots]] (the equity series), the scan entrypoint (`cli.py cmd_scan`, shipped), `streamlit` + a Lightweight Charts component (new deps — coordinator edit).
+- [[panel-data-layer]] (the view models), [[equity-snapshots]] (the equity series), the extracted order-free `signals/scan.py::run_scan` (coordinator pre-step — see Component design), `streamlit` + a Lightweight Charts component (new deps — coordinator edit).
 
 ## Approach
 

--- a/docs/features/equity-snapshots.md
+++ b/docs/features/equity-snapshots.md
@@ -22,11 +22,14 @@ side effect). Two pieces:
 - `data/store.py` gains an `equity_snapshots` table and:
   - `write_equity_snapshot(*, as_of: str, equity: float, day_pl: float) -> None` — append-only insert.
   - `load_equity_snapshots(*, since: str | None = None) -> list[dict]` — ordered by `as_of` ascending, optional lower bound.
-- `execution/reconcile.py` — immediately after it computes `nav` and
-  `day_pl = nav − start_of_day_equity` (the existing lines), it appends one
-  snapshot `(as_of=now (RFC-3339 Z), equity=nav, day_pl=day_pl)`. This is purely
-  additive — it does not change the reconcile diff, the `account_state` update, or
-  the `ReconcileReport`.
+- `execution/reconcile.py` — **after `store.write_account_state(...)`** (reconcile.py
+  ~line 536-540, i.e. once the kill-switch truth row is written), it appends one
+  snapshot `(as_of=now (RFC-3339 Z), equity=broker.nav, day_pl=day_pl)`. Note: the
+  reconcile value is `broker.nav` (there is no bare `nav` local). Placing the append
+  *after* `write_account_state` guarantees a snapshot-write failure can never delay
+  or interpose before the kill-switch's `account_state` write. Purely additive — it
+  does not change the reconcile diff, the `account_state` update, or the
+  `ReconcileReport`.
 
 ## Acceptance criteria
 
@@ -60,7 +63,7 @@ write reuses already-computed `nav`/`day_pl`, the snapshot can never disagree wi
 
 ## Depends on
 
-- `execution/reconcile.py` + `data/store.py` (shipped, Phase 3) — this is an additive edit to both (coordinator-serialized — touches shipped files).
+- `execution/reconcile.py` + `data/store.py` (shipped, Phase 3) — additive edits to both (coordinator-serialized — touches shipped files). **Store-edit ownership (D-03):** this spec owns the `equity_snapshots` table + `write_equity_snapshot`/`load_equity_snapshots` and **lands first** on `data/store.py`; [[panel-data-layer]] then adds `load_fills` (serialized after, not parallel).
 
 ## Approach
 

--- a/docs/features/panel-data-layer.md
+++ b/docs/features/panel-data-layer.md
@@ -22,21 +22,28 @@ book-risk sum).
 Backend module `panel/data.py`. A `PanelData(store)` (or module functions) exposing
 pydantic/dataclass view models + loaders:
 
-- `equity_series(since=None) -> list[EquityPoint]` — from `load_equity_snapshots`; each point `(as_of, equity, day_pl)` + a computed running `drawdown` (peak-to-current).
-- `blotter() -> BlotterView` — open positions (`load_open_positions`), each with `unrealized_pl`; plus `day_pl` + `start_of_day_equity` (`load_account_state`) and **risk-in-use vs the limit** (the book-risk sum, read-only-reused from `risk/limits.py`, against `max_book_risk`).
+- `equity_series(since=None) -> list[EquityPoint]` — from `load_equity_snapshots`; each point `(as_of, equity, day_pl, drawdown)`. **`drawdown = (running_peak − equity) / running_peak`** (a fraction ≥ 0; **0 at a new peak**) — A-01 resolution.
+- `blotter() -> BlotterView` — open positions (`load_open_positions`), each surfacing its **reconciled** `unrealized_pl` (a **passthrough** from the `Position`; NOT recomputed and NO live-price call — INV-16/read-only, D-05); plus `day_pl` + `start_of_day_equity` (`load_account_state`) and **risk-in-use vs limit**: `risk_in_use = book_risk_sum(open_positions)` and `risk_budget = book_risk_budget(equity, cfg)` (= `max_book_risk × equity`), **both read-only-reused from `risk/limits.py`** (the extracted helpers — see D-02 below), so the panel figure matches the kill switch exactly.
 - `watchlist() -> list[Candidate]` — the latest persisted `load_watchlist()` (INV-13 shape, unchanged).
-- `deviation_log(limit=...) -> list[DeviationRow]` — from `load_deviation_log`.
-- `chart_data(instrument, timeframe) -> ChartData` — candles (`load_candles`) + the active/proposed entry/stop/target + signal marker for that instrument (from the open position and/or the watchlist candidate), shaped for the Lightweight Charts component.
+- `deviation_log(limit=...) -> list[DeviationRow]` — from the shipped `load_deviation_log(*, limit=None)` (already newest-first).
+- `chart_data(instrument, timeframe) -> ChartData` — candles (`load_candles`) + overlays for that instrument, shaped for the Lightweight Charts component. **Overlay precedence (A-02):** if an open `Position` exists → the **"active"** overlay (entry/stop/target from the position); if a watchlist `Candidate` exists → the **"proposed"** overlay; when both exist, include **both** with distinct styling. Keep the dimension name `timeframe` end-to-end (INV-13); map to `load_candles`'s `granularity` argument only at the store call (D-05).
 
-Also adds any missing store loaders this needs: `load_fills` (recent fills, for the
-blotter's fill/slippage context) and consumes the new `load_equity_snapshots`
-([[equity-snapshots]]).
+**Store loaders this adds (DRIFT-03 — ownership + serialization).** This spec owns
+**`load_fills(*, limit: int | None = None) -> list[Fill]`** — newest-first by
+`filled_at`, reconstructing the frozen INV-14 `Fill` (mirroring
+`get_fill_by_client_order_id`). It **consumes** `load_equity_snapshots` (owned by
+[[equity-snapshots]]). Both specs edit the shipped `data/store.py` → the edits are
+**serialized, not parallel**: [[equity-snapshots]] lands first (it owns the
+`equity_snapshots` table + `write_equity_snapshot`/`load_equity_snapshots`), then
+this spec adds `load_fills`. Note loaders use different timestamp keys
+(`equity_snapshots.as_of` vs `fills.filled_at` vs `deviation_log.created_at`) — the
+view models must not assume one uniform key.
 
 ## Acceptance criteria
 
 - [ ] Every accessor is **read-only** — `panel/data.py` performs no writes and imports no order/execution/sizing/placement capability (no `execution.orders`, no `risk.sizing`, no `submit_order`/`build_bracket`). A test asserts this.
-- [ ] `equity_series` returns points ordered by `as_of` with a correct running `drawdown` (peak-to-current); verified on a seeded snapshot fixture (incl. a drawdown after a new peak).
-- [ ] `blotter()` returns open positions with `unrealized_pl`, today's `day_pl`, and `risk_in_use` computed from the same stop-distance book-risk sum the kill switch uses (read-only reuse), plus the `max_book_risk` limit for the vs-limit display.
+- [ ] `equity_series` returns points ordered by `as_of` with `drawdown = (running_peak − equity)/running_peak` (fraction ≥ 0, **0 at a new peak**); verified on a seeded fixture incl. a drawdown after a new peak.
+- [ ] `blotter()` returns open positions with the **reconciled** `unrealized_pl` (passthrough, not recomputed), today's `day_pl`, `risk_in_use = book_risk_sum(open_positions)`, and `risk_budget = book_risk_budget(equity, cfg)` (= `max_book_risk × equity`) — both reused from the extracted `risk/limits.py` helpers so the figure matches the kill switch exactly.
 - [ ] `watchlist()` returns the latest run's `Candidate[]` unchanged (INV-13 shape; a round-trip against a seeded watchlist).
 - [ ] `deviation_log()` returns rows newest-first with UTC timestamps; `chart_data()` returns candles plus the entry/stop/target/signal overlay values for the instrument.
 - [ ] All timestamps surfaced are UTC RFC-3339 (INV-03); no secret is read into a view model or logged (INV-08); reads the demo store only (INV-07).
@@ -45,12 +52,23 @@ blotter's fill/slippage context) and consumes the new `load_equity_snapshots`
 ## Component design
 
 `panel/data.py` depends only on `data/store.py` (loaders), `signals/ranker.Candidate`,
-`execution/models` (`Position`/`Fill`), and a **read-only** call into
-`risk/limits.py` for the book-risk sum (no `check_limits` order construction — just
-the exposure figure). View models are small frozen dataclasses/pydantic. Pure
-functions over loaded rows so each is unit-testable with a seeded store fixture.
-Missing loaders (`load_fills`, and `load_equity_snapshots` from [[equity-snapshots]])
-are added to `data/store.py` in the store's existing style.
+`execution/models` (`Position`/`Fill`), and **read-only** calls into `risk/limits.py`
+for `book_risk_sum`/`book_risk_budget` (the exposure figures — **never**
+`check_limits`, which constructs an order decision). View models are small frozen
+dataclasses/pydantic. Pure functions over loaded rows so each is unit-testable with
+a seeded store fixture. `panel/data.py` must NOT import `execution.orders`,
+`execution.models.build_bracket`, `risk.sizing`, or `cli` — directly or transitively
+(INV-01 transitive boundary; a test asserts it).
+
+**DRIFT-02 — `book_risk_sum`/`book_risk_budget` must be extracted first.** Today
+`risk/limits.py` has the reusable per-position `position_risk(position)`, but the
+**sum** is inlined inside `check_limits` (`current_book_risk = sum(position_risk(p)
+…)`, no standalone function) and the budget is the local `max_book_risk × equity`. A
+**coordinator pre-step** extracts `book_risk_sum(open_positions) -> float` and
+`book_risk_budget(equity, cfg) -> float` into `risk/limits.py`, with `check_limits`
+calling them back (behaviour-preserving; re-run the Phase 3 limits tests) — directly
+analogous to the T-02 correlation-primitive extraction. This spec depends on that
+extraction.
 
 ## Non-goals
 
@@ -66,19 +84,23 @@ are added to `data/store.py` in the store's existing style.
 
 ## Depends on
 
-- [[equity-snapshots]] (the `equity_snapshots` table + `load_equity_snapshots`), shipped store loaders (`load_open_positions`, `load_account_state`, `load_watchlist`, `load_deviation_log`, `load_candles`), `risk/limits.py` (read-only book-risk sum), `signals/ranker.Candidate`, `execution/models`.
+- [[equity-snapshots]] (the `equity_snapshots` table + `load_equity_snapshots`; lands first on `data/store.py`), the **`book_risk_sum`/`book_risk_budget` extraction** in `risk/limits.py` (coordinator pre-step), shipped store loaders (`load_open_positions`, `load_account_state`, `load_watchlist`, `load_deviation_log`, `load_candles`), `signals/ranker.Candidate`, `execution/models`.
 
 ## Approach
 
-Build `panel/data.py` + the two missing store loaders; unit-test every view model
-against a seeded store. The drawdown computation and the risk-in-use reuse are the
+Build `panel/data.py` + the new `load_fills` loader (serialized after
+[[equity-snapshots]]'s store edits); unit-test every view model against a seeded
+store. The drawdown formula and the `book_risk_sum`/`book_risk_budget` reuse are the
 two bits with real logic — test them hardest.
 
 ## Open questions
 
-- Risk-in-use: extract the book-risk sum from `risk/limits.py` into a small shared
-  read-only helper, or recompute in `panel/data.py`? Propose a read-only reuse of
-  the existing sum so the panel figure matches the kill switch exactly.
+**Resolved at cross-spec audit (2026-05-29):** D-02 — `risk_in_use` reuses the
+extracted `book_risk_sum`/`book_risk_budget` (no recompute, matches the kill switch);
+D-03 — `load_fills(*, limit=None) -> list[Fill]` (newest-first), store.py edits
+serialized after [[equity-snapshots]]; D-05 — `unrealized_pl` is a reconciled
+passthrough (no live price), `timeframe` dimension kept end-to-end; A-01 drawdown
+formula + A-02 overlay precedence pinned above.
 
 ## Out of scope
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -13,6 +13,8 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 
 **Enforcement:** Execution engine code must not be callable as a Hermes tool. Order placement lives in `execution/orders.py` and is invoked only by the deterministic execution path, never by a Hermes job.
 
+**Enforcement (always-on UI / monitoring surfaces — added Phase 4):** No always-on or operator-facing read surface (`panel/`, the deviation monitor, any future dashboard) may reach order-placement or risk sizing/placement code — **directly or transitively**. Concretely: `panel/` and `monitoring/` must not import `execution.orders`, `execution.models.build_bracket`, `risk.sizing`, or `risk.limits` placement paths, and must not import `cli` (which carries those at module level). A read-only "refresh/scan" affordance must reach the ranker via an order-free entrypoint (`signals/scan.py::run_scan`), not via `cli.cmd_scan`. Enforced by a **transitive-import boundary test** over the surface's module graph — a UI button that can place a trade is exactly the hazard this invariant exists to prevent.
+
 ---
 
 ## INV-02 · All Claude Outputs Feeding Automation Must Be Structured JSON with Safe Defaults

--- a/docs/phases/phase-4-spec-audit-2026-05-29.md
+++ b/docs/phases/phase-4-spec-audit-2026-05-29.md
@@ -1,0 +1,69 @@
+# Fathom Phase 4 — Cross-Spec Audit (2026-05-29)
+
+Run per `runbook-cross-spec-audit` by a fresh, independent, read-only auditor (no
+prior session context). Fixes applied afterward by the lead — each finding
+annotated with its resolution. Audit + fixes landed together in one PR.
+
+## Scope
+
+The 3 Phase 4 specs (`equity-snapshots`, `panel-data-layer`, `admin-panel`),
+cross-checked against `invariants.md`, `phase-4.md`, `code-map.md`, `INDEX.md`, and
+the shipped contracts (`data/store.py` loaders + tables, `execution/reconcile.py`
+NAV/day_pl, `risk/limits.py` book-risk, `signals/ranker.py::Candidate`,
+`execution/models.py`, `cli.py::cmd_scan`).
+
+## Summary
+
+11 shared concepts · 5 consistent · **3 blocking** · 4 non-blocking · 1
+invariant-promotion candidate. The headline finding (D-01) is a real INV-01
+import-chain breach in the shipped code path the panel would call; the other
+blockers are two missing extractions (mirroring the precedented T-02 pattern) and
+under-specified loader/overlay contracts. No deeper rework.
+
+## Drift findings & resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| D-01 | blocking | `cli.py` imports `execution.orders.submit_order`/`build_bracket`/`risk.*` at **module level**, so a panel doing `from cli import cmd_scan` would transitively pull the order path into its import graph — breaking the panel's own INV-01 boundary test. Also `cmd_scan(args: Namespace)` is argparse-coupled, not kwargs-callable. | **Fixed** — `admin-panel` now refreshes via an **order-free** `signals/scan.py::run_scan(...)` (a coordinator pre-step extraction; `cmd_scan` becomes a thin argparse adapter), never imports `cli`, and the INV-01 boundary test is **transitive**. Added to phase-4 coordinator pre-steps + code-map. |
+| D-02 | blocking | `panel-data-layer` assumes a reusable book-risk **sum** in `risk/limits.py`; only the per-position `position_risk` is reusable — the sum is **inlined** in `check_limits` (line 400). | **Fixed** — a coordinator pre-step extracts `book_risk_sum(open_positions)` + `book_risk_budget(equity, cfg)`; `check_limits` calls them back (behaviour-preserving). `panel-data-layer` reuses them; the blotter surfaces `risk_in_use` + `risk_budget = max_book_risk × equity`. (Mirrors T-02.) |
+| D-03 | blocking | `load_fills` doesn't exist + had no signature; `equity-snapshots` and `panel-data-layer` both edit shipped `data/store.py` with no serialization declared. | **Fixed** — `panel-data-layer` pins `load_fills(*, limit=None) -> list[Fill]` (newest-first, reconstructs the frozen `Fill`); store.py edits **serialized**: `equity-snapshots` owns the `equity_snapshots` table + 2 accessors and lands first, then `panel-data-layer` adds `load_fills`. Per-loader timestamp keys noted. |
+| D-04 | non-blocking | `equity-snapshots` prose says "equity = nav" / "~line 535"; the shipped value is `broker.nav` (no bare `nav` local); append ordering vs `write_account_state` ambiguous. | **Fixed** — prose → `equity = broker.nav`; the append is pinned **strictly after `write_account_state`** (so a snapshot-write failure can't delay the kill-switch truth row); non-fatal guard kept. Additivity verdict: SOUND. |
+| D-05 | non-blocking | `panel-data-layer` reads as if it computes `unrealized_pl`; it's a reconciled passthrough. Dimension-name `timeframe` vs store's `granularity`. | **Fixed** — `unrealized_pl` documented as a reconciled passthrough (no recompute, no live price — INV-16/read-only); `timeframe` kept end-to-end, mapped to `granularity` only at the `load_candles` call. |
+
+## Ambiguity findings & resolutions
+
+| ID | Finding | Resolution |
+|---|---|---|
+| A-01 | `equity_series` drawdown semantics (absolute vs fraction vs signed; value at peak) undefined | **Fixed** — `drawdown = (running_peak − equity)/running_peak` (fraction ≥ 0, **0 at a new peak**), pinned in `panel-data-layer` + `admin-panel`. |
+| A-02 | `chart_data` overlay when an open position AND a watchlist candidate coexist for one pair — which wins? | **Fixed (lead ruling)** — draw **both**: position = "active" overlay, candidate = "proposed" overlay, distinct styling; neither hides the other. |
+
+## Invariant promotion
+
+- **IPC-01 → applied as an INV-01 enforcement clause** (not a new INV number): "No
+  always-on UI/monitoring surface (`panel/`, monitor, future dashboards) may reach
+  order-placement or risk sizing/placement — directly or transitively; the
+  scan-refresh path uses the order-free `signals/scan.py::run_scan`, not
+  `cli.cmd_scan`. Enforced by a transitive-import boundary test." Added to
+  `docs/invariants.md` under INV-01.
+
+## Consistent (no action)
+
+`Candidate`/INV-13 shape (watchlist view renders it unchanged); `load_deviation_log`
+signature (already newest-first, takes `limit`); `Position`/`Fill` frozen shapes
+(INV-14) the blotter/chart read; `account_state` carries `day_pl` +
+`start_of_day_equity`; the equity-snapshots reconcile-append additivity claim
+(verified sound).
+
+## Action plan — status
+
+All 3 blocking + 2 non-blocking drifts and both ambiguities **Fixed** in this PR;
+the IPC-01 INV-01 clause added. **Two coordinator pre-step extractions** surfaced for
+the taskgraph: `signals/scan.py::run_scan` (from `cli.py`) and
+`book_risk_sum`/`book_risk_budget` (from `risk/limits.py`) — both behaviour-preserving,
+coordinator-serialized, before the panel fan-out.
+
+**Sequencing:** coordinator pre-steps `{run_scan extraction, book_risk_sum
+extraction, streamlit+lightweight-charts dep}` → `equity-snapshots` (store + reconcile
+append) → `panel-data-layer` (`load_fills` + view models) → `admin-panel` (join).
+
+**Verdict after fixes:** spec corpus coherent; **ready for taskgraph generation.**

--- a/docs/phases/phase-4.md
+++ b/docs/phases/phase-4.md
@@ -109,10 +109,18 @@ endpoint (INV-07, impl-Phase 5).
 
 ## The Read-Only Boundary (critical — INV-01)
 
-- **The panel never gains order authority.** `panel/` must not import `execution/orders.py` or `risk/`, must not call `fathom execute`, and exposes no execute/approve action. A reviewer + a test assert this.
-- **The one action is scan-refresh** — `fathom scan` is a non-order operation (refresh candles → rank → persist watchlist). It places no trades and touches no order endpoint.
+- **The panel never gains order authority.** `panel/` must not import `execution.orders`, `execution.models.build_bracket`, `risk` sizing/placement, **or `cli`** — directly or transitively (a **transitive-import boundary test** enforces it; promoted into INV-01's enforcement clause this phase).
+- **The one action is scan-refresh** — via an **order-free** `signals/scan.py::run_scan(...)`, **not** `cli.cmd_scan` (which imports the order path at module level). Scan refreshes candles → ranks → persists the watchlist; it places no trades and touches no order endpoint.
 - **Execution stays the operator CLI.** Approving and placing a trade remains `fathom execute` at the terminal — deliberately not a UI button.
 - **Read-only over the broker.** The panel reads the store; the only OANDA contact is via the scan-refresh's existing read path.
+
+## Coordinator pre-steps (before fan-out — surfaced by the cross-spec audit)
+
+Two behaviour-preserving extractions from shipped files (each coordinator-serialized,
+mirroring Phase 3's T-02 correlation extraction), plus the charts dep:
+- **`signals/scan.py::run_scan(...)`** — extract an order-free, kwargs-callable scan entrypoint from `cli.cmd_scan` so the panel can refresh without importing the order path (`cli.cmd_scan` becomes a thin argparse adapter). Touches shipped `cli.py`.
+- **`risk/limits.py::book_risk_sum(open_positions)` + `book_risk_budget(equity, cfg)`** — extract the inlined book-risk sum so the blotter's risk-in-use reuses it (matches the kill switch). `check_limits` calls them back. Touches shipped `risk/limits.py`.
+- **`streamlit` + a Lightweight Charts component** — coordinator dep edit (`pyproject.toml` + `CLAUDE.md`) before `admin-panel`.
 
 ---
 


### PR DESCRIPTION
## Summary

Ran `runbook-cross-spec-audit` over the 3 Phase 4 specs with a fresh, independent, read-only auditor. Found **3 blocking, 2 non-blocking drifts, 2 ambiguities, 1 invariant-promotion candidate** — all fixed here. Report: `docs/phases/phase-4-spec-audit-2026-05-29.md`.

### Blocking fixes
- **D-01 (real INV-01 catch):** `cli.py` imports `execution.orders.submit_order`/`build_bracket`/`risk.*` at **module level** — so a panel doing `from cli import cmd_scan` would transitively pull the order path into its import graph, defeating its own boundary test. Fixed: `admin-panel` refreshes via an **order-free** `signals/scan.py::run_scan(...)` (coordinator extraction; `cmd_scan` → thin argparse adapter), never imports `cli`, and the INV-01 boundary test is **transitive**. Promoted an **INV-01 enforcement clause** for always-on UI/monitoring surfaces.
- **D-02:** the book-risk **sum** is inlined in `check_limits` (no reusable fn). Fixed: coordinator extracts `book_risk_sum` + `book_risk_budget` (behaviour-preserving, à la T-02); the panel reuses them so risk-in-use matches the kill switch exactly.
- **D-03:** pinned `load_fills(*, limit=None) -> list[Fill]`; **serialized** `data/store.py` edits (equity-snapshots first, then panel-data-layer).

### Non-blocking + ambiguities
D-04 (`equity = broker.nav`, append strictly after `write_account_state`), D-05 (`unrealized_pl` reconciled passthrough; `timeframe` naming), A-01 (`drawdown = (peak − equity)/peak`, 0 at peak), A-02 (overlay precedence: position = "active", candidate = "proposed", both drawn).

### Surfaced for the taskgraph
Two coordinator pre-step extractions (`signals/scan.py::run_scan`, `risk/limits.py::book_risk_sum`) + the `streamlit`/Lightweight-Charts dep. INDEX statuses → `ready`.

**Verdict:** corpus coherent; ready for taskgraph generation. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)