### PR TITLE
chore(deps): add streamlit + lightweight-charts (Phase 4 C-A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "httpx>=0.27",
     "matplotlib>=3.7",
     "anthropic>=0.39",
+    "streamlit>=1.30",
+    "streamlit-lightweight-charts>=0.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Coordinator dep edit before P4-T-05 (admin-panel). Adds `streamlit>=1.30` + `streamlit-lightweight-charts>=0.7` for the read-only dashboard. Mirrors the Phase 2 matplotlib / Phase 3 anthropic coordinator edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)