### PR TITLE
P4-T-02: extract book_risk_sum / book_risk_budget (behaviour-preserving)

### DIFF
--- a/risk/limits.py
+++ b/risk/limits.py
@@ -66,6 +66,8 @@ __all__ = [
     "DEFAULT_MAX_PER_CORRELATION_GROUP",
     "DEFAULT_CORRELATION_THRESHOLD",
     "position_risk",
+    "book_risk_sum",
+    "book_risk_budget",
     "check_limits",
     "kill_switch_status",
 ]
@@ -213,6 +215,32 @@ def position_risk(position: Position) -> float:
     if not math.isfinite(risk) or risk < 0:
         return 0.0
     return risk
+
+
+def book_risk_sum(open_positions: Sequence[Position]) -> float:
+    """Aggregate stop-distance risk of the open book in account-price terms.
+
+    The single source of truth for ``current_book_risk`` — the sum of every open
+    position's :func:`position_risk` (stop-distance, **not** notional).
+    :func:`check_limits` calls this for its book-risk check, and the read-only
+    admin-panel blotter reuses it so the panel's "risk-in-use" figure is
+    byte-identical to the figure the kill-switch backstop evaluates (INV-05;
+    panel-data-layer DRIFT-02). An empty book is ``0.0``.
+    """
+    return sum(position_risk(p) for p in open_positions)
+
+
+def book_risk_budget(equity: float, config: LimitsConfig) -> float:
+    """The aggregate book-risk budget in account currency: ``max_book_risk × equity``.
+
+    The single source of truth for the book-risk cap amount. :func:`check_limits`
+    compares ``book_risk_sum(open) + order_risk`` against this, and the read-only
+    admin-panel blotter reuses it so the panel's "limit" figure matches the
+    kill-switch backstop exactly (INV-05; panel-data-layer DRIFT-02). The caller
+    owns guarding ``equity`` finiteness/positivity before relying on the result
+    (``check_limits`` rejects a non-finite/non-positive equity upstream).
+    """
+    return config.max_book_risk * equity
 
 
 def _next_utc_midnight(now: datetime) -> datetime:
@@ -397,14 +425,14 @@ def check_limits(
         )
 
     # --- 3. Book risk (stop-distance risk, not notional). -------------------
-    current_book_risk = sum(position_risk(p) for p in open_positions)
-    book_risk_budget = cfg.max_book_risk * equity
-    if current_book_risk + order_risk > book_risk_budget:
+    current_book_risk = book_risk_sum(open_positions)
+    budget = book_risk_budget(equity, cfg)
+    if current_book_risk + order_risk > budget:
         return _reject(
             f"Book-risk cap exceeded: current {current_book_risk:.6g} + order "
             f"{order_risk:.6g} = {current_book_risk + order_risk:.6g} > "
             f"{cfg.max_book_risk:.4g} × equity {equity:.6g} = "
-            f"{book_risk_budget:.6g}."
+            f"{budget:.6g}."
         )
 
     # --- 4. Correlation bucket (shared exposure). ---------------------------

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -23,6 +23,8 @@ from risk.limits import (
     DEFAULT_MAX_PER_CORRELATION_GROUP,
     LimitDecision,
     LimitsConfig,
+    book_risk_budget,
+    book_risk_sum,
     check_limits,
     kill_switch_status,
     position_risk,
@@ -260,6 +262,59 @@ class TestBookRisk:
         decision = _check(_order(), open_positions=positions, order_risk=1.0)
         assert decision.allowed is False
         assert decision.reason is not None and "book-risk" in decision.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Extracted helpers (P4-T-02 / DRIFT-02): book_risk_sum + book_risk_budget are
+# the single source of truth check_limits calls back into, so the admin-panel
+# blotter can show the exact figures the kill switch uses.
+# ---------------------------------------------------------------------------
+
+
+class TestBookRiskHelpers:
+    def test_book_risk_sum_empty_is_zero(self) -> None:
+        assert book_risk_sum([]) == 0.0
+
+    def test_book_risk_sum_single_matches_position_risk(self) -> None:
+        p = _position(units=1, entry_price=1000.0, stop_loss_price=500.0)  # risk 500
+        assert book_risk_sum([p]) == pytest.approx(position_risk(p))
+        assert book_risk_sum([p]) == pytest.approx(500.0)
+
+    def test_book_risk_sum_multi_matches_sum_of_position_risk(self) -> None:
+        positions = [
+            _position(trade_id="A", units=1000, entry_price=1.2500, stop_loss_price=1.2450),
+            _position(trade_id="B", units=1, entry_price=1000.0, stop_loss_price=500.0),
+            _position(trade_id="C", units=2000, entry_price=1.1000, stop_loss_price=1.0900),
+        ]
+        expected = sum(position_risk(p) for p in positions)
+        assert book_risk_sum(positions) == pytest.approx(expected)
+
+    def test_book_risk_budget_is_max_book_risk_times_equity(self) -> None:
+        cfg = LimitsConfig()  # default max_book_risk == 0.01
+        assert book_risk_budget(100_000.0, cfg) == pytest.approx(1000.0)
+
+    def test_book_risk_budget_honours_overridden_cap(self) -> None:
+        cfg = LimitsConfig(max_book_risk=0.025)
+        assert book_risk_budget(80_000.0, cfg) == pytest.approx(0.025 * 80_000.0)
+
+    def test_check_limits_uses_the_helpers_at_the_boundary(self) -> None:
+        # Reconstruct check_limits' book-risk decision from the extracted
+        # helpers: current + order vs budget — confirming one source of truth.
+        positions = [
+            _position(trade_id="A", units=1, entry_price=1000.0, stop_loss_price=500.0),  # 500
+            _position(trade_id="B", units=1, entry_price=1000.0, stop_loss_price=500.0),  # 500
+        ]
+        cfg = LimitsConfig()
+        current = book_risk_sum(positions)
+        budget = book_risk_budget(EQUITY, cfg)
+        assert current == pytest.approx(1000.0)
+        assert budget == pytest.approx(1000.0)
+        # order_risk that exactly fills the budget is allowed; one cent over rejects.
+        at_budget = _check(_order(), open_positions=positions, order_risk=0.0, config=cfg)
+        assert at_budget.allowed is True
+        over = _check(_order(), open_positions=positions, order_risk=0.01, config=cfg)
+        assert over.allowed is False
+        assert over.reason is not None and "book-risk" in over.reason.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Behaviour-preserving extraction of the book-risk sum + budget from `risk/limits.py::check_limits` (DRIFT-02 resolution for panel-data-layer). So the admin-panel blotter can show "risk-in-use vs limit" using the EXACT figures the INV-05 kill switch evaluates, both expressions now live in one place and `check_limits` calls them back.

## What changed
- `book_risk_sum(open_positions: Sequence[Position]) -> float` = `sum(position_risk(p) ...)`; empty book -> `0.0`.
- `book_risk_budget(equity: float, config: LimitsConfig) -> float` = `config.max_book_risk * equity`.
- `check_limits` now calls both instead of inlining. The inlined local `book_risk_budget` was renamed to `budget` to avoid shadowing the new module-level function; it holds the identical value, so the reject reason string and all return values are **byte-identical**.
- Both added to `__all__`.
- `tests/test_limits.py` extended with a `TestBookRiskHelpers` class: empty -> 0.0; single/multi sum matches `sum(position_risk)`; budget = `max_book_risk × equity` (default + overridden cap); and a boundary test confirming `check_limits`' book-risk decision is reconstructable from the helpers.

## Behaviour-preserving confirmation
- check_limits logic, thresholds, ordering, reject messages and return values unchanged. **All existing Phase 3 limits tests pass unchanged** (not edited).
- `./.venv/bin/python -m mypy .` -> 0 errors (81 source files).
- `./.venv/bin/python -m pytest -q tests/test_limits.py` -> 33 passed.
- `./.venv/bin/python -m pytest -q` (full repo) -> 972 passed.

Touches only `risk/limits.py` and `tests/test_limits.py`.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)