### PR TITLE
P4-T-03: equity-snapshots (table + reconcile append)

### DIFF
--- a/.claude/context/data.md
+++ b/.claude/context/data.md
@@ -261,3 +261,65 @@
 **CLAUDE.md trigger-table:** pyproject.toml dep added → CLAUDE.md Stack updated (YES).
 
 **Merge plan:** `gh pr merge 46 --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P4-T-03 — 2026-05-29 (feat/p4-T-03-equity)
+
+**What was done:**
+- Added the `equity_snapshots` table to `data/store.py` — an APPEND-ONLY broker-sourced
+  equity time series for the panel's equity curve. Columns: `as_of` (TEXT, UTC RFC-3339 /
+  INV-03), `equity` (REAL, broker NAV / INV-16), `day_pl` (REAL, `nav − start_of_day_equity`).
+  - `_CREATE_EQUITY_SNAPSHOTS_SQL` — **no PK / no unique constraint** (deliberate): every
+    reconcile pass yields a distinct `rowid`, so history is never clobbered. Wired into
+    `_create_tables` via `CREATE TABLE IF NOT EXISTS` (additive migration).
+  - `_INSERT_EQUITY_SNAPSHOT_SQL` — plain `INSERT` (NOT `INSERT OR REPLACE/IGNORE` — those
+    would defeat append-only; contrast with the `account_state` SINGLETON `id=1` row).
+  - `write_equity_snapshot(*, as_of: str, equity: float, day_pl: float) -> None` — note the
+    signature takes `as_of` as an already-formatted RFC-3339 **str** (per the feature spec),
+    unlike `write_account_state` which takes a `datetime` and formats internally.
+  - `load_equity_snapshots(*, since: str | None = None) -> list[dict]` — ordered by `as_of`
+    ASC; `since` is an INCLUSIVE (`>=`) lower bound, works lexicographically because RFC-3339
+    UTC `Z` strings sort chronologically (same trick as `load_watchlist`).
+- Added the snapshot append to `execution/reconcile.py`, **STRICTLY AFTER**
+  `store.write_account_state(...)`, reusing already-computed `broker.nav` + `day_pl` (no new
+  broker call). The `as_of` is the reconcile `now` formatted via `data.store._to_rfc3339` so
+  it byte-matches the `account_state.as_of` written from the same `now`.
+  - Import of `_to_rfc3339` is **local** (inside the guarded block) — keeps reconcile's
+    module-level import discipline intact (`data.store` is otherwise TYPE_CHECKING-only there,
+    to avoid an import cycle) and only runs on the snapshot path.
+  - Wrapped in a **NON-FATAL guard** (`try/except Exception` → `logger.warning(..., exc_info=True)`):
+    a snapshot-write failure never aborts the reconcile. Broker-truth (the kill switch's
+    `account_state` row) is already committed before the append is attempted, so a failure
+    here cannot delay or interpose before it.
+
+**Behaviour-preserving guarantee (the load-bearing claim):**
+- ZERO change to the diff/adopt/close/refresh logic, the `account_state` write, or the
+  `ReconcileReport`. **All 18 existing `tests/test_reconciliation.py` tests pass UNCHANGED.**
+- Store-edit ownership (D-03): this task OWNS the `equity_snapshots` migration and **lands
+  first** on `data/store.py`. P4-T-04 (panel-data-layer) will later add `load_fills` to the
+  same file — serialized after, not parallel.
+
+**Tests (`tests/test_equity_snapshots.py`, 12 tests):**
+- Store: empty store → `[]`; round-trip; append-only (two writes at SAME `as_of` → two rows);
+  ascending order from out-of-order inserts; `since` inclusive filter; `since=None` returns all.
+- Reconcile (v20 mocked via `responses`): one snapshot per pass with `equity == broker.nav`
+  and `day_pl == nav − start_of_day_equity` (== `ReconcileReport.day_pl` == `account_state`);
+  drawdown second-pass (`day_pl == -50`, NOT the lifetime `pl`); two reconciles → two ordered
+  points; **call-order spy** proving `account_state` write precedes the snapshot; non-fatal
+  guard (snapshot raise → reconcile still returns, account_state still written, WARNING logged,
+  no partial row).
+- Reuses helpers imported from `tests.test_reconciliation` (`_client`, `_register`,
+  `_summary_response`, `_open_trades_response`, `NOW`, `OPEN_TRADES_URL`, `SUMMARY_URL`).
+
+**AC verification results:**
+- `./.venv/bin/python -m mypy .` → "Success: no issues found in 82 source files", exit 0
+- `./.venv/bin/python -m pytest -q tests/test_equity_snapshots.py` → 12 passed, exit 0
+- `./.venv/bin/python -m pytest -q tests/test_reconciliation.py` → 18 passed (UNCHANGED), exit 0
+- `./.venv/bin/python -m pytest -q` (full suite) → 984 passed, exit 0
+
+**No new dependencies** (sqlite3 stdlib; `responses` already a dev dep).
+**CLAUDE.md trigger-table check:** no new dep, no new CLI command, no new doc/feature —
+CLAUDE.md NOT edited.
+
+**Merge plan:** `gh pr merge 112 --squash --delete-branch` (lead action after reviewer pass)

--- a/data/store.py
+++ b/data/store.py
@@ -344,6 +344,36 @@ class Store:
         WHERE  event_id  = ?
     """
 
+    # ------------------------------------------------------------------
+    # equity_snapshots table (Phase 4 — equity-snapshots P4-T-03).
+    # An append-only broker-sourced equity time series for the panel's equity
+    # curve.  Each reconcile pass appends one immutable row; there is no PK to
+    # overwrite (the surrogate ``rowid`` is the only key).  All timestamps are
+    # UTC RFC 3339 TEXT (INV-03).  Broker-truth ``nav`` is the equity (INV-16).
+    # ------------------------------------------------------------------
+
+    #: SQL to create the ``equity_snapshots`` table if it does not exist.
+    #: Append-only: no PRIMARY KEY / unique constraint, so every reconcile pass
+    #: yields a distinct row even at the same ``as_of`` — history is never
+    #: clobbered.  ``as_of`` is UTC RFC 3339 (INV-03); ``equity`` is broker NAV
+    #: (INV-16); ``day_pl`` is ``nav − start_of_day_equity``.
+    _CREATE_EQUITY_SNAPSHOTS_SQL: str = """
+        CREATE TABLE IF NOT EXISTS equity_snapshots (
+            as_of    TEXT NOT NULL,
+            equity   REAL NOT NULL,
+            day_pl   REAL NOT NULL
+        )
+    """
+
+    #: Append one equity snapshot row.  Plain ``INSERT`` (no OR REPLACE/IGNORE):
+    #: the table is append-only, so repeated calls accumulate history.
+    _INSERT_EQUITY_SNAPSHOT_SQL: str = """
+        INSERT INTO equity_snapshots
+            (as_of, equity, day_pl)
+        VALUES
+            (?, ?, ?)
+    """
+
     #: SQL to upsert a single candle row (replace on PK conflict).
     _UPSERT_CANDLE_SQL: str = """
         INSERT OR REPLACE INTO candles
@@ -408,6 +438,7 @@ class Store:
         self._conn.execute(self._CREATE_POSITIONS_SQL)
         self._conn.execute(self._CREATE_ACCOUNT_STATE_SQL)
         self._conn.execute(self._CREATE_DEVIATION_LOG_SQL)
+        self._conn.execute(self._CREATE_EQUITY_SNAPSHOTS_SQL)
         self._conn.commit()
 
     def close(self) -> None:
@@ -1387,6 +1418,86 @@ class Store:
                     "severity": severity,
                     "created_at": created_at,
                     "delivered": bool(delivered_int),
+                }
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # equity_snapshots table (Phase 4 — equity-snapshots P4-T-03)
+    # ------------------------------------------------------------------
+
+    def write_equity_snapshot(
+        self,
+        *,
+        as_of: str,
+        equity: float,
+        day_pl: float,
+    ) -> None:
+        """Append one immutable equity snapshot (append-only — no overwrite).
+
+        Each reconcile pass calls this once with the broker-truth figures it
+        already computed (``equity`` ← ``broker.nav`` (INV-16), ``day_pl`` ←
+        ``nav − start_of_day_equity``).  A plain ``INSERT`` accumulates history;
+        there is no PK to clobber, so two calls at the same ``as_of`` yield two
+        distinct rows.
+
+        Args:
+            as_of: UTC RFC 3339 timestamp of the snapshot (INV-03). Already a
+                string — the caller formats the reconcile ``now`` via the store's
+                RFC 3339 helper so it matches the ``account_state.as_of`` it just
+                wrote.
+            equity: Broker NAV at ``as_of`` (broker-truth equity, INV-16).
+            day_pl: Today's P&L vs start-of-day equity (``nav − sod_equity``).
+        """
+        self._conn.execute(
+            self._INSERT_EQUITY_SNAPSHOT_SQL,
+            (as_of, float(equity), float(day_pl)),
+        )
+        self._conn.commit()
+
+    def load_equity_snapshots(
+        self,
+        *,
+        since: str | None = None,
+    ) -> list[dict[str, object]]:
+        """Load equity snapshots ordered by ``as_of`` ascending (oldest first).
+
+        Args:
+            since: If given, return only rows with ``as_of >= since`` (an RFC
+                3339 string lower bound — works lexicographically because RFC
+                3339 UTC strings sort chronologically).  ``None`` returns all.
+
+        Returns:
+            A list of dicts with keys ``as_of`` (RFC 3339 TEXT), ``equity``
+            (float) and ``day_pl`` (float), ordered by ``as_of`` ascending.
+            Empty list when no rows match.
+        """
+        if since is not None:
+            cursor = self._conn.execute(
+                """
+                SELECT as_of, equity, day_pl
+                FROM   equity_snapshots
+                WHERE  as_of >= ?
+                ORDER  BY as_of ASC
+                """,
+                (since,),
+            )
+        else:
+            cursor = self._conn.execute(
+                """
+                SELECT as_of, equity, day_pl
+                FROM   equity_snapshots
+                ORDER  BY as_of ASC
+                """
+            )
+        result: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            as_of, equity, day_pl = row
+            result.append(
+                {
+                    "as_of": as_of,
+                    "equity": float(equity),
+                    "day_pl": float(day_pl),
                 }
             )
         return result

--- a/execution/reconcile.py
+++ b/execution/reconcile.py
@@ -541,4 +541,31 @@ def reconcile(
     report.start_of_day_equity = start_of_day_equity
     report.day_pl = day_pl
     report.snapshotted_today = snapshotted
+
+    # equity-snapshots (P4-T-03): append one immutable broker-sourced equity
+    # point for the panel's equity curve, reusing the figures we just wrote to
+    # account_state — equity == broker.nav (INV-16), day_pl == nav − sod_equity.
+    # STRICTLY AFTER write_account_state so a snapshot-write failure can never
+    # delay or interpose before the kill switch's broker-truth row.  Purely
+    # additive and NON-FATAL: a failure here is logged at WARNING and swallowed
+    # — broker-truth reconciliation must never abort over a history append.
+    try:
+        # Local import keeps reconcile's module-level import discipline intact
+        # (data.store is otherwise TYPE_CHECKING-only here) and reuses the store's
+        # RFC 3339 helper so this as_of byte-matches the account_state.as_of just
+        # written from the same `now` (INV-03).
+        from data.store import _to_rfc3339
+
+        store.write_equity_snapshot(
+            as_of=_to_rfc3339(now),
+            equity=broker.nav,
+            day_pl=day_pl,
+        )
+    except Exception:  # noqa: BLE001 — snapshot is best-effort, never fatal
+        logger.warning(
+            "equity snapshot append failed (non-fatal; reconcile broker-truth "
+            "already committed)",
+            exc_info=True,
+        )
+
     return report

--- a/tests/test_equity_snapshots.py
+++ b/tests/test_equity_snapshots.py
@@ -1,0 +1,279 @@
+"""Tests for the equity-snapshots feature (P4-T-03).
+
+Two layers:
+
+* **Store** (``data.store``) — the ``equity_snapshots`` table + accessors:
+  append-only (no overwrite), ``load_equity_snapshots`` ordered by ``as_of``
+  ascending, ``since`` lower-bound filter, empty-store behaviour.
+* **Reconcile append** (``execution.reconcile``) — v20 mocked with the
+  ``responses`` library (no live HTTP): each reconcile pass appends exactly one
+  snapshot with ``equity == broker.nav`` and ``day_pl == nav − sod_equity`` (the
+  same figures it writes to ``account_state``); the append is *after*
+  ``write_account_state``; the append is non-fatal (a snapshot-write failure
+  logs WARNING but never aborts the reconcile — broker-truth wins).
+
+INV-03 (UTC RFC 3339 ``as_of``), INV-16 (broker NAV is the equity) are checked
+here.  The reconcile-path tests reuse the helpers from ``test_reconciliation``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+import responses as resp_lib
+
+from data.store import Store, _to_rfc3339
+from execution.reconcile import reconcile
+
+from tests.test_reconciliation import (
+    NOW,
+    OPEN_TRADES_URL,
+    SUMMARY_URL,
+    _client,
+    _open_trades_response,
+    _register,
+    _summary_response,
+)
+
+
+def _store() -> Store:
+    return Store(db_path=":memory:")
+
+
+# ===========================================================================
+# Store layer — table + accessors
+# ===========================================================================
+
+
+class TestEquitySnapshotStore:
+    def test_empty_store_returns_no_snapshots(self) -> None:
+        store = _store()
+        assert store.load_equity_snapshots() == []
+
+    def test_write_then_load_round_trips_floats_and_timestamp(self) -> None:
+        store = _store()
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:00:00Z", equity=10_050.0, day_pl=50.0
+        )
+        rows = store.load_equity_snapshots()
+        assert rows == [
+            {"as_of": "2026-05-29T13:00:00Z", "equity": 10_050.0, "day_pl": 50.0}
+        ]
+        # broker NAV stored as float (INV-16); as_of is RFC 3339 Z (INV-03).
+        assert isinstance(rows[0]["equity"], float)
+        assert isinstance(rows[0]["day_pl"], float)
+        assert str(rows[0]["as_of"]).endswith("Z")
+
+    def test_append_only_same_as_of_yields_two_distinct_rows(self) -> None:
+        # Append-only: no PK to clobber — two writes at the SAME as_of must NOT
+        # overwrite each other (unlike account_state's singleton row).
+        store = _store()
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:00:00Z", equity=10_000.0, day_pl=0.0
+        )
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:00:00Z", equity=10_010.0, day_pl=10.0
+        )
+        rows = store.load_equity_snapshots()
+        assert len(rows) == 2
+        assert {r["equity"] for r in rows} == {10_000.0, 10_010.0}
+
+    def test_load_is_ordered_by_as_of_ascending(self) -> None:
+        store = _store()
+        # Insert out of chronological order; load must return oldest-first.
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:10:00Z", equity=10_020.0, day_pl=20.0
+        )
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:00:00Z", equity=10_000.0, day_pl=0.0
+        )
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:05:00Z", equity=10_010.0, day_pl=10.0
+        )
+        rows = store.load_equity_snapshots()
+        as_ofs = [r["as_of"] for r in rows]
+        assert as_ofs == [
+            "2026-05-29T13:00:00Z",
+            "2026-05-29T13:05:00Z",
+            "2026-05-29T13:10:00Z",
+        ]
+
+    def test_since_filters_to_at_or_after_bound_inclusive(self) -> None:
+        store = _store()
+        for minute, equity in ((0, 10_000.0), (5, 10_010.0), (10, 10_020.0)):
+            store.write_equity_snapshot(
+                as_of=f"2026-05-29T13:{minute:02d}:00Z",
+                equity=equity,
+                day_pl=equity - 10_000.0,
+            )
+        rows = store.load_equity_snapshots(since="2026-05-29T13:05:00Z")
+        as_ofs = [r["as_of"] for r in rows]
+        # Inclusive lower bound: 13:05 is kept, 13:00 is dropped.
+        assert as_ofs == ["2026-05-29T13:05:00Z", "2026-05-29T13:10:00Z"]
+
+    def test_since_none_returns_all(self) -> None:
+        store = _store()
+        store.write_equity_snapshot(
+            as_of="2026-05-29T13:00:00Z", equity=10_000.0, day_pl=0.0
+        )
+        assert len(store.load_equity_snapshots(since=None)) == 1
+
+
+# ===========================================================================
+# Reconcile append — v20 mocked (no live HTTP)
+# ===========================================================================
+
+
+class TestReconcileAppendsSnapshot:
+    @resp_lib.activate
+    def test_one_snapshot_per_pass_equity_is_broker_nav(self) -> None:
+        _register(
+            _open_trades_response(),
+            _summary_response(nav="10050.00", pl="50.00"),
+        )
+        store = _store()
+        report = reconcile(client=_client(), store=store, now=NOW)
+
+        rows = store.load_equity_snapshots()
+        assert len(rows) == 1
+        snap = rows[0]
+        # equity == broker.nav (INV-16).
+        assert snap["equity"] == 10_050.0
+        # day_pl == nav − start_of_day_equity — identical to account_state and
+        # to the ReconcileReport (this is the day-open snapshot pass, so ≈ 0).
+        assert snap["day_pl"] == report.day_pl == 0.0
+        # as_of is the reconcile `now` as RFC 3339 Z (INV-03) and matches the
+        # account_state row written from the same `now`.
+        assert snap["as_of"] == _to_rfc3339(NOW)
+        state = store.load_account_state()
+        assert state is not None and snap["as_of"] == state["as_of"]
+
+    @resp_lib.activate
+    def test_day_pl_matches_nav_minus_start_of_day_equity(self) -> None:
+        # Second-pass drawdown: start_of_day snapshot at 10_000 from an earlier
+        # reconcile, then NAV falls to 9_950 → day_pl == -50.0 in the snapshot.
+        store = _store()
+        store.write_account_state(
+            start_of_day_equity=10_000.0,
+            day_pl=0.0,
+            as_of=NOW,
+        )
+        _register(
+            _open_trades_response(),
+            _summary_response(nav="9950.00", pl="-100.00"),
+        )
+        later = datetime(2026, 5, 29, 13, 5, 0, tzinfo=timezone.utc)
+        report = reconcile(client=_client(), store=store, now=later)
+
+        rows = store.load_equity_snapshots()
+        assert len(rows) == 1
+        snap = rows[0]
+        assert snap["equity"] == 9_950.0  # broker NAV (INV-16)
+        # nav − start_of_day_equity = 9950 − 10000 = -50 (NOT the lifetime pl).
+        assert snap["day_pl"] == -50.0 == report.day_pl
+        assert snap["as_of"] == _to_rfc3339(later)
+
+    def test_two_reconciles_yield_two_ordered_points(self) -> None:
+        store = _store()
+        t1 = datetime(2026, 5, 29, 13, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 5, 29, 13, 5, 0, tzinfo=timezone.utc)
+
+        def _do_reconcile(now: datetime, *, nav: str, pl: str) -> None:
+            with resp_lib.RequestsMock() as rsps:
+                rsps.add(
+                    resp_lib.GET,
+                    OPEN_TRADES_URL,
+                    json=_open_trades_response(),
+                    status=200,
+                )
+                rsps.add(
+                    resp_lib.GET,
+                    SUMMARY_URL,
+                    json=_summary_response(nav=nav, pl=pl),
+                    status=200,
+                )
+                reconcile(client=_client(), store=store, now=now)
+
+        _do_reconcile(t1, nav="10000.00", pl="0.00")
+        _do_reconcile(t2, nav="10030.00", pl="30.00")
+
+        rows = store.load_equity_snapshots()
+        assert len(rows) == 2
+        assert [r["as_of"] for r in rows] == [_to_rfc3339(t1), _to_rfc3339(t2)]
+        assert [r["equity"] for r in rows] == [10_000.0, 10_030.0]
+
+
+class TestAppendIsAdditiveAndNonFatal:
+    @resp_lib.activate
+    def test_append_happens_strictly_after_write_account_state(self) -> None:
+        # Record call order: write_account_state MUST be committed before the
+        # snapshot append, so a snapshot failure can never interpose before the
+        # kill-switch's broker-truth row.
+        store = _store()
+        order: list[str] = []
+
+        real_write_account_state = store.write_account_state
+        real_write_snapshot = store.write_equity_snapshot
+
+        def _spy_account_state(**kwargs: Any) -> None:
+            order.append("account_state")
+            real_write_account_state(**kwargs)
+
+        def _spy_snapshot(**kwargs: Any) -> None:
+            order.append("snapshot")
+            real_write_snapshot(**kwargs)
+
+        store.write_account_state = _spy_account_state  # type: ignore[method-assign]
+        store.write_equity_snapshot = _spy_snapshot  # type: ignore[method-assign]
+
+        _register(_open_trades_response(), _summary_response())
+        reconcile(client=_client(), store=store, now=NOW)
+
+        assert order == ["account_state", "snapshot"]
+
+    @resp_lib.activate
+    def test_snapshot_write_failure_does_not_abort_reconcile(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A snapshot-write failure is non-fatal: reconcile still returns a normal
+        # report and the account_state (broker-truth) row is still written.
+        store = _store()
+
+        def _boom(**kwargs: Any) -> None:
+            raise RuntimeError("disk full")
+
+        store.write_equity_snapshot = _boom  # type: ignore[method-assign]
+
+        _register(
+            _open_trades_response(),
+            _summary_response(nav="10050.00", pl="50.00"),
+        )
+        with caplog.at_level(logging.WARNING, logger="fathom.execution.reconcile"):
+            report = reconcile(client=_client(), store=store, now=NOW)
+
+        # Reconcile completed: report is intact, account_state was written.
+        assert report.day_pl == 0.0
+        state = store.load_account_state()
+        assert state is not None and state["start_of_day_equity"] == 10_050.0
+        # The failure was logged at WARNING, never raised.
+        assert any(
+            "equity snapshot" in rec.message.lower() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )
+
+    @resp_lib.activate
+    def test_snapshot_failure_leaves_no_partial_row(self) -> None:
+        store = _store()
+
+        def _boom(**kwargs: Any) -> None:
+            raise RuntimeError("disk full")
+
+        store.write_equity_snapshot = _boom  # type: ignore[method-assign]
+        _register(_open_trades_response(), _summary_response())
+        reconcile(client=_client(), store=store, now=NOW)
+
+        # Restore the real method only to read back — no snapshot was persisted.
+        assert Store.load_equity_snapshots(store) == []


### PR DESCRIPTION
## Summary
Backend enabler for the panel's equity curve (P4-T-03). Adds an append-only `equity_snapshots` table plus a one-line snapshot append in the already-periodic `reconcile`, giving the panel a true broker-sourced equity time series with no new moving parts.

## Changes
- **`data/store.py`** — `equity_snapshots` table (`as_of` TEXT RFC-3339 / INV-03, `equity` REAL, `day_pl` REAL), append-only (no PK, plain `INSERT`), wired into `_create_tables` via `CREATE TABLE IF NOT EXISTS`. New accessors:
  - `write_equity_snapshot(*, as_of, equity, day_pl)` — append-only insert.
  - `load_equity_snapshots(*, since=None)` — ordered by `as_of` ascending; `since` is an inclusive (`>=`) lower bound.
- **`execution/reconcile.py`** — appends one snapshot per pass with `equity=broker.nav` (INV-16) and `day_pl=nav − start_of_day_equity`, reusing the already-fetched figures (no new broker call). The `as_of` is the reconcile `now` formatted via the store's RFC-3339 helper, so it byte-matches the `account_state.as_of` written from the same `now`.
- **`tests/test_equity_snapshots.py`** — store accessors (append-only, ascending order, `since` filter, empty store) + reconcile-path tests against a mocked v20.

## Behaviour-preserving / additive
- The append happens **strictly after `store.write_account_state(...)`**, so a snapshot-write failure can never delay or interpose before the kill-switch's broker-truth row. A dedicated test asserts the `account_state → snapshot` call order.
- The append is wrapped in a **non-fatal guard**: a failure logs WARNING and is swallowed — reconcile still returns a normal `ReconcileReport` and the `account_state` row is still written. Tests cover both the guard and that no partial row is left.
- No change to the diff/adopt/close/refresh logic, the `account_state` write, or the `ReconcileReport`. **All existing Phase 3 reconciliation tests pass unchanged** (18/18).

## Verification
- `mypy .` → 0 errors (82 source files).
- `pytest` → 984 passed; `tests/test_reconciliation.py` 18/18 unchanged; `tests/test_equity_snapshots.py` 12/12.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)