### PR TITLE
docs(phase-5): draft 3 feature specs (go-live guardrails)

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -76,8 +76,12 @@ Maps to product-spec Phase 5. A **read-only** Streamlit dashboard over the exist
 | panel-data-layer | `panel/data.py` read-only accessors + view models (blotter incl. risk-in-use, equity series + drawdown, watchlist, deviation log, chart data); the tested seam | [panel-data-layer.md](panel-data-layer.md) | ready |
 | admin-panel | Streamlit app: 5 views + Lightweight Charts overlays + scan-refresh button; INV-01 transitive read-only boundary | [admin-panel.md](admin-panel.md) | ready |
 
-## Later — go-live (impl-Phase 5)
+## Phase 5 — go-live decision, real money (specs drafted; cross-spec audit pending)
 
-| Feature | Summary | Status |
-|---|---|---|
-| go-live | live-endpoint switch + small-size deliberate go-live decision (product-spec Phase 6, INV-07) | planned |
+Maps to product-spec Phase 6. **Go-live safety guardrails only — the live cutover is INV-07-blocked** (no demo track record yet) and operator-only; nothing here flips live or wires the live token. See [phase-5.md](../phases/phase-5.md).
+
+| Feature | Summary | Spec file | Status |
+|---|---|---|---|
+| preflight-check | `fathom preflight` GO/NO-GO readiness (account/kill-switch/brackets/env consistency + operator track-record attestation); read-only | [preflight-check.md](preflight-check.md) | draft |
+| live-trading-gate | defense-in-depth live gate (ENV=live + `live_trading_enabled` + preflight pass + typed confirm) + reduced `live_risk_fraction` (0.10%); pure, default-refuse | [live-trading-gate.md](live-trading-gate.md) | draft |
+| go-live-runbook | the deliberate reviewed cutover procedure (INV-07 prerequisite, gate sequence, small-size start, rollback) — doc/config artifact | [go-live-runbook.md](go-live-runbook.md) | draft |

--- a/docs/features/go-live-runbook.md
+++ b/docs/features/go-live-runbook.md
@@ -1,0 +1,86 @@
+# Feature: go-live-runbook
+
+**Status.** draft
+**Phase.** Phase 5
+**Owner.** saambaby
+**Last updated.** 2026-05-30
+
+## Summary
+
+The deliberate, reviewed go-live cutover procedure — a documentation/config artifact
+(not code, like the Hermes job definition), written so that *when* the demo track
+record justifies it, the operator can flip to live in one well-guarded, reversible
+step. It encodes the INV-07 prerequisite, the gate sequence (the four
+`live-trading-gate` gates + `fathom preflight`), the small-size start, the rollback
+plan, and the monitoring-during-cutover plan. It is the single source of truth for
+"how we go live" and the record of the go/no-go decision.
+
+## User-facing behaviour
+
+A markdown runbook (e.g. `docs/go-live-runbook.md` or
+`hermes_integration/jobs/`-style) with:
+
+- **Prerequisites (INV-07 — hard gate):** the demo track record is recorded and
+  positive — Phase 2 (T-08 Discord), Phase 3 (T-11 live demo loop), Phase 4 (T-06
+  panel) operator acceptances closed with results; the plumbing has proven reliable
+  on fake money over a sustained demo period. **The cutover does not proceed until
+  every box is ticked.**
+- **The cutover sequence (operator-only):** set the live token in `.env`; `ENV=live`;
+  run `fathom preflight --attest-track-record` → must be **GO**; enable
+  `live_trading_enabled=True`; `fathom execute` a single small candidate (typed
+  confirmation) at `live_risk_fraction` (0.10%); watch it fill + bracket;
+  `scripts/run_monitor.py` running; `fathom reconcile` matches broker truth.
+- **Small-size start + ramp:** begin at 0.10%; ramp toward 0.25% only after a
+  documented live track record; the ramp is a deliberate operator decision, never
+  automatic.
+- **Rollback:** how to immediately stand down — set `live_trading_enabled=False`
+  (instant: the gate refuses), `ENV=demo`, flatten/close open live positions via the
+  operator path, and the daily-loss kill switch as the automated backstop.
+- **Monitoring during cutover:** the deviation monitor + Discord alerts live; what to
+  watch (slippage, adverse path, feed health) for the first live trades.
+- **Go/No-Go decision record:** a place to record the dated, reviewed decision and
+  who signed off.
+
+## Acceptance criteria
+
+- [ ] The runbook states the INV-07 prerequisite as a hard gate (cutover blocked until the demo track record is recorded + positive) and lists the specific closed acceptances required (T-08, T-11, T-06).
+- [ ] The cutover sequence references **only** the real, shipped controls: `ENV`, `live_trading_enabled`, `fathom preflight`, `fathom execute` (typed confirm), `live_risk_fraction`, `scripts/run_monitor.py`, `fathom reconcile`. No invented commands.
+- [ ] A rollback/stand-down procedure exists (flag-off is instant; kill switch is the automated backstop) and a small-size-start + manual-ramp policy is documented.
+- [ ] The monitoring-during-cutover plan and a dated go/no-go decision-record section are present.
+- [ ] It is explicit that going live is **operator-only and deliberate** — no automated step performs the cutover (INV-07).
+
+## Component design
+
+Pure documentation — the capstone artifact. It is verified by an artifact lint
+(the referenced commands/flags exist; the INV-07 + rollback + decision-record
+sections are present), mirroring how the Phase 2 `daily.md` Hermes job was
+"configured, not coded." It composes the controls built by [[preflight-check]] +
+[[live-trading-gate]] into the human procedure.
+
+## Non-goals
+
+- No code, no live connection (operator-only, INV-07). It documents; it does not execute.
+- No auto-ramp / auto-cutover.
+
+## Touches
+
+- [INV-07] — the procedure is the embodiment of demo-first; the prerequisite gate is its first section.
+- [INV-05] — documents the small-size start (≤ the cap) + manual ramp.
+
+## Depends on
+
+- [[preflight-check]] + [[live-trading-gate]] (the controls it sequences) — drafted/built first so the runbook references real commands.
+
+## Approach
+
+Written last (the capstone), after the gate + preflight ship, so every referenced
+command is real. Artifact-lint verification + operator review.
+
+## Open questions
+
+- Location — `docs/go-live-runbook.md` vs `hermes_integration/`-style. Propose `docs/`
+  (it's an operator procedure, not a Hermes job).
+
+## Out of scope
+
+- The gate/preflight code (their own specs); the actual cutover (operator-only, INV-07).

--- a/docs/features/live-trading-gate.md
+++ b/docs/features/live-trading-gate.md
@@ -1,0 +1,106 @@
+# Feature: live-trading-gate
+
+**Status.** draft
+**Phase.** Phase 5
+**Owner.** saambaby
+**Last updated.** 2026-05-30
+
+## Summary
+
+The real-money safety gate. Today `ENV=live` alone would place live orders; this
+feature makes a live order require **four independent gates**, all of which must
+pass: `ENV=live` **AND** `live_trading_enabled=True` (default False) **AND** a
+passing `fathom preflight` **AND** an interactive typed confirmation. It also
+selects a **reduced live position size** (`live_risk_fraction`, default 0.10% ≤ the
+0.25% INV-05 cap). Demo is unchanged — no new friction. This is the highest-stakes
+code in the system: a bug here is an accidental real-money trade, so the gate logic
+is a pure, exhaustively-tested module and the default is always "refuse."
+
+## User-facing behaviour
+
+- `config/settings.py` adds: `live_trading_enabled: bool = False`; `live_risk_fraction: float = 0.001` (0.10%), documented; validated `0 < live_risk_fraction <= 0.0025` (never above the INV-05 cap).
+- `execution/live_gate.py` (pure):
+  - `assert_live_allowed(*, settings, preflight_report, confirmed: bool) -> None` — raises `LiveTradingBlocked(reason)` unless **all** hold: `settings.env == "live"`, `settings.live_trading_enabled`, `preflight_report.go`, and `confirmed`. The reason names the **first** failing gate. On demo (`env != "live"`) it is a no-op (demo path unchanged).
+  - `effective_risk_fraction(settings) -> float` — `live_risk_fraction` when `env=="live"`, else the demo `DEFAULT_RISK_FRACTION` (0.0025). The **only** place the env-dependent fraction is selected; sizing itself is unchanged (INV-09).
+- `fathom execute` (live context): runs `fathom preflight`, then requires a typed confirmation (the operator types the `oanda_account_id`); calls `assert_live_allowed(...)` before sizing; sizes with `effective_risk_fraction(settings)`. Any gate failing ⇒ refuse with the named reason + non-zero exit, **no order placed**. On demo, `execute` behaves exactly as Phase 3 (no preflight, no confirm, 0.25% fraction).
+
+## Acceptance criteria
+
+- [ ] `assert_live_allowed` raises `LiveTradingBlocked` (naming the failing gate) if ANY of {`env=="live"`, `live_trading_enabled`, `preflight.go`, `confirmed`} is false; it returns (allows) only when all four are true. Exhaustively unit-tested across the truth table.
+- [ ] On demo (`env != "live"`), `assert_live_allowed` is a no-op and `fathom execute` is byte-identical to Phase 3 — no preflight, no confirmation prompt, no new friction (a test pins the demo path unchanged).
+- [ ] `effective_risk_fraction` returns `live_risk_fraction` (≤ 0.0025) for live and `DEFAULT_RISK_FRACTION` for demo; settings validation rejects `live_risk_fraction > 0.0025` or ≤ 0 (INV-05 — live is never larger than the cap).
+- [ ] `live_trading_enabled` defaults to **False**; `ENV=live` with the flag False ⇒ refuse. The four gates are independent (no single misconfiguration places a live order).
+- [ ] A live `fathom execute` requires the typed confirmation (the account id); a wrong/empty confirmation ⇒ refuse, no order. `--yes` does NOT bypass the live confirmation (live always confirms; `--yes` only affects demo).
+- [ ] No code path connects to the live endpoint in tests; the live token is never required to run the suite or logged (INV-07/08). The gate is pure + offline-testable (settings/report/confirmed injected).
+- [ ] INV-09 preserved: `risk/sizing.py`/`execution/orders.py` mechanics are unchanged; only the *fraction input* and the *operator-boundary gate* are env-aware.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    actor OP as Operator
+    participant CLI as fathom execute (live)
+    participant PF as fathom preflight
+    participant GATE as live_gate.assert_live_allowed
+    participant SZ as sizing (effective_risk_fraction)
+    participant EX as execution/orders
+
+    OP->>CLI: fathom execute <candidate>  (ENV=live)
+    CLI->>PF: run_preflight(...)
+    PF-->>CLI: PreflightReport(go=?)
+    CLI->>OP: type the account id to confirm
+    OP-->>CLI: <typed confirmation>
+    CLI->>GATE: assert_live_allowed(env, flag, preflight.go, confirmed)
+    alt any gate fails
+        GATE-->>CLI: raise LiveTradingBlocked(reason)
+        CLI-->>OP: REFUSE (named gate), exit ≠ 0 — no order
+    else all four pass
+        CLI->>SZ: size with effective_risk_fraction = live_risk_fraction (0.10%)
+        SZ->>EX: bracketed, idempotent order (same mechanics as demo)
+        EX-->>OP: Fill
+    end
+```
+
+## Component design
+
+The gate logic is a **pure** `execution/live_gate.py` (no I/O) so the entire truth
+table is unit-tested without the CLI or a broker. `fathom execute` (single-writer on
+`cli.py`; this task adds the live gate, after [[preflight-check]] added `fathom
+preflight`) wires: preflight → typed confirm → `assert_live_allowed` → size with
+`effective_risk_fraction` → the unchanged Phase 3 submit path. The reduced fraction
+flows into the **same** `size_position` (INV-09: mechanics identical; only the
+fraction input differs, selected once at the boundary). Default-refuse everywhere:
+the gate's bias is to block.
+
+## Non-goals
+
+- No live connection / token wiring (operator-only, deferred — INV-07). The gate is built + tested offline.
+- No size-ramp automation (ramping past 0.10% is an operator decision on a live track record).
+- No change to sizing/orders/reconcile/monitor mechanics (INV-09).
+
+## Touches
+
+- [INV-07] — the multi-gate that keeps live deliberate; the cutover stays operator-only.
+- [INV-05] — `live_risk_fraction` validated ≤ 0.25% (never larger).
+- [INV-09] — mechanics unchanged; the env-aware gate + fraction selection are a sanctioned operator-boundary layer (invariant-clarification candidate — see phase-5 open questions).
+- [INV-08] — live token in `.env`, never logged.
+
+## Depends on
+
+- [[preflight-check]] (`run_preflight`/`PreflightReport` — the gate requires a passing preflight; also serializes the `cli.py` edit after it), `config/settings.py` (the new flags), `risk/sizing.py` (`DEFAULT_RISK_FRACTION`, `size_position` — unchanged), `execution/orders.py` (unchanged submit path), `cli.py` (`fathom execute`).
+
+## Approach
+
+Build the pure `live_gate` + the settings flags + validation first (exhaustive
+truth-table tests, demo-noop test, INV-05 validation test), then wire `fathom
+execute` (live: preflight + confirm + gate + reduced fraction; demo: unchanged).
+Never require the live token in tests.
+
+## Open questions
+
+- Confirm token = the `oanda_account_id` (proposed) vs a fixed `LIVE` string — lean account id (forces looking at *which* account).
+- Should `effective_risk_fraction` also enforce an absolute notional ceiling, or just the fraction? Propose fraction-only for Phase 5; a notional ceiling later.
+
+## Out of scope
+
+- The readiness checks themselves ([[preflight-check]]); the cutover procedure ([[go-live-runbook]]); the actual live cutover (operator-only, INV-07).

--- a/docs/features/preflight-check.md
+++ b/docs/features/preflight-check.md
@@ -1,0 +1,82 @@
+# Feature: preflight-check
+
+**Status.** draft
+**Phase.** Phase 5
+**Owner.** saambaby
+**Last updated.** 2026-05-30
+
+## Summary
+
+A read-only go/no-go readiness check the operator runs before considering a live
+cutover (and before any live `fathom execute`). It verifies the *mechanical*
+prerequisites are in place — account reachable, kill switch armed and not tripped,
+brackets/INV-04 enforceable, env↔flag↔token consistency — and requires an explicit
+operator **track-record attestation** (it never auto-judges "edge quality"). It
+prints a clear GO / NO-GO with per-check status and exits non-zero on NO-GO. It is
+the readiness gate that `live-trading-gate` requires before a live order; it places
+no orders and changes no state.
+
+## User-facing behaviour
+
+- `execution/preflight.py` — `run_preflight(*, settings, store, client=None, attested: bool = False) -> PreflightReport`:
+  - **Account reachable** — an account-summary read succeeds (uses the injected client; on demo this hits practice, never live unless the operator has already set ENV=live).
+  - **Kill switch** — `risk/limits.py` reports the daily-loss kill switch is *armed and not tripped* for the current `account_state`.
+  - **Brackets/INV-04** — confirms the execution path enforces SL+TP (a static check that `build_bracket`/order submission can't produce a naked order — e.g. config/contract assertion).
+  - **Env/flag/token consistency** — if `ENV=live`, a live-shaped token + `oanda_account_id` are present; `live_trading_enabled` state is reported; no demo/live mismatch.
+  - **Track-record attestation** — `attested` must be True (the operator asserts the demo track record per INV-07); preflight **does not** judge edge quality itself.
+  - Returns a `PreflightReport` with an overall `go: bool` and a list of per-check `(name, ok, detail)`.
+- `fathom preflight [--db-path PATH] [--attest-track-record]` — runs it, prints each check + an overall **GO**/**NO-GO**, exits 0 on GO / non-zero on NO-GO. Read-only; places nothing.
+
+## Acceptance criteria
+
+- [ ] `run_preflight` returns `go=False` if ANY check fails, with the failing check(s) named in the report; `go=True` only when **all** mechanical checks pass **and** `attested=True`.
+- [ ] Track-record attestation is required: `attested=False` → NO-GO with a reason pointing at INV-07 (preflight never green-lights live on its own).
+- [ ] Kill-switch check is NO-GO when the switch is tripped or `account_state` is missing/stale; GO when armed and not tripped.
+- [ ] Env/flag/token consistency: `ENV=live` without a token/account or with `live_trading_enabled=False` is reported clearly (NO-GO or a flagged warning per the rules); demo is always internally consistent.
+- [ ] `fathom preflight` exits 0 on GO, non-zero on NO-GO; prints per-check status; **places no order and writes no state** (read-only — a test asserts no order/write capability).
+- [ ] No secret (token) is printed (INV-08); all timestamps UTC (INV-03).
+- [ ] Pure/deterministic core — `run_preflight` takes injected `settings`/`store`/`client`; unit-tested against a seeded store + stub client (no live HTTP).
+
+## Component design
+
+`execution/preflight.py` is a pure orchestration over read-only inputs: it composes
+existing read paths (`store.load_account_state`, `risk.limits.kill_switch_status` /
+the armed-check, an account-summary read via the injected client) into a
+`PreflightReport`. No order/sizing call. The `fathom preflight` CLI command wires it
+(single-writer on `cli.py`; this task adds `preflight`, `live-trading-gate` later
+adds the `execute` gate — serialized). Demo-safe: with `ENV=demo` it checks the
+practice account; it never forces a live connection.
+
+## Non-goals
+
+- No enforcement — preflight *reports*; the actual live refusal is [[live-trading-gate]].
+- No edge-quality judgement — the operator attests the track record (INV-07).
+- No order placement, no state writes (read-only).
+
+## Touches
+
+- [INV-07] — surfaces the track-record attestation; the readiness half of the go-live gate.
+- [INV-08] — never prints the token. [INV-03] — UTC timestamps.
+- [INV-09] — reads `settings` at the operator boundary (readiness reporting), does not alter the mechanics.
+
+## Depends on
+
+- `config/settings.py` (env + the new flags from [[live-trading-gate]] — preflight *reports* `live_trading_enabled`; the flag itself is added by that spec, so coordinate ordering), `risk/limits.py` (kill-switch armed/tripped state), `data/store.py` (`load_account_state`), `data/oanda_client.py` (account-summary read).
+
+## Approach
+
+Build the pure `run_preflight` + report first (full offline tests with a seeded
+store + stub client), then the thin `fathom preflight` CLI command. Note: it reports
+`live_trading_enabled`, which [[live-trading-gate]] adds to settings — if drafted
+first, gate the report behind a `getattr` default or sequence after the flag lands.
+
+## Open questions
+
+- Exact check set — propose the five above; confirm whether "brackets/INV-04" is a
+  static contract assertion or a dry-run order construction (lean static).
+- Attestation marker — a CLI flag (`--attest-track-record`) for now vs a persisted
+  signed-off record. Propose the flag for Phase 5; a persisted marker later.
+
+## Out of scope
+
+- The live refusal/gate ([[live-trading-gate]]); the cutover doc ([[go-live-runbook]]); the actual live connection (operator-only, INV-07).


### PR DESCRIPTION
## Summary

Layer-4 feature specs for **impl-Phase 5** (= product-spec Phase 6 — go-live, real money). Status **draft** — the cross-spec audit promotes to `ready`. **Guardrails only — nothing flips live (INV-07).**

### Specs (drafting order = dependency order)
1. **preflight-check** — `execution/preflight.py::run_preflight` + `fathom preflight` GO/NO-GO readiness (account reachable, kill switch armed/not-tripped, brackets/INV-04, env↔flag↔token consistency, operator track-record attestation). Read-only — no order, no state write.
2. **live-trading-gate** — the real-money safety gate: config flags (`live_trading_enabled=False`, `live_risk_fraction=0.001` validated ≤ the 0.25% INV-05 cap) + a pure `execution/live_gate.py` (`assert_live_allowed` four-gate truth table, default-refuse; `effective_risk_fraction`) + the `fathom execute` live gate. Demo path byte-identical (INV-09 mechanics unchanged). → opus (a bug = an accidental real-money trade).
3. **go-live-runbook** — the deliberate reviewed cutover procedure (INV-07 prerequisite, gate sequence, small-size start, rollback, monitoring). Doc/config artifact.

Each has acceptance criteria, component design, deps, proposed defaults; `live-trading-gate` carries a sequence diagram. `INDEX.md` Phase 5 section replaces the go-live stub. Surfaced for the audit: the **INV-09 clarification** (the env-aware gate is a sanctioned operator-boundary layer; mechanics stay single-path).

Docs only — no code, nothing live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)