### PR TITLE
docs(phase-5): cross-spec audit + fixes

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -76,12 +76,12 @@ Maps to product-spec Phase 5. A **read-only** Streamlit dashboard over the exist
 | panel-data-layer | `panel/data.py` read-only accessors + view models (blotter incl. risk-in-use, equity series + drawdown, watchlist, deviation log, chart data); the tested seam | [panel-data-layer.md](panel-data-layer.md) | ready |
 | admin-panel | Streamlit app: 5 views + Lightweight Charts overlays + scan-refresh button; INV-01 transitive read-only boundary | [admin-panel.md](admin-panel.md) | ready |
 
-## Phase 5 — go-live decision, real money (specs drafted; cross-spec audit pending)
+## Phase 5 — go-live decision, real money (specs ready; cross-spec audit passed 2026-05-30)
 
 Maps to product-spec Phase 6. **Go-live safety guardrails only — the live cutover is INV-07-blocked** (no demo track record yet) and operator-only; nothing here flips live or wires the live token. See [phase-5.md](../phases/phase-5.md).
 
 | Feature | Summary | Spec file | Status |
 |---|---|---|---|
-| preflight-check | `fathom preflight` GO/NO-GO readiness (account/kill-switch/brackets/env consistency + operator track-record attestation); read-only | [preflight-check.md](preflight-check.md) | draft |
-| live-trading-gate | defense-in-depth live gate (ENV=live + `live_trading_enabled` + preflight pass + typed confirm) + reduced `live_risk_fraction` (0.10%); pure, default-refuse | [live-trading-gate.md](live-trading-gate.md) | draft |
-| go-live-runbook | the deliberate reviewed cutover procedure (INV-07 prerequisite, gate sequence, small-size start, rollback) — doc/config artifact | [go-live-runbook.md](go-live-runbook.md) | draft |
+| preflight-check | `fathom preflight` GO/NO-GO readiness (account/kill-switch/brackets/env consistency + operator track-record attestation); read-only | [preflight-check.md](preflight-check.md) | ready |
+| live-trading-gate | defense-in-depth live gate (ENV=live + `live_trading_enabled` + preflight pass + typed confirm) + reduced `live_risk_fraction` (0.10%); pure, default-refuse | [live-trading-gate.md](live-trading-gate.md) | ready |
+| go-live-runbook | the deliberate reviewed cutover procedure (INV-07 prerequisite, gate sequence, small-size start, rollback) — doc/config artifact | [go-live-runbook.md](go-live-runbook.md) | ready |

--- a/docs/features/go-live-runbook.md
+++ b/docs/features/go-live-runbook.md
@@ -1,6 +1,6 @@
 # Feature: go-live-runbook
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 5
 **Owner.** saambaby
 **Last updated.** 2026-05-30
@@ -30,9 +30,11 @@ A markdown runbook (e.g. `docs/go-live-runbook.md` or
   `live_trading_enabled=True`; `fathom execute` a single small candidate (typed
   confirmation) at `live_risk_fraction` (0.10%); watch it fill + bracket;
   `scripts/run_monitor.py` running; `fathom reconcile` matches broker truth.
-- **Small-size start + ramp:** begin at 0.10%; ramp toward 0.25% only after a
-  documented live track record; the ramp is a deliberate operator decision, never
-  automatic.
+- **Small-size start + ramp:** begin at 0.10% (`LIVE_RISK_FRACTION=0.001` in `.env`);
+  ramp toward 0.25% only after a documented live track record, by editing
+  `LIVE_RISK_FRACTION` — the settings-time `Field(le=0.0025)` validator rejects any
+  ramp typo above the INV-05 cap at startup. The ramp is a deliberate operator
+  decision, never automatic.
 - **Rollback:** how to immediately stand down — set `live_trading_enabled=False`
   (instant: the gate refuses), `ENV=demo`, flatten/close open live positions via the
   operator path, and the daily-loss kill switch as the automated backstop.

--- a/docs/features/live-trading-gate.md
+++ b/docs/features/live-trading-gate.md
@@ -1,6 +1,6 @@
 # Feature: live-trading-gate
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 5
 **Owner.** saambaby
 **Last updated.** 2026-05-30
@@ -18,17 +18,19 @@ is a pure, exhaustively-tested module and the default is always "refuse."
 
 ## User-facing behaviour
 
-- `config/settings.py` adds: `live_trading_enabled: bool = False`; `live_risk_fraction: float = 0.001` (0.10%), documented; validated `0 < live_risk_fraction <= 0.0025` (never above the INV-05 cap).
+- `config/settings.py` adds: `live_trading_enabled: bool = False`; **`live_risk_fraction: float = Field(default=0.001, gt=0.0, le=0.0025)`** (0.10%; the `le=0.0025` bound references the INV-05 cap so the two cannot drift) — mirrors `LimitsConfig`'s `Field` constraints. A `Settings` constructed with `live_risk_fraction <= 0` or `> 0.0025` raises `ValidationError` at load time (B-5: the settings-time validator is the only thing between a `.env` typo and a real-money cap breach).
 - `execution/live_gate.py` (pure):
-  - `assert_live_allowed(*, settings, preflight_report, confirmed: bool) -> None` — raises `LiveTradingBlocked(reason)` unless **all** hold: `settings.env == "live"`, `settings.live_trading_enabled`, `preflight_report.go`, and `confirmed`. The reason names the **first** failing gate. On demo (`env != "live"`) it is a no-op (demo path unchanged).
-  - `effective_risk_fraction(settings) -> float` — `live_risk_fraction` when `env=="live"`, else the demo `DEFAULT_RISK_FRACTION` (0.0025). The **only** place the env-dependent fraction is selected; sizing itself is unchanged (INV-09).
-- `fathom execute` (live context): runs `fathom preflight`, then requires a typed confirmation (the operator types the `oanda_account_id`); calls `assert_live_allowed(...)` before sizing; sizes with `effective_risk_fraction(settings)`. Any gate failing ⇒ refuse with the named reason + non-zero exit, **no order placed**. On demo, `execute` behaves exactly as Phase 3 (no preflight, no confirm, 0.25% fraction).
+  - `assert_live_allowed(*, settings, preflight_report, confirmed: bool) -> None` — raises `LiveTradingBlocked(reason)` unless **all** hold: `settings.env == "live"`, `settings.live_trading_enabled is True`, `preflight_report.go is True`, and `confirmed is True`. The reason names the **first** failing gate. On demo (`env != "live"`) it is a no-op (demo path unchanged).
+    - **Default-refuse on a bad preflight (B-1):** treat a `preflight_report` that is `None`, not a `PreflightReport`, or whose `.go` is not **exactly `True`** as a **failed** preflight gate (raise). The caller (`cmd_execute`) must wrap `run_preflight(...)` so that **any exception from it in the live path is caught and converted to a refuse** (non-zero exit, no order) — an exception is never interpreted as GO. Bias is always to block.
+  - `effective_risk_fraction(settings) -> float` — `settings.live_risk_fraction` when `env=="live"`, else the demo `DEFAULT_RISK_FRACTION` (0.0025). The **only** place the env-dependent fraction is selected; the sizing function itself is unchanged (INV-09, per the new INV-09 operator-boundary clause).
+- `fathom execute` (live context): runs `run_preflight` (exceptions → refuse), then requires a typed confirmation — the operator types the `oanda_account_id` (a plain `str`, safe to echo — not the SecretStr token). This live confirm is a **distinct prompt evaluated before `assert_live_allowed`, NOT guarded by `--yes`/`skip_confirm`** (N-3): the existing `--yes`-gated `[y/N]` confirm (`cli.py:1625`) remains **demo-only**; live always requires the typed account id even with `--yes`. Then calls `assert_live_allowed(...)` before sizing; sizes with `effective_risk_fraction(settings)`. Any gate failing ⇒ refuse with the named reason + non-zero exit, **no order placed**. On demo, `execute` behaves exactly as Phase 3 (no preflight, no typed confirm, 0.25% fraction).
 
 ## Acceptance criteria
 
-- [ ] `assert_live_allowed` raises `LiveTradingBlocked` (naming the failing gate) if ANY of {`env=="live"`, `live_trading_enabled`, `preflight.go`, `confirmed`} is false; it returns (allows) only when all four are true. Exhaustively unit-tested across the truth table.
+- [ ] `assert_live_allowed` raises `LiveTradingBlocked` (naming the failing gate) if ANY of {`env=="live"`, `live_trading_enabled`, `preflight.go`, `confirmed`} is false; it returns (allows) only when all four are true. Exhaustively unit-tested across the truth table, **including rows where `preflight_report` is `None`, not a `PreflightReport`, or `.go` is non-`True` → all refuse** (B-1). A `cmd_execute` test pins that an exception raised by `run_preflight` in the live path becomes a refuse (no order), never a GO.
 - [ ] On demo (`env != "live"`), `assert_live_allowed` is a no-op and `fathom execute` is byte-identical to Phase 3 — no preflight, no confirmation prompt, no new friction (a test pins the demo path unchanged).
-- [ ] `effective_risk_fraction` returns `live_risk_fraction` (≤ 0.0025) for live and `DEFAULT_RISK_FRACTION` for demo; settings validation rejects `live_risk_fraction > 0.0025` or ≤ 0 (INV-05 — live is never larger than the cap).
+- [ ] `effective_risk_fraction` returns `live_risk_fraction` (≤ 0.0025) for live and `DEFAULT_RISK_FRACTION` for demo; settings validation (the `Field(gt=0.0, le=0.0025)` bound) rejects `live_risk_fraction > 0.0025` or ≤ 0 at load time — a test pins both bounds (INV-05 — live is never larger than the cap).
+- [ ] `cmd_execute` (`cli.py:~1528`) passes `risk_fraction=effective_risk_fraction(settings)` to `size_position` **instead of** the hard-coded `DEFAULT_RISK_FRACTION` (B-2). A test pins that the **demo** `size_position` call receives exactly `0.0025` (demo numerically unchanged) and a **live** call receives `live_risk_fraction`.
 - [ ] `live_trading_enabled` defaults to **False**; `ENV=live` with the flag False ⇒ refuse. The four gates are independent (no single misconfiguration places a live order).
 - [ ] A live `fathom execute` requires the typed confirmation (the account id); a wrong/empty confirmation ⇒ refuse, no order. `--yes` does NOT bypass the live confirmation (live always confirms; `--yes` only affects demo).
 - [ ] No code path connects to the live endpoint in tests; the live token is never required to run the suite or logged (INV-07/08). The gate is pure + offline-testable (settings/report/confirmed injected).
@@ -65,12 +67,20 @@ sequenceDiagram
 
 The gate logic is a **pure** `execution/live_gate.py` (no I/O) so the entire truth
 table is unit-tested without the CLI or a broker. `fathom execute` (single-writer on
-`cli.py`; this task adds the live gate, after [[preflight-check]] added `fathom
-preflight`) wires: preflight → typed confirm → `assert_live_allowed` → size with
-`effective_risk_fraction` → the unchanged Phase 3 submit path. The reduced fraction
-flows into the **same** `size_position` (INV-09: mechanics identical; only the
-fraction input differs, selected once at the boundary). Default-refuse everywhere:
-the gate's bias is to block.
+`cli.py`; this task adds the live gate **after** [[preflight-check]] adds `fathom
+preflight` — the two Phase-5 `cli.py` edits are serialized in that order, N-1/N-2)
+wires: `run_preflight` (exceptions→refuse) → the **separate, non-`--yes`** typed
+account-id confirm → `assert_live_allowed` → size with `effective_risk_fraction` →
+the unchanged Phase 3 submit path. Concretely, the `cmd_execute` `size_position` call
+at `cli.py:~1528` changes `risk_fraction=DEFAULT_RISK_FRACTION` →
+`risk_fraction=effective_risk_fraction(settings)`; on demo that returns `0.0025`
+(numerically identical) and the gate block is skipped, so the demo path is unchanged.
+The reduced fraction flows into the **same** `size_position` (INV-09: mechanics
+identical; only the fraction input + the pre-submit gate differ, per the new INV-09
+operator-boundary clause). Default-refuse everywhere: the gate's bias is to block.
+
+The new settings fields land first (this task), so [[preflight-check]] reads them
+directly with no `getattr` hedge (N-1).
 
 ## Non-goals
 
@@ -98,8 +108,14 @@ Never require the live token in tests.
 
 ## Open questions
 
-- Confirm token = the `oanda_account_id` (proposed) vs a fixed `LIVE` string — lean account id (forces looking at *which* account).
 - Should `effective_risk_fraction` also enforce an absolute notional ceiling, or just the fraction? Propose fraction-only for Phase 5; a notional ceiling later.
+
+**Resolved at cross-spec audit (2026-05-30):** confirm token = `oanda_account_id`
+(plain `str`, safe to echo, forces looking at *which* account); INV-09 amended to
+sanction this env-aware operator-boundary gate (B-4/P-1); B-1 default-refuse on
+bad/None/exception preflight pinned; B-2 `effective_risk_fraction` threaded into
+`cmd_execute`'s `size_position` call; B-5 `Field(gt=0.0, le=0.0025)` bound pinned;
+N-1/N-2/N-3 ordering + non-`--yes` live confirm pinned.
 
 ## Out of scope
 

--- a/docs/features/preflight-check.md
+++ b/docs/features/preflight-check.md
@@ -1,6 +1,6 @@
 # Feature: preflight-check
 
-**Status.** draft
+**Status.** ready
 **Phase.** Phase 5
 **Owner.** saambaby
 **Last updated.** 2026-05-30
@@ -20,7 +20,7 @@ no orders and changes no state.
 
 - `execution/preflight.py` — `run_preflight(*, settings, store, client=None, attested: bool = False) -> PreflightReport`:
   - **Account reachable** — an account-summary read succeeds (uses the injected client; on demo this hits practice, never live unless the operator has already set ENV=live).
-  - **Kill switch** — `risk/limits.py` reports the daily-loss kill switch is *armed and not tripped* for the current `account_state`.
+  - **Kill switch (B-3 — concrete shipped semantics):** there is no "armed" field on the shipped API. Preflight loads `store.load_account_state()` and calls `risk.limits.kill_switch_status(day_pl=…, start_of_day_equity=…, config=LimitsConfig(), now=…)`. **"Armed and healthy" ≡ `account_state is not None` AND its `as_of` is within the staleness window (default 10 min of `now`) AND `KillSwitchStatus.active is False` (not tripped).** NO-GO if `account_state` is missing, stale, or the switch is tripped (`active is True`). For single-source reuse (à la `book_risk_sum`, P4-T-02), extract a small **`kill_switch_armed(account_state, now, config) -> (bool, reason)`** into `risk/limits.py` and have preflight call it (coordinator-serialized edit to the shipped `risk/limits.py`).
   - **Brackets/INV-04** — confirms the execution path enforces SL+TP (a static check that `build_bracket`/order submission can't produce a naked order — e.g. config/contract assertion).
   - **Env/flag/token consistency** — if `ENV=live`, a live-shaped token + `oanda_account_id` are present; `live_trading_enabled` state is reported; no demo/live mismatch.
   - **Track-record attestation** — `attested` must be True (the operator asserts the demo track record per INV-07); preflight **does not** judge edge quality itself.
@@ -31,7 +31,7 @@ no orders and changes no state.
 
 - [ ] `run_preflight` returns `go=False` if ANY check fails, with the failing check(s) named in the report; `go=True` only when **all** mechanical checks pass **and** `attested=True`.
 - [ ] Track-record attestation is required: `attested=False` → NO-GO with a reason pointing at INV-07 (preflight never green-lights live on its own).
-- [ ] Kill-switch check is NO-GO when the switch is tripped or `account_state` is missing/stale; GO when armed and not tripped.
+- [ ] Kill-switch check is NO-GO when `account_state is None`, when its `as_of` is older than the staleness window (default 10 min), or when `kill_switch_status(...).active is True` (tripped); GO only when present + fresh + not tripped (`kill_switch_armed` returns True). A test pins each case.
 - [ ] Env/flag/token consistency: `ENV=live` without a token/account or with `live_trading_enabled=False` is reported clearly (NO-GO or a flagged warning per the rules); demo is always internally consistent.
 - [ ] `fathom preflight` exits 0 on GO, non-zero on NO-GO; prints per-check status; **places no order and writes no state** (read-only — a test asserts no order/write capability).
 - [ ] No secret (token) is printed (INV-08); all timestamps UTC (INV-03).
@@ -61,21 +61,29 @@ practice account; it never forces a live connection.
 
 ## Depends on
 
-- `config/settings.py` (env + the new flags from [[live-trading-gate]] — preflight *reports* `live_trading_enabled`; the flag itself is added by that spec, so coordinate ordering), `risk/limits.py` (kill-switch armed/tripped state), `data/store.py` (`load_account_state`), `data/oanda_client.py` (account-summary read).
+- [[live-trading-gate]] (lands its settings fields **first** — preflight reads `live_trading_enabled` directly), `risk/limits.py` (`kill_switch_status` + the new `kill_switch_armed` helper this spec extracts — coordinator-serialized edit to the shipped file), `data/store.py` (`load_account_state`), `data/oanda_client.py` (`account_summary` read).
 
 ## Approach
 
-Build the pure `run_preflight` + report first (full offline tests with a seeded
-store + stub client), then the thin `fathom preflight` CLI command. Note: it reports
-`live_trading_enabled`, which [[live-trading-gate]] adds to settings — if drafted
-first, gate the report behind a `getattr` default or sequence after the flag lands.
+Build order (N-1, resolved): [[live-trading-gate]]'s settings fields land **first**,
+so this spec reads `live_trading_enabled`/`live_risk_fraction` **directly — no
+`getattr` hedge**. Add the `kill_switch_armed` helper to `risk/limits.py`
+(coordinator-serialized), then build the pure `run_preflight` + report (full offline
+tests with a seeded store + stub client), then the thin `fathom preflight` CLI
+command (the second Phase-5 `cli.py` edit, after the gate's — see N-2 in the
+taskgraph).
 
 ## Open questions
 
-- Exact check set — propose the five above; confirm whether "brackets/INV-04" is a
-  static contract assertion or a dry-run order construction (lean static).
-- Attestation marker — a CLI flag (`--attest-track-record`) for now vs a persisted
-  signed-off record. Propose the flag for Phase 5; a persisted marker later.
+- "brackets/INV-04" check — static contract assertion vs a dry-run order
+  construction. Lean **static** (assert the order/bracket contract can't yield a
+  naked order); confirm.
+
+**Resolved at cross-spec audit (2026-05-30):** B-3 — concrete `kill_switch_status`
+semantics + a defined 10-min staleness window + the `kill_switch_armed` extraction
+(no phantom "armed" API); N-1 — build order pinned, `getattr` hedge dropped.
+Attestation marker = the `--attest-track-record` CLI flag for Phase 5 (a persisted
+signed-off record later).
 
 ## Out of scope
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -95,6 +95,8 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 
 **Enforcement:** No `if env == 'live':` branches in logic code. Only `oanda_client.py` reads `env` to select the endpoint.
 
+**Enforcement (operator-boundary go-live gate — added Phase 5):** The single-code-path rule governs the **execution, risk, and monitoring mechanics** — `risk/sizing.py`, `execution/orders.py`, `execution/reconcile.py`, and the deviation monitor must contain **no** `env`-aware branches and must not read `settings.env`. The go-live **safety gate** is the one sanctioned exception: `execution/live_gate.py` (`assert_live_allowed`, `effective_risk_fraction`) and the `fathom execute`/`fathom preflight` wiring in `cli.py` may read `settings.env`, `settings.live_trading_enabled`, and `settings.live_risk_fraction` **solely to select the operator-boundary gate behaviour and the risk-fraction *input***. It must not alter the mechanics: the same `size_position`/`build_bracket`/`submit_order` code runs demo and live; only the injected `risk_fraction` value and the pre-submit gate differ. `oanda_client.py` remains the only reader of `env` for **endpoint** selection. A test asserts no `env`-aware branch exists in `risk/sizing.py`, `execution/orders.py`, `execution/reconcile.py`, or the monitor.
+
 ---
 
 ## INV-10 · Approved-Set Gate — No Signal Without Validation

--- a/docs/phases/phase-5-spec-audit-2026-05-30.md
+++ b/docs/phases/phase-5-spec-audit-2026-05-30.md
@@ -1,0 +1,67 @@
+# Fathom Phase 5 — Cross-Spec Audit (2026-05-30)
+
+Run per `runbook-cross-spec-audit` by a fresh, independent, read-only auditor (no
+prior context). This phase touches **real money** — any ambiguity that could let a
+live order slip through was treated as blocking. Fixes applied by the lead; each
+finding annotated with its resolution. Audit + fixes landed together in one PR.
+
+## Scope
+
+The 3 Phase 5 specs (`preflight-check`, `live-trading-gate`, `go-live-runbook`),
+cross-checked against `invariants.md` (INV-07/09/05/04/08), `phase-5.md`,
+`code-map.md`, `INDEX.md`, and the shipped contracts (`config/settings.py`,
+`risk/sizing.py`, `risk/limits.py`, `data/store.py`, `data/oanda_client.py`,
+`cli.py::cmd_execute`).
+
+## Summary
+
+12 shared concepts · 5 consistent · **5 blocking** · 4 non-blocking · 2
+invariant-promotion/clarification candidates. The four-gate design is sound; the
+blockers are spec-level (no architectural rework) but include **two live-order-leak
+holes** and an **unresolved INV-09 violation** — all fixed below.
+
+## Drift findings & resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| B-1 | blocking | `assert_live_allowed` default-refuse undefined for `preflight_report` that is `None`/malformed/`.go`-non-True, or when `run_preflight` raises mid-gate — "safe by accident" is not acceptable for real money | **Fixed** — `live-trading-gate` now pins: a `None`/non-`PreflightReport`/non-exactly-`True` `.go` is a **failed** preflight gate (raise); `cmd_execute` catches any `run_preflight` exception → refuse (never GO). Truth-table tests add `None`/exception rows. |
+| B-2 | blocking | `effective_risk_fraction` not actually threaded in — shipped `cmd_execute` (`cli.py:1528`) hard-codes `risk_fraction=DEFAULT_RISK_FRACTION`; a live trade would size at 0.25%, not the reduced 0.10% | **Fixed** — spec names the exact substitution `risk_fraction=effective_risk_fraction(settings)` at `cli.py:~1528` + an AC pinning demo receives `0.0025` and live receives `live_risk_fraction`. |
+| B-3 | blocking | preflight's "armed and not tripped" has no shipped counterpart — `kill_switch_status` only reports tripped/not; `load_account_state` has no staleness flag | **Fixed** — `preflight-check` pins concrete semantics: armed ≡ `account_state` present + `as_of` fresh (10-min window) + `KillSwitchStatus.active is False`; extract a reusable `kill_switch_armed(account_state, now, config)` into `risk/limits.py` (single-source, à la `book_risk_sum`). |
+| B-4 | blocking | the env-aware gate violates INV-09 as written ("no `if env=='live'` branches; only `oanda_client` reads env"); the phase deferred the decision instead of resolving it | **Fixed (P-1)** — **INV-09 amended** with an operator-boundary-gate enforcement clause: mechanics (`sizing`/`orders`/`reconcile`/monitor) stay env-free + single-path; the go-live gate (`live_gate.py` + cli wiring) is the one sanctioned `env`-reader for gate behaviour + the fraction *input*; a test asserts no env-branch in the mechanics. |
+| B-5 | blocking | the `0 < live_risk_fraction <= 0.0025` bound was prose-only; shipped `Settings` has no such validator — a `.env` typo (`0.025`) would load a 10× cap breach | **Fixed** — pinned `live_risk_fraction: float = Field(default=0.001, gt=0.0, le=0.0025)` (mirrors `LimitsConfig`; `le` references the cap so they can't drift) + a both-bounds `ValidationError` AC. |
+
+## Ambiguity findings & resolutions
+
+| ID | Finding | Resolution |
+|---|---|---|
+| N-1 | preflight↔settings ordering hand-wavy (`getattr` hedge) | **Fixed** — build order pinned: gate's settings fields land first; preflight reads them directly, no `getattr`. |
+| N-2 | two Phase-5 tasks edit `cli.py`; serialization not explicit | **Fixed** — `cli.py` serialized across exactly the two Phase-5 tasks: `fathom preflight` (preflight-check) then the `execute` gate (live-trading-gate); to be encoded in the taskgraph. |
+| N-3 | risk an implementer reuses the `--yes`-gated confirm for live | **Fixed** — the live typed-account-id confirm is a **distinct prompt, not `--yes`-gated**; the existing `[y/N]` confirm stays demo-only; AC: live `execute --yes` still requires the typed account id. |
+| N-4 | runbook ramp doesn't name the env key / validation | **Fixed** — names `LIVE_RISK_FRACTION` + notes the `Field(le=0.0025)` startup validation rejects a ramp typo above the cap. |
+
+## Invariant promotion / clarification
+
+- **P-1 → applied:** INV-09 amended (above, B-4) to sanction the operator-boundary
+  go-live gate while keeping the mechanics single-path + env-free, with a
+  no-env-branch-in-mechanics enforcement test.
+- **P-2 → applied as a code-structure decision:** extract `kill_switch_armed` into
+  `risk/limits.py` (single-source readiness read), referenced by `preflight-check`
+  (B-3). Not a new invariant.
+
+## Consistent (no action)
+
+Confirm token = `oanda_account_id` (shipped plain `str`, safe to echo, not an INV-08
+secret); `account_summary` reachability maps to the real `OandaClient.account_summary`;
+`size_position(risk_fraction=…)` kwarg exists + correctly named; demo-path-unchanged
+stated consistently across both code specs; INV-08 token-non-printing correct (only
+`oanda_api_token` is `SecretStr`).
+
+## Action plan — status
+
+All 5 blocking + 4 non-blocking findings **Fixed** in this PR; INV-09 amended; the
+`kill_switch_armed` extraction decided. Two coordinator-serialized shipped-file
+edits surfaced for the taskgraph: the `kill_switch_armed` extraction
+(`risk/limits.py`) and the `cli.py` two-task serialization (preflight command →
+execute gate). Nothing in this phase connects live (INV-07).
+
+**Verdict after fixes:** spec corpus coherent; **ready for taskgraph generation.**


### PR DESCRIPTION
## Summary

Ran `runbook-cross-spec-audit` over the 3 Phase 5 specs with a fresh, independent, read-only auditor (real-money phase — any live-order-leak ambiguity treated as **blocking**). **5 blocking, 4 non-blocking findings — all fixed.** Report: `docs/phases/phase-5-spec-audit-2026-05-30.md`.

### Blocking fixes
- **B-1 (leak hole):** `assert_live_allowed` default-refuse pinned for a `None`/malformed/non-`True`-`.go` preflight, and `cmd_execute` catches any `run_preflight` exception → refuse. "Safe by accident" isn't acceptable for real money.
- **B-2 (leak hole):** the reduced fraction wasn't actually threaded in — shipped `cmd_execute` (`cli.py:1528`) hard-codes `DEFAULT_RISK_FRACTION`, so live would size at 0.25%, not 0.10%. Spec now names the exact `effective_risk_fraction(settings)` substitution + a demo-identical AC.
- **B-3:** preflight's "armed" check had no shipped counterpart — pinned to real `kill_switch_status` semantics + a 10-min `account_state` staleness window + a `kill_switch_armed` extraction (single-source, à la `book_risk_sum`).
- **B-4:** **INV-09 amended** — the env-aware gate violated it as written; added an operator-boundary-gate clause (mechanics stay env-free/single-path; only `live_gate` + cli wiring read env; enforcement test asserts no env-branch in sizing/orders/reconcile/monitor).
- **B-5:** `live_risk_fraction` pinned to `Field(gt=0.0, le=0.0025)` — a `.env` typo (`0.025`) can no longer load a 10× cap breach.

### Non-blocking
N-1 build order (drop `getattr`), N-2 `cli.py` two-task serialization, N-3 live typed-confirm is separate + not `--yes`-bypassable, N-4 runbook names `LIVE_RISK_FRACTION` + the `le=0.25%` validation.

Specs → `ready`. Surfaced for the taskgraph: the `kill_switch_armed` extraction + the `cli.py` two-task serialization. **Nothing connects live (INV-07).**

**Verdict:** corpus coherent; ready for taskgraph generation. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)