### PR TITLE
P5-T-01: settings flags + kill_switch_armed extraction

### DIFF
--- a/.claude/context/infra.md
+++ b/.claude/context/infra.md
@@ -29,3 +29,31 @@
 - `mypy config/` → "Success: no issues found in 2 source files", exit 0
 
 **Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass)
+
+---
+
+## P5-T-01 — 2026-05-30 (feat/p5-T-01-settings)
+
+**What was done:**
+- `config/settings.py`: added two Phase 5 live-trading gate fields (additive, no existing behaviour changed):
+  - `live_trading_enabled: bool = False` — explicit opt-in required before any live order (INV-07, D-P5-2).
+  - `live_risk_fraction: float = Field(default=0.001, gt=0.0, le=0.0025)` — per-trade risk fraction for live orders; `le=0.0025` mirrors the INV-05 0.25% per-trade cap so the two cannot drift (B-5). A `Settings` constructed with `live_risk_fraction <= 0` or `> 0.0025` raises `pydantic.ValidationError` at load time.
+  - Added `Field` to the pydantic import. Pattern mirrors `LimitsConfig`'s `Field` constraints in `risk/limits.py`.
+- `.env.example`: added `LIVE_TRADING_ENABLED=false` and `LIVE_RISK_FRACTION=0.001` entries (required by the drift-guard test in `test_config.py`).
+- `risk/limits.py`: added `kill_switch_armed(account_state, now, *, config, staleness_minutes=10) -> tuple[bool, str]` (pure, exported in `__all__`). Single source of truth for kill-switch readiness used by the preflight check (P5-T-03). "Armed and healthy" = account_state present + `as_of` within `staleness_minutes` of `now` (UTC, INV-03) + `kill_switch_status().active is False`. Returns `(True, "")` or `(False, "missing" | "stale" | "tripped")`. Reuses `kill_switch_status` internally — no logic duplication.
+  - `as_of` is parsed from RFC 3339 UTC string via `fromisoformat(s.rstrip("Z")).replace(tzinfo=timezone.utc)` (codebase-standard pattern). The `dict[str, object]` values are cast with `# type: ignore[arg-type]` before `float()` (mypy cannot narrow from `object`; the value contract is documented).
+
+**Patterns established / confirmed:**
+- `Field(gt=0.0, le=0.0025)` in `Settings` validates at construction — same pattern as `LimitsConfig.daily_loss_cap` etc.
+- `kill_switch_armed` is the single-source readiness helper; never re-implement the tripped/staleness logic elsewhere — always call this.
+- Staleness window default is 10 min (D-P5-B). Callers can override via `staleness_minutes`.
+- RFC 3339 parsing: `datetime.fromisoformat(s.rstrip("Z")).replace(tzinfo=timezone.utc)` — matches `execution/reconcile.py` and `execution/orders.py` pattern.
+
+**AC verification results:**
+- `mypy .` (87 files) → "Success: no issues found", exit 0
+- `pytest -q` → 1058 passed (18 new), 87 pre-existing warnings, exit 0
+- `pytest tests/test_limits.py tests/test_config.py -v` → 54 passed, exit 0
+
+**New dependency added to pyproject.toml:** NO
+
+**Merge plan:** `gh pr merge 125 --squash --delete-branch`

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,12 @@ ENV=demo
 # Leave blank (or omit) for backtest-only runs that do not need Discord delivery.
 # INV-08: never commit the real URL — this is a placeholder only.
 DISCORD_WEBHOOK_URL=your-discord-webhook-url-here
+
+# Phase 5: live-trading gate (INV-05 / INV-07).
+# LIVE_TRADING_ENABLED must be explicitly set to true before live orders can proceed.
+# Default false — demo runs are unaffected by this flag.
+LIVE_TRADING_ENABLED=false
+
+# Per-trade risk fraction for live orders (must be > 0 and <= 0.0025, the INV-05 cap).
+# Default 0.001 (0.10%). Validated at startup; a value outside the range raises immediately.
+LIVE_RISK_FRACTION=0.001

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,7 +11,7 @@ Usage:
 
 from typing import Literal, Optional
 
-from pydantic import SecretStr, model_validator
+from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _BASE_URLS: dict[str, str] = {
@@ -48,6 +48,25 @@ class Settings(BaseSettings):
     oanda_account_id: str
     oanda_base_url: str = ""
     discord_webhook_url: Optional[SecretStr] = None
+
+    # --- Phase 5: live-trading gate fields (INV-05 / INV-07) ----------------
+    #: Enable live-order placement. Defaults to ``False`` — an explicit opt-in
+    #: is required before a live `fathom execute` can proceed (D-P5-2).
+    live_trading_enabled: bool = False
+
+    #: Per-trade risk fraction for live orders.  Validated ≤ 0.0025 (the
+    #: INV-05 per-trade cap) so a ``.env`` typo can never exceed the cap (B-5).
+    #: Default 0.001 (0.10%) — the reduced initial live size (D-P5-3).
+    live_risk_fraction: float = Field(
+        default=0.001,
+        gt=0.0,
+        le=0.0025,
+        description=(
+            "Per-trade risk fraction for live orders (default 0.001 = 0.10%). "
+            "Must be > 0 and ≤ 0.0025 (the INV-05 0.25% per-trade cap). "
+            "Validated at Settings construction so a .env typo raises immediately."
+        ),
+    )
 
     @model_validator(mode="after")
     def derive_base_url(self) -> "Settings":

--- a/risk/limits.py
+++ b/risk/limits.py
@@ -70,6 +70,7 @@ __all__ = [
     "book_risk_budget",
     "check_limits",
     "kill_switch_status",
+    "kill_switch_armed",
 ]
 
 # ---------------------------------------------------------------------------
@@ -479,3 +480,71 @@ def kill_switch_status(
         cap_amount=cap_amount,
         reset_at=_next_utc_midnight(now),
     )
+
+
+def kill_switch_armed(
+    account_state: "dict[str, object] | None",
+    now: datetime,
+    *,
+    config: LimitsConfig,
+    staleness_minutes: int = 10,
+) -> tuple[bool, str]:
+    """Report whether the kill switch is "armed and healthy" for preflight.
+
+    "Armed and healthy" means the account state is present, its ``as_of``
+    timestamp is within ``staleness_minutes`` of ``now`` (UTC, INV-03), **and**
+    the kill switch is not currently tripped (``KillSwitchStatus.active is
+    False``).  Any of these failing returns ``(False, reason)`` naming why.
+
+    This is the single source of truth for the kill-switch readiness used by
+    the preflight check (P5-T-03).  It reuses :func:`kill_switch_status`
+    internally so the tripped/not-tripped logic is never duplicated.
+
+    Args:
+        account_state: The dict returned by ``store.load_account_state()``
+            (keys: ``start_of_day_equity``, ``day_pl``, ``as_of``), or
+            ``None`` when reconciliation has never written a row.
+        now: UTC-aware current time (INV-03).  Never use ``datetime.now()``
+            without a timezone — pass ``datetime.now(timezone.utc)``.
+        config: Book-level limits config; the ``daily_loss_cap`` is used to
+            evaluate whether the switch is tripped.
+        staleness_minutes: Maximum age of ``account_state.as_of`` (in minutes)
+            before the state is considered stale and the function returns
+            ``(False, "stale")``.  Default 10 (D-P5-B).
+
+    Returns:
+        ``(True, "")`` iff all three conditions hold: present, fresh, not
+        tripped.  ``(False, reason)`` otherwise, where ``reason`` is one of
+        ``"missing"`` (no account_state row), ``"stale"`` (as_of too old), or
+        ``"tripped"`` (kill switch active).
+    """
+    if account_state is None:
+        return False, "missing"
+
+    # Parse as_of — stored as RFC 3339 UTC string (INV-03); handle "Z" suffix.
+    as_of_raw = str(account_state["as_of"])
+    as_of_str = as_of_raw.rstrip("Z") if as_of_raw.endswith("Z") else as_of_raw
+    as_of_dt = datetime.fromisoformat(as_of_str).replace(tzinfo=timezone.utc)
+
+    # Normalise now to UTC (guard against naive callers, per _next_utc_midnight).
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
+
+    age = now - as_of_dt
+    if age > timedelta(minutes=staleness_minutes):
+        return False, "stale"
+
+    day_pl_val: float = float(account_state["day_pl"])  # type: ignore[arg-type]
+    sod_equity_val: float = float(account_state["start_of_day_equity"])  # type: ignore[arg-type]
+    status = kill_switch_status(
+        day_pl=day_pl_val,
+        start_of_day_equity=sod_equity_val,
+        config=config,
+        now=now,
+    )
+    if status.active:
+        return False, "tripped"
+
+    return True, ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,13 @@
 Two responsibilities:
 1. Drift guard — assert that .env.example keys match the declared Settings fields.
 2. Validation guard — assert that Settings() raises a clear error when required fields are absent.
+3. Phase 5 live-trading gate fields — live_trading_enabled / live_risk_fraction defaults +
+   Field(gt=0.0, le=0.0025) boundary validation (INV-05).
 """
 
 import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -117,7 +120,6 @@ def test_oanda_base_url_derived_from_env(monkeypatch: pytest.MonkeyPatch) -> Non
 
     # Temporarily prevent loading from any .env file on disk.
     # We achieve this by pointing cwd at a directory with no .env.
-    import tempfile
     with tempfile.TemporaryDirectory() as tmpdir:
         monkeypatch.chdir(tmpdir)
 
@@ -131,3 +133,72 @@ def test_oanda_base_url_derived_from_env(monkeypatch: pytest.MonkeyPatch) -> Non
 
         live_settings = Settings(env="live")
         assert live_settings.oanda_base_url == "https://api-fxtrade.oanda.com"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Phase 5 live-trading gate fields (INV-05 / INV-07) P5-T-01
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTradingGateFields:
+    """live_trading_enabled + live_risk_fraction defaults + boundary validation."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject required fields and isolate from .env on disk."""
+        monkeypatch.setenv("OANDA_API_TOKEN", "test-token")
+        monkeypatch.setenv("OANDA_ACCOUNT_ID", "test-account")
+        monkeypatch.chdir(tempfile.mkdtemp())
+
+    def _make_settings(self, **kwargs: Any) -> Any:
+        from importlib import reload
+        import config.settings as settings_mod
+        reload(settings_mod)
+        return settings_mod.Settings(**kwargs)
+
+    def test_live_trading_enabled_default_false(self) -> None:
+        """live_trading_enabled must default to False (INV-07: demo first)."""
+        s = self._make_settings()
+        assert s.live_trading_enabled is False
+
+    def test_live_trading_enabled_can_be_set_true(self) -> None:
+        s = self._make_settings(live_trading_enabled=True)
+        assert s.live_trading_enabled is True
+
+    def test_live_risk_fraction_default(self) -> None:
+        """live_risk_fraction must default to 0.001 (0.10%, D-P5-3)."""
+        s = self._make_settings()
+        assert s.live_risk_fraction == pytest.approx(0.001)
+
+    def test_live_risk_fraction_upper_bound_exact(self) -> None:
+        """Exactly 0.0025 (the INV-05 cap) is allowed (le=0.0025)."""
+        s = self._make_settings(live_risk_fraction=0.0025)
+        assert s.live_risk_fraction == pytest.approx(0.0025)
+
+    def test_live_risk_fraction_above_cap_raises(self) -> None:
+        """Any value > 0.0025 must raise ValidationError at construction (INV-05, B-5)."""
+        with pytest.raises(ValidationError) as exc_info:
+            self._make_settings(live_risk_fraction=0.0026)
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("live_risk_fraction",) for e in errors), (
+            f"Expected ValidationError on live_risk_fraction field, got: {errors}"
+        )
+
+    def test_live_risk_fraction_zero_raises(self) -> None:
+        """live_risk_fraction=0.0 must raise ValidationError (gt=0.0)."""
+        with pytest.raises(ValidationError) as exc_info:
+            self._make_settings(live_risk_fraction=0.0)
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("live_risk_fraction",) for e in errors)
+
+    def test_live_risk_fraction_negative_raises(self) -> None:
+        """Negative live_risk_fraction must raise ValidationError (gt=0.0)."""
+        with pytest.raises(ValidationError) as exc_info:
+            self._make_settings(live_risk_fraction=-0.001)
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("live_risk_fraction",) for e in errors)
+
+    def test_live_risk_fraction_custom_within_bounds(self) -> None:
+        """A valid fraction within (0, 0.0025] is accepted."""
+        s = self._make_settings(live_risk_fraction=0.0015)
+        assert s.live_risk_fraction == pytest.approx(0.0015)

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -26,6 +26,7 @@ from risk.limits import (
     book_risk_budget,
     book_risk_sum,
     check_limits,
+    kill_switch_armed,
     kill_switch_status,
     position_risk,
 )
@@ -506,3 +507,124 @@ class TestPurity:
         _check(order, open_positions=positions, returns=returns)
         assert len(positions) == n_before
         assert set(returns.keys()) == keys_before
+
+
+# ---------------------------------------------------------------------------
+# kill_switch_armed — P5-T-01 (preflight readiness helper, B-3 semantics).
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitchArmed:
+    """kill_switch_armed(account_state, now, config=...) -> (bool, reason).
+
+    Armed + healthy ≡ present + fresh (within 10 min) + not tripped.
+    Each of the three failure modes returns (False, named_reason).
+    """
+
+    # RFC 3339 UTC timestamp 5 minutes before NOW — fresh.
+    _FRESH_AS_OF = "2026-05-29T11:55:00Z"
+    # 15 minutes before NOW — stale (> default 10-min window).
+    _STALE_AS_OF = "2026-05-29T11:45:00Z"
+
+    def _state(
+        self,
+        *,
+        as_of: str = _FRESH_AS_OF,
+        day_pl: float = 0.0,
+        start_of_day_equity: float = SOD_EQUITY,
+    ) -> dict[str, object]:
+        return {
+            "start_of_day_equity": start_of_day_equity,
+            "day_pl": day_pl,
+            "as_of": as_of,
+        }
+
+    def test_armed_when_present_fresh_not_tripped(self) -> None:
+        armed, reason = kill_switch_armed(
+            self._state(), NOW, config=LimitsConfig()
+        )
+        assert armed is True
+        assert reason == ""
+
+    def test_missing_returns_false_missing(self) -> None:
+        armed, reason = kill_switch_armed(None, NOW, config=LimitsConfig())
+        assert armed is False
+        assert reason == "missing"
+
+    def test_stale_returns_false_stale(self) -> None:
+        armed, reason = kill_switch_armed(
+            self._state(as_of=self._STALE_AS_OF), NOW, config=LimitsConfig()
+        )
+        assert armed is False
+        assert reason == "stale"
+
+    def test_exactly_at_staleness_boundary_is_not_stale(self) -> None:
+        # Exactly 10 minutes old: age == timedelta(minutes=10) — NOT stale
+        # (boundary is >, not >=).
+        exactly_10_ago = "2026-05-29T11:50:00Z"
+        armed, reason = kill_switch_armed(
+            self._state(as_of=exactly_10_ago), NOW, config=LimitsConfig()
+        )
+        assert armed is True
+        assert reason == ""
+
+    def test_one_second_over_staleness_is_stale(self) -> None:
+        one_sec_over = "2026-05-29T11:49:59Z"
+        armed, reason = kill_switch_armed(
+            self._state(as_of=one_sec_over), NOW, config=LimitsConfig()
+        )
+        assert armed is False
+        assert reason == "stale"
+
+    def test_tripped_returns_false_tripped(self) -> None:
+        # day_pl at/below the cap trips the switch.
+        armed, reason = kill_switch_armed(
+            self._state(day_pl=-SOD_EQUITY * LimitsConfig().daily_loss_cap),
+            NOW,
+            config=LimitsConfig(),
+        )
+        assert armed is False
+        assert reason == "tripped"
+
+    def test_over_cap_also_tripped(self) -> None:
+        armed, reason = kill_switch_armed(
+            self._state(day_pl=-5000.0), NOW, config=LimitsConfig()
+        )
+        assert armed is False
+        assert reason == "tripped"
+
+    def test_custom_staleness_minutes_respected(self) -> None:
+        # 5 minutes old is fresh with default window=10 but stale with window=4.
+        five_min_ago = "2026-05-29T11:55:00Z"
+        armed_default, _ = kill_switch_armed(
+            self._state(as_of=five_min_ago), NOW, config=LimitsConfig(),
+            staleness_minutes=10,
+        )
+        armed_short, reason_short = kill_switch_armed(
+            self._state(as_of=five_min_ago), NOW, config=LimitsConfig(),
+            staleness_minutes=4,
+        )
+        assert armed_default is True
+        assert armed_short is False
+        assert reason_short == "stale"
+
+    def test_pure_identical_inputs_identical_result(self) -> None:
+        state = self._state()
+        r1 = kill_switch_armed(state, NOW, config=LimitsConfig())
+        r2 = kill_switch_armed(state, NOW, config=LimitsConfig())
+        assert r1 == r2
+
+    def test_reuses_kill_switch_status_logic_for_tripped(self) -> None:
+        """kill_switch_armed's tripped decision must agree with kill_switch_status."""
+        day_pl = -1500.0
+        state = self._state(day_pl=day_pl)
+        armed, reason = kill_switch_armed(state, NOW, config=LimitsConfig())
+        status = kill_switch_status(
+            day_pl=day_pl,
+            start_of_day_equity=SOD_EQUITY,
+            config=LimitsConfig(),
+            now=NOW,
+        )
+        assert armed is not status.active  # if tripped → not armed
+        assert reason == "tripped"
+        assert status.active is True


### PR DESCRIPTION
## Summary

- Additive-only edits to `config/settings.py` and `risk/limits.py`; no change to existing `Settings`, `kill_switch_status`, or `check_limits` behaviour.
- `config/settings.py`: adds `live_trading_enabled: bool = False` and `live_risk_fraction: float = Field(default=0.001, gt=0.0, le=0.0025)`. The `Field(le=0.0025)` bound enforces the INV-05 0.25% per-trade cap at Settings construction time — a `.env` typo (`> 0.0025` or `<= 0`) raises `ValidationError` immediately (B-5).
- `risk/limits.py`: adds pure `kill_switch_armed(account_state, now, *, config, staleness_minutes=10) -> tuple[bool, str]` — returns `(True, "")` only when `account_state` is present, `as_of` is within the staleness window, and `kill_switch_status(...).active is False`; returns `(False, "missing" | "stale" | "tripped")` otherwise. Reuses `kill_switch_status` internally (single-source of truth). Exported in `__all__`.
- Tests: new `TestLiveTradingGateFields` class in `tests/test_config.py` (default, upper-bound-exact, above-cap, zero, negative, custom); new `TestKillSwitchArmed` class in `tests/test_limits.py` (armed/missing/stale/boundary/tripped/custom-window/pure/consistency with `kill_switch_status`).

## Verification

- `mypy .` 0 errors (87 files checked)
- `pytest -q` 1058 passed (all existing + 18 new tests; 87 pre-existing warnings only)
- Existing settings tests (`test_config.py`) and Phase 3 limits tests (`test_limits.py`) pass unchanged

## Constraints

- Touches only `config/settings.py`, `risk/limits.py`, `tests/test_config.py`, `tests/test_limits.py`, `.env.example`
- Nothing live: no live token, no live connection (INV-07)
- INV-09 preserved: `risk/limits.py` mechanics are unchanged; `kill_switch_armed` is a pure read-only helper
- INV-08: no secrets logged or committed

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)