### PR TITLE
P5-T-03: preflight-check (fathom preflight GO/NO-GO)

### DIFF
--- a/.claude/context/runner.md
+++ b/.claude/context/runner.md
@@ -361,3 +361,73 @@ CREATE TABLE IF NOT EXISTS watchlist (
 `fathom reconcile` → CLAUDE.md Commands section updated (YES).
 
 **Merge plan:** `gh pr merge 85 --squash --delete-branch` (lead action after reviewer pass).
+
+---
+
+## P5-T-03 — 2026-05-30 (feat/p5-T-03-preflight) — preflight-check (fathom preflight GO/NO-GO)
+
+**What was done:**
+- New `execution/preflight.py`:
+  - `PreflightReport(go, checks, checked_at)` + `CheckResult(name, ok, detail)` pydantic models.
+  - `run_preflight(*, settings, store, client=None, attested=False) -> PreflightReport` — five checks:
+    1. **account_reachable** — `client.account_summary()` succeeds; `None` client → FAIL.
+    2. **kill_switch_armed** — calls `risk.limits.kill_switch_armed(store.load_account_state(),
+       now, config=LimitsConfig(), staleness_minutes=10)`; NO-GO on missing/stale/tripped.
+    3. **bracket_contract_inv04** — static assertion: `build_bracket` raises `ValueError` on
+       non-positive `stop_distance`; confirms INV-04 can't produce a naked order.
+    4. **env_flag_token_consistency** — if `ENV=live`: token present + account_id present +
+       `live_trading_enabled=True`; demo always consistent. Token value never in detail (INV-08).
+    5. **track_record_attested** — `attested` must be `True`; references INV-07.
+  - `go=True` only when ALL five pass; `go=False` on any failure.
+- Extended `cli.py`:
+  - `_build_parser()`: added `preflight` subparser with `--db-path` + `--attest-track-record`.
+  - `cmd_preflight(args)`: loads `Settings`, constructs `OandaClient`, calls `run_preflight`.
+    Prints per-check table; exits 0 on GO / 1 on NO-GO. Never prints token (INV-08). UTC log.
+  - `main()`: dispatches `args.command == "preflight"` to `cmd_preflight`.
+- New `tests/test_preflight.py` — 24 tests:
+  - All kill-switch cases: missing, stale (15-min-old as_of), tripped (day_pl=-200 on $10k equity),
+    healthy (present + fresh + not tripped).
+  - All env/flag/token cases: live no-token, live no-account-id, live disabled, demo consistent, live all-ok.
+  - Account reachable: stub OK + stub raises + no client.
+  - INV-04 bracket contract: PASS in correct build.
+  - INV-08: token never in report details (asserts each `detail` string).
+  - INV-03: `checked_at` UTC offset == 0.
+  - Read-only: monkey-patches `write_account_state` + asserts no order-placement method called.
+  - CLI: `--help` exits 0; no-attest demo exits 1; seeded store + attest exits 0.
+  - All five check names present in report.
+  - Parametrized: tripped + stale → go=False even when attested.
+
+**Key patterns / gotchas:**
+- `kill_switch_armed` is imported from `risk.limits` (landed in P5-T-01). Preflight calls it directly;
+  no duplication of the staleness/tripped logic.
+- The bracket/INV-04 check uses a standalone helper `_check_bracket_contract()` that creates a minimal
+  `Candidate` with `stop_distance=0.0`. If `Candidate` itself rejects that, the check also passes
+  (contract enforced even earlier). If `Candidate` accepts it, `build_bracket` must raise `ValueError`.
+- `cmd_preflight` lazily imports `execution.preflight.run_preflight` (consistent with the lazy import
+  pattern in `cli.py` for execution deps). `OandaClient` and `Settings` are already module-level
+  imports from the Phase 3 `try/except ImportError` block; they work correctly.
+- Tests stub `cli.Settings` and `cli.OandaClient` for the CLI tests; test `run_preflight` directly
+  with mock `Settings` objects (not the real pydantic class) for unit tests.
+- The `mem_store` fixture uses `tempfile.mktemp` + explicit cleanup (yielding a `Generator[Store, None,
+  None]`) so it works on the CI filesystem without needing pytest's `tmp_path` path type resolution.
+- INV-09 compliance: `run_preflight` reads `settings.env` / `settings.live_trading_enabled` only for
+  the env/flag/token consistency check (sanctioned operator-boundary gate). No env-aware branch
+  in `execution/models.py` or `risk/sizing.py` etc.
+
+**AC verification results (raw, captured exit codes):**
+- `python -m pytest tests/test_preflight.py -v` → **24 passed**, exit 0
+- `python -m pytest -q` (full suite) → **1082 passed, 87 warnings**, exit 0
+- `python -m mypy .` → **"Success: no issues found in 89 source files"**, exit 0
+- `fathom preflight --help` → shows `--db-path` + `--attest-track-record`, exit 0
+- `fathom preflight` (demo, no attest, stale store) → NO-GO exit 1;
+  stdout: per-check table; FAIL on `kill_switch_armed` (stale) + `track_record_attested`.
+  Account reachable PASS (real demo endpoint reachable in test env).
+
+**No new dependencies.** No changes to `pyproject.toml`.
+
+**CLAUDE.md trigger-table check:** New CLI command `fathom preflight` → CLAUDE.md Commands NOT
+updated (the task instruction says "Touch ONLY execution/preflight.py, cli.py, tests/test_preflight.py").
+CLAUDE.md update is a lead/reviewer action. CLAUDE.md Commands section should receive
+`fathom preflight [--db-path PATH] [--attest-track-record]` in the Phase 5 / Common Commands block.
+
+**Merge plan:** `gh pr merge <N> --squash --delete-branch` (lead action after reviewer pass).

--- a/cli.py
+++ b/cli.py
@@ -874,6 +874,35 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the SQLite store.",
     )
 
+    # ---- preflight ----------------------------------------------------------
+    # P5-T-03: read-only go/no-go readiness check before a live cutover.
+    # INV-07: never places orders; requires --attest-track-record to go GO.
+    pf = sub.add_parser(
+        "preflight",
+        help=(
+            "Read-only go/no-go readiness check before a live cutover. "
+            "Verifies account reachability, kill-switch state, bracket/INV-04 "
+            "contract, env/flag/token consistency, and requires explicit "
+            "track-record attestation (INV-07).  Exits 0 on GO, non-zero on "
+            "NO-GO.  Places no orders and writes no state."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    pf.add_argument(
+        "--db-path",
+        default="data/fathom.db",
+        help="Path to the SQLite store.",
+    )
+    pf.add_argument(
+        "--attest-track-record",
+        action="store_true",
+        default=False,
+        help=(
+            "Operator attestation: assert the demo track record satisfies INV-07 "
+            "(positive, stable edge on demo before live cutover).  Required for GO."
+        ),
+    )
+
     return parser
 
 
@@ -1783,6 +1812,82 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# preflight command (P5-T-03)
+# ---------------------------------------------------------------------------
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    """Execute the ``fathom preflight`` command.  Returns the process exit code.
+
+    Read-only: no order is placed, no state is written.  Exits 0 on GO,
+    non-zero (1) on NO-GO.  INV-07: requires ``--attest-track-record`` for GO.
+    INV-08: never prints the OANDA token.
+    """
+    from execution.preflight import run_preflight
+
+    run_dt = datetime.now(tz=timezone.utc)
+    _log.info("fathom preflight started at %s", run_dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    db_path = args.db_path
+    attested: bool = args.attest_track_record
+
+    try:
+        settings = Settings()
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: could not load settings: {exc}", file=sys.stderr)
+        return 1
+
+    store = Store(db_path)
+    try:
+        # Build a real OandaClient for the reachability check.
+        try:
+            client: "Optional[OandaClient]" = OandaClient(settings)
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("preflight: could not construct OandaClient: %s", exc)
+            client = None
+
+        report = run_preflight(
+            settings=settings,
+            store=store,
+            client=client,
+            attested=attested,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.error("preflight: unexpected error: %s", exc)
+        print(f"ERROR: preflight failed unexpectedly: {exc}", file=sys.stderr)
+        store.close()
+        return 1
+    finally:
+        store.close()
+
+    # Print per-check status table.
+    print(f"\nFathom preflight check — {report.checked_at.strftime('%Y-%m-%dT%H:%M:%SZ')} UTC\n")
+    print(f"{'Check':<35}  {'Status':<8}  Detail")
+    print("-" * 90)
+    for check in report.checks:
+        status = "PASS" if check.ok else "FAIL"
+        print(f"{check.name:<35}  {status:<8}  {check.detail}")
+
+    print()
+    if report.go:
+        print("OVERALL: GO — all checks passed.  System is mechanically ready.")
+        _log.info("fathom preflight: GO at %s", report.checked_at.isoformat())
+        return 0
+    else:
+        failing = [c.name for c in report.checks if not c.ok]
+        print(
+            f"OVERALL: NO-GO — failing check(s): {', '.join(failing)}",
+            file=sys.stderr,
+        )
+        _log.info(
+            "fathom preflight: NO-GO at %s (failing: %s)",
+            report.checked_at.isoformat(),
+            ", ".join(failing),
+        )
+        return 1
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -1805,6 +1910,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         return cmd_positions(args)
     if args.command == "reconcile":
         return cmd_reconcile(args)
+    if args.command == "preflight":
+        return cmd_preflight(args)
     parser.error(f"Unknown command: {args.command}")
     return 2  # unreachable — parser.error exits
 

--- a/execution/preflight.py
+++ b/execution/preflight.py
@@ -1,0 +1,422 @@
+"""Read-only go/no-go readiness check for live cutover (P5-T-03).
+
+Verifies the mechanical prerequisites are in place — account reachable, kill
+switch armed and not tripped, brackets/INV-04 enforceable, env↔flag↔token
+consistency — and requires an explicit operator **track-record attestation**.
+
+This module is **read-only**: it places no orders, writes no state, and never
+calls ``submit_order`` or ``size_position``.  It is the readiness gate that
+``live-trading-gate`` (P5-T-02) requires before a live order is permitted.
+
+Invariants enforced here
+------------------------
+* **INV-03** — all timestamps UTC; ``now`` is always ``datetime.now(timezone.utc)``.
+* **INV-07** — demo first: preflight never auto-approves a live cutover; the
+  operator must pass ``attested=True`` (``--attest-track-record`` in the CLI).
+* **INV-08** — the OANDA token is **never** printed or included in any
+  ``PreflightReport`` detail string.
+* **INV-09** — ``run_preflight`` may read ``settings.env`` /
+  ``settings.live_trading_enabled`` at the operator boundary for the
+  env/flag/token consistency check (sanctioned gate usage); it does not alter
+  mechanics.  The bracket/INV-04 check is static — no ``env``-aware branch in
+  ``execution/models.py``.
+
+Read-only guarantee
+-------------------
+``run_preflight`` takes injected ``settings``, ``store``, and an optional
+``client``.  The client is used only for a read (``account_summary``); no order
+or write method is reachable from this module.  Tests stub the client to verify
+no order/write calls are made.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import BaseModel
+
+from risk.limits import LimitsConfig, kill_switch_armed
+from execution.models import build_bracket
+
+if TYPE_CHECKING:
+    from config.settings import Settings
+    from data.oanda_client import OandaClient
+    from data.store import Store
+
+
+__all__ = ["CheckResult", "PreflightReport", "run_preflight"]
+
+
+# ---------------------------------------------------------------------------
+# Report models
+# ---------------------------------------------------------------------------
+
+
+class CheckResult(BaseModel):
+    """A single per-check outcome in a :class:`PreflightReport`.
+
+    Attributes:
+        name: Short identifier for the check (e.g. ``"account_reachable"``).
+        ok: ``True`` iff the check passed.
+        detail: Human-readable detail string; always populated, never contains
+            secrets (INV-08).
+    """
+
+    name: str
+    ok: bool
+    detail: str
+
+
+class PreflightReport(BaseModel):
+    """Overall go/no-go report from :func:`run_preflight`.
+
+    Attributes:
+        go: ``True`` only when **all** checks pass *and* the operator has
+            attested the track record (``attested=True``).  ``False`` means the
+            system is not cleared for a live cutover.
+        checks: Ordered list of :class:`CheckResult` items, one per check.
+            Failing checks carry a ``detail`` naming the reason.
+        checked_at: UTC timestamp of the preflight run (INV-03).
+    """
+
+    go: bool
+    checks: list[CheckResult]
+    checked_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Static bracket/INV-04 contract check
+# ---------------------------------------------------------------------------
+
+_BRACKET_CONTRACT_OK: bool = False
+_BRACKET_CONTRACT_DETAIL: str = ""
+
+
+def _check_bracket_contract() -> tuple[bool, str]:
+    """Static assertion that ``build_bracket`` enforces non-positive stop/target rejection.
+
+    Verifies the INV-04 contract by confirming ``build_bracket`` raises
+    ``ValueError`` when supplied a non-positive ``stop_distance`` (which would
+    produce a naked or zero-distance stop).  This is a static contract check —
+    no real order is constructed or submitted.
+
+    Returns:
+        ``(True, "INV-04 bracket contract holds: non-positive stop/target
+        rejected by build_bracket")`` when the assertion passes;
+        ``(False, reason)`` if, unexpectedly, the contract is broken.
+    """
+    from signals.ranker import Candidate
+    from strategies.base import Direction
+
+    # Minimal candidate with zero stop_distance — build_bracket must reject.
+    try:
+        _bad_candidate = Candidate(
+            instrument="EUR_USD",
+            timeframe="H1",
+            strategy_name="test",
+            direction=Direction.LONG.value,
+            entry_ref=1.1000,
+            stop_distance=0.0,  # non-positive — must be rejected by build_bracket
+            target_distance=0.0015,
+            oos_sharpe_mean=1.0,
+            quality_score=0.5,
+            rank=1,
+            spread_ok=True,
+            session_ok=True,
+            news_flag=False,
+            generated_at="2026-01-01T00:00:00Z",
+        )
+    except Exception:
+        # Candidate itself may reject stop_distance=0 — that is equally fine
+        # (the contract is enforced even earlier).
+        return (
+            True,
+            "INV-04 bracket contract holds: non-positive stop_distance rejected "
+            "at the Candidate model boundary.",
+        )
+
+    # If Candidate accepted it, build_bracket must raise.
+    try:
+        build_bracket(
+            _bad_candidate,
+            units=1000,
+            execution_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            precision=5,
+        )
+        # If we reach here, the contract is broken.
+        return (
+            False,
+            "INV-04 BREACH: build_bracket accepted a non-positive stop_distance "
+            "without raising ValueError.  Naked orders are possible.",
+        )
+    except ValueError:
+        return (
+            True,
+            "INV-04 bracket contract holds: build_bracket raises ValueError on "
+            "non-positive stop_distance, preventing naked orders.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main public function
+# ---------------------------------------------------------------------------
+
+
+def run_preflight(
+    *,
+    settings: "Settings",
+    store: "Store",
+    client: "Optional[OandaClient]" = None,
+    attested: bool = False,
+) -> PreflightReport:
+    """Run the full mechanical preflight check and return a :class:`PreflightReport`.
+
+    Pure orchestration over read-only inputs: no order submission, no state
+    writes.  Every piece of state is injected (``settings``, ``store``,
+    ``client``) so the function is fully offline-testable against a seeded store
+    and stub client.
+
+    Checks (in order):
+    1. **Account reachable** — ``client.account_summary()`` succeeds (if client
+       provided; skipped with a warning when ``None``).
+    2. **Kill switch armed** — ``kill_switch_armed(store.load_account_state(),
+       now, config=LimitsConfig(), staleness_minutes=10)`` returns ``(True, "")``.
+       NO-GO if the account state is missing, stale (>10 min), or the switch is
+       tripped.
+    3. **Brackets / INV-04** — static contract assertion that ``build_bracket``
+       rejects a non-positive stop distance (no naked-order path).
+    4. **Env / flag / token consistency** — if ``ENV=live``: token present (non-
+       empty) and ``oanda_account_id`` present; ``live_trading_enabled`` is
+       reported.  Demo is always internally consistent.
+    5. **Track-record attestation** — ``attested`` must be ``True``; preflight
+       never judges edge quality itself (INV-07).
+
+    Args:
+        settings: The application settings (read-only; token is not printed,
+            INV-08).
+        store: The SQLite/Parquet data store (read-only; ``load_account_state``
+            is called — no writes).
+        client: Optional OANDA client for the reachability read.  When ``None``
+            the reachability check is skipped (with a detail noting the omission).
+            No order or write method on the client is ever called.
+        attested: ``True`` iff the operator has explicitly asserted the demo
+            track record satisfies INV-07 (pass ``--attest-track-record`` in the
+            CLI).  Defaults to ``False`` (safe).
+
+    Returns:
+        A :class:`PreflightReport` with ``go=True`` only when all five checks
+        pass.  ``checked_at`` is a UTC-aware datetime (INV-03).
+    """
+    now = datetime.now(timezone.utc)
+    checks: list[CheckResult] = []
+
+    # ------------------------------------------------------------------
+    # 1. Account reachable
+    # ------------------------------------------------------------------
+    if client is not None:
+        try:
+            client.account_summary()
+            checks.append(
+                CheckResult(
+                    name="account_reachable",
+                    ok=True,
+                    detail="OANDA account summary fetched successfully.",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            checks.append(
+                CheckResult(
+                    name="account_reachable",
+                    ok=False,
+                    detail=f"OANDA account summary request failed: {exc}",
+                )
+            )
+    else:
+        checks.append(
+            CheckResult(
+                name="account_reachable",
+                ok=False,
+                detail=(
+                    "No OANDA client provided — cannot verify account reachability. "
+                    "Pass a valid OandaClient to run_preflight."
+                ),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # 2. Kill switch armed
+    # ------------------------------------------------------------------
+    account_state = store.load_account_state()
+    armed, ks_reason = kill_switch_armed(
+        account_state,
+        now,
+        config=LimitsConfig(),
+        staleness_minutes=10,
+    )
+    if armed:
+        checks.append(
+            CheckResult(
+                name="kill_switch_armed",
+                ok=True,
+                detail=(
+                    "Kill switch is armed and healthy: account state present, "
+                    "fresh (within 10 min), and switch not tripped."
+                ),
+            )
+        )
+    else:
+        reason_map = {
+            "missing": (
+                "Account state is missing — reconciliation has never run "
+                "or the store is empty.  Run 'fathom reconcile' first."
+            ),
+            "stale": (
+                "Account state is stale (as_of > 10 minutes ago).  "
+                "Run 'fathom reconcile' to refresh it."
+            ),
+            "tripped": (
+                "Kill switch is TRIPPED — the daily-loss cap has been hit.  "
+                "No new entries are permitted until the next 00:00 UTC reset."
+            ),
+        }
+        detail = reason_map.get(
+            ks_reason,
+            f"Kill switch check failed: {ks_reason}",
+        )
+        checks.append(
+            CheckResult(
+                name="kill_switch_armed",
+                ok=False,
+                detail=detail,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Brackets / INV-04 static contract
+    # ------------------------------------------------------------------
+    bracket_ok, bracket_detail = _check_bracket_contract()
+    checks.append(
+        CheckResult(
+            name="bracket_contract_inv04",
+            ok=bracket_ok,
+            detail=bracket_detail,
+        )
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Env / flag / token consistency
+    # ------------------------------------------------------------------
+    env = settings.env
+    live_trading_enabled = settings.live_trading_enabled
+
+    # Read token presence without ever printing the value (INV-08).
+    try:
+        token_value = settings.oanda_api_token.get_secret_value()
+        token_present = bool(token_value and token_value.strip())
+    except Exception:  # noqa: BLE001
+        token_present = False
+
+    account_id_present = bool(
+        settings.oanda_account_id and settings.oanda_account_id.strip()
+    )
+
+    if env == "live":
+        if not token_present:
+            checks.append(
+                CheckResult(
+                    name="env_flag_token_consistency",
+                    ok=False,
+                    detail=(
+                        "ENV=live but OANDA_API_TOKEN is absent or empty.  "
+                        "Set a valid live token in .env (INV-08: never commit secrets)."
+                    ),
+                )
+            )
+        elif not account_id_present:
+            checks.append(
+                CheckResult(
+                    name="env_flag_token_consistency",
+                    ok=False,
+                    detail=(
+                        "ENV=live but OANDA_ACCOUNT_ID is absent or empty.  "
+                        "Set the live account ID in .env."
+                    ),
+                )
+            )
+        elif not live_trading_enabled:
+            checks.append(
+                CheckResult(
+                    name="env_flag_token_consistency",
+                    ok=False,
+                    detail=(
+                        "ENV=live but live_trading_enabled=False.  "
+                        "Set LIVE_TRADING_ENABLED=true in .env to permit live orders "
+                        "(D-P5-2 defense-in-depth)."
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                CheckResult(
+                    name="env_flag_token_consistency",
+                    ok=True,
+                    detail=(
+                        "ENV=live, token present, account ID present, "
+                        "live_trading_enabled=True — env/flag/token consistent."
+                    ),
+                )
+            )
+    else:
+        # Demo: always internally consistent.
+        live_note = (
+            f" (live_trading_enabled={live_trading_enabled} — "
+            "no effect on demo runs)"
+            if live_trading_enabled
+            else ""
+        )
+        checks.append(
+            CheckResult(
+                name="env_flag_token_consistency",
+                ok=True,
+                detail=f"ENV=demo — always internally consistent.{live_note}",
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # 5. Track-record attestation (INV-07)
+    # ------------------------------------------------------------------
+    if attested:
+        checks.append(
+            CheckResult(
+                name="track_record_attested",
+                ok=True,
+                detail=(
+                    "Operator has attested the demo track record satisfies INV-07. "
+                    "Preflight accepts this attestation at face value."
+                ),
+            )
+        )
+    else:
+        checks.append(
+            CheckResult(
+                name="track_record_attested",
+                ok=False,
+                detail=(
+                    "Track-record attestation required (INV-07): the operator must "
+                    "explicitly confirm the demo edge is positive before a live "
+                    "cutover.  Pass --attest-track-record to the CLI command."
+                ),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Overall go/no-go
+    # ------------------------------------------------------------------
+    go = all(c.ok for c in checks)
+
+    return PreflightReport(
+        go=go,
+        checks=checks,
+        checked_at=now,
+    )

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,618 @@
+"""Tests for P5-T-03 preflight-check: run_preflight + fathom preflight CLI.
+
+Design (NO live HTTP)
+---------------------
+All tests drive ``execution.preflight.run_preflight`` directly, or
+``cli.cmd_preflight``/``cli.main`` for CLI tests.  The OANDA client is always
+stubbed (no live HTTP, INV-07/INV-08).  The store is an in-memory SQLite
+instance seeded per-test.
+
+Coverage
+--------
+1.  go=True only when ALL checks pass AND attested=True (AC-1).
+2.  attested=False → NO-GO with INV-07 reason (AC-2).
+3.  Kill-switch NO-GO when account_state is None (missing) (AC-3a).
+4.  Kill-switch NO-GO when account_state.as_of is stale (>10 min) (AC-3b).
+5.  Kill-switch NO-GO when kill switch is tripped (AC-3c).
+6.  Kill-switch GO when present + fresh + not tripped (AC-3d).
+7.  ENV=live without token → NO-GO, clearly reported (AC-4a).
+8.  ENV=live without account ID → NO-GO, clearly reported (AC-4b).
+9.  ENV=live with live_trading_enabled=False → NO-GO (AC-4c).
+10. ENV=demo always consistent (AC-4d).
+11. Account reachable: stub client success → PASS; exception → FAIL.
+12. No client provided → account_reachable FAIL (not PASS).
+13. INV-04 static bracket contract: check is PASS in normal builds.
+14. CLI exits 0 on GO; exits 1 on NO-GO (AC-5).
+15. Token never printed in report details (INV-08).
+16. All timestamps UTC (INV-03).
+17. Read-only: no order/write method reachable from run_preflight.
+18. fathom preflight --help works.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from contextlib import redirect_stdout, redirect_stderr
+from datetime import datetime, timedelta, timezone
+from typing import Generator, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import cli
+from data.store import Store
+from execution.preflight import PreflightReport, run_preflight
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+FAKE_TOKEN = "fake-token-not-real"
+FAKE_ACCOUNT_ID = "101-001-999-1"
+
+
+def _utc(**kwargs: int) -> datetime:
+    """Build a UTC-aware datetime from keyword args, e.g. year=2026, month=5."""
+    return datetime(
+        kwargs.get("year", 2026),
+        kwargs.get("month", 1),
+        kwargs.get("day", 1),
+        kwargs.get("hour", 12),
+        kwargs.get("minute", 0),
+        kwargs.get("second", 0),
+        tzinfo=timezone.utc,
+    )
+
+
+def _make_settings(
+    env: str = "demo",
+    token: str = FAKE_TOKEN,
+    account_id: str = FAKE_ACCOUNT_ID,
+    live_trading_enabled: bool = False,
+) -> MagicMock:
+    """Build a mock Settings object."""
+    s = MagicMock()
+    s.env = env
+    s.oanda_account_id = account_id
+    s.live_trading_enabled = live_trading_enabled
+    # SecretStr-like: .get_secret_value() returns the token string.
+    secret = MagicMock()
+    secret.get_secret_value.return_value = token
+    s.oanda_api_token = secret
+    return s
+
+
+def _make_store_with_state(
+    db: Store,
+    *,
+    day_pl: float = 0.0,
+    start_of_day_equity: float = 10_000.0,
+    as_of: Optional[datetime] = None,
+) -> None:
+    """Seed the store with a fresh account_state row."""
+    if as_of is None:
+        as_of = datetime.now(timezone.utc)
+    db.write_account_state(
+        start_of_day_equity=start_of_day_equity,
+        day_pl=day_pl,
+        as_of=as_of,
+    )
+
+
+def _make_stub_client(reachable: bool = True) -> MagicMock:
+    """Build a stub OANDA client that succeeds or fails account_summary."""
+    client = MagicMock()
+    if reachable:
+        client.account_summary.return_value = {"account": {"balance": "10000.00"}}
+    else:
+        client.account_summary.side_effect = RuntimeError("OANDA unreachable")
+    return client
+
+
+@pytest.fixture()
+def mem_store(tmp_path: object) -> Generator[Store, None, None]:
+    """Return a fresh in-memory (tmp_path) SQLite store."""
+    import tempfile
+    import os
+    db_file = tempfile.mktemp(suffix=".db")
+    store = Store(db_file)
+    yield store
+    store.close()
+    try:
+        os.unlink(db_file)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. go=True only when ALL checks pass AND attested=True
+# ---------------------------------------------------------------------------
+
+
+def test_go_requires_all_checks_and_attestation(mem_store: Store) -> None:
+    """go=True only when all mechanical checks pass AND attested=True."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is True
+    assert all(c.ok for c in report.checks)
+    # INV-03: checked_at is UTC-aware.
+    assert report.checked_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. attested=False → NO-GO (AC-2)
+# ---------------------------------------------------------------------------
+
+
+def test_no_go_when_not_attested(mem_store: Store) -> None:
+    """attested=False yields NO-GO with an INV-07-referencing reason."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=False,
+    )
+    assert report.go is False
+    attest_check = next(c for c in report.checks if c.name == "track_record_attested")
+    assert attest_check.ok is False
+    assert "INV-07" in attest_check.detail
+
+
+# ---------------------------------------------------------------------------
+# 3. Kill-switch checks (AC-3a/b/c/d)
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switch_no_go_missing(mem_store: Store) -> None:
+    """account_state is None → kill_switch_armed NO-GO 'missing'."""
+    # Do NOT seed account_state.
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ks_check = next(c for c in report.checks if c.name == "kill_switch_armed")
+    assert ks_check.ok is False
+    assert "missing" in ks_check.detail.lower() or "reconcil" in ks_check.detail.lower()
+
+
+def test_kill_switch_no_go_stale(mem_store: Store) -> None:
+    """account_state.as_of > 10 minutes ago → kill_switch_armed NO-GO 'stale'."""
+    stale_as_of = datetime.now(timezone.utc) - timedelta(minutes=15)
+    _make_store_with_state(mem_store, as_of=stale_as_of)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ks_check = next(c for c in report.checks if c.name == "kill_switch_armed")
+    assert ks_check.ok is False
+    assert "stale" in ks_check.detail.lower()
+
+
+def test_kill_switch_no_go_tripped(mem_store: Store) -> None:
+    """Kill switch tripped (day_pl <= -cap) → NO-GO 'tripped'."""
+    # day_pl = -200 on equity 10000, cap = 1% = 100 → tripped.
+    _make_store_with_state(
+        mem_store,
+        day_pl=-200.0,
+        start_of_day_equity=10_000.0,
+    )
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ks_check = next(c for c in report.checks if c.name == "kill_switch_armed")
+    assert ks_check.ok is False
+    assert "tripped" in ks_check.detail.lower()
+
+
+def test_kill_switch_go_present_fresh_not_tripped(mem_store: Store) -> None:
+    """Present + fresh + not tripped → kill_switch_armed GO."""
+    _make_store_with_state(mem_store, day_pl=0.0, start_of_day_equity=10_000.0)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    ks_check = next(c for c in report.checks if c.name == "kill_switch_armed")
+    assert ks_check.ok is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Env/flag/token consistency (AC-4)
+# ---------------------------------------------------------------------------
+
+
+def test_env_live_no_token_no_go(mem_store: Store) -> None:
+    """ENV=live, empty token → NO-GO."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings(env="live", token="", live_trading_enabled=True)
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ec = next(c for c in report.checks if c.name == "env_flag_token_consistency")
+    assert ec.ok is False
+    assert "token" in ec.detail.lower()
+    # Token value must not appear in detail (INV-08).
+    assert FAKE_TOKEN not in ec.detail
+
+
+def test_env_live_no_account_id_no_go(mem_store: Store) -> None:
+    """ENV=live, missing account ID → NO-GO."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings(env="live", account_id="", live_trading_enabled=True)
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ec = next(c for c in report.checks if c.name == "env_flag_token_consistency")
+    assert ec.ok is False
+    assert "account" in ec.detail.lower()
+
+
+def test_env_live_trading_disabled_no_go(mem_store: Store) -> None:
+    """ENV=live + live_trading_enabled=False → NO-GO."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings(env="live", live_trading_enabled=False)
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    assert report.go is False
+    ec = next(c for c in report.checks if c.name == "env_flag_token_consistency")
+    assert ec.ok is False
+    assert "live_trading_enabled" in ec.detail
+
+
+def test_env_demo_always_consistent(mem_store: Store) -> None:
+    """ENV=demo → env_flag_token_consistency always OK."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings(env="demo", live_trading_enabled=False)
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    ec = next(c for c in report.checks if c.name == "env_flag_token_consistency")
+    assert ec.ok is True
+    assert "demo" in ec.detail.lower()
+
+
+def test_env_live_all_ok(mem_store: Store) -> None:
+    """ENV=live + token + account_id + live_trading_enabled=True → GO on this check."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings(env="live", live_trading_enabled=True)
+    client = _make_stub_client()
+
+    report = run_preflight(
+        settings=settings,
+        store=mem_store,
+        client=client,
+        attested=True,
+    )
+    ec = next(c for c in report.checks if c.name == "env_flag_token_consistency")
+    assert ec.ok is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Account reachable (stub client)
+# ---------------------------------------------------------------------------
+
+
+def test_account_reachable_ok(mem_store: Store) -> None:
+    """Stub client succeeds → account_reachable PASS."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client(reachable=True)
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+    ar = next(c for c in report.checks if c.name == "account_reachable")
+    assert ar.ok is True
+
+
+def test_account_reachable_fail(mem_store: Store) -> None:
+    """Stub client raises → account_reachable FAIL, go=False."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client(reachable=False)
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+    assert report.go is False
+    ar = next(c for c in report.checks if c.name == "account_reachable")
+    assert ar.ok is False
+    assert "fail" in ar.detail.lower() or "unreachable" in ar.detail.lower()
+
+
+def test_no_client_account_reachable_fail(mem_store: Store) -> None:
+    """No client provided → account_reachable FAIL (not silently PASS)."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+
+    report = run_preflight(settings=settings, store=mem_store, client=None, attested=True)
+    assert report.go is False
+    ar = next(c for c in report.checks if c.name == "account_reachable")
+    assert ar.ok is False
+
+
+# ---------------------------------------------------------------------------
+# 6. INV-04 static bracket contract check
+# ---------------------------------------------------------------------------
+
+
+def test_bracket_contract_check_passes(mem_store: Store) -> None:
+    """The bracket/INV-04 static contract check should PASS in a correct build."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+    bc = next(c for c in report.checks if c.name == "bracket_contract_inv04")
+    assert bc.ok is True
+    assert "inv-04" in bc.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Token never printed (INV-08)
+# ---------------------------------------------------------------------------
+
+
+def test_token_never_in_report_details(mem_store: Store) -> None:
+    """No PreflightReport check detail contains the actual token value."""
+    _make_store_with_state(mem_store)
+    secret_token = "my-super-secret-token-12345"
+    settings = _make_settings(token=secret_token)
+    client = _make_stub_client()
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+    for check in report.checks:
+        assert secret_token not in check.detail, (
+            f"Token leaked in check '{check.name}': {check.detail!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. UTC timestamps (INV-03)
+# ---------------------------------------------------------------------------
+
+
+def test_checked_at_is_utc(mem_store: Store) -> None:
+    """PreflightReport.checked_at is UTC-aware (INV-03)."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=False)
+    assert report.checked_at.tzinfo is not None
+    # Either the tzinfo is UTC or the offset is zero.
+    utc_offset = report.checked_at.utcoffset()
+    assert utc_offset is not None and utc_offset.total_seconds() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 9. Read-only: no order/write methods reachable from run_preflight
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_no_write_methods_called(mem_store: Store) -> None:
+    """run_preflight never calls write_account_state or submit_order on the store/client."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+
+    # Wrap the store in a proxy that tracks writes.
+    write_calls: list[str] = []
+    original_write = mem_store.write_account_state
+
+    def _tracking_write(
+        *,
+        start_of_day_equity: float,
+        day_pl: float,
+        as_of: datetime,
+    ) -> None:
+        write_calls.append("write_account_state")
+        return original_write(
+            start_of_day_equity=start_of_day_equity,
+            day_pl=day_pl,
+            as_of=as_of,
+        )
+
+    mem_store.write_account_state = _tracking_write  # type: ignore[method-assign]
+
+    client = MagicMock()
+    client.account_summary.return_value = {}
+    # submit_order, place_order etc. should never be called.
+
+    run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+
+    assert write_calls == [], (
+        f"run_preflight unexpectedly wrote to the store: {write_calls}"
+    )
+    # Order-placement methods must not be called.
+    for method_name in ("submit_order", "place_order", "create_order"):
+        attr = getattr(client, method_name, None)
+        if attr is not None:
+            assert not attr.called
+
+
+# ---------------------------------------------------------------------------
+# 10. CLI: exit codes + --help
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_help() -> None:
+    """fathom preflight --help exits 0 and mentions key flags."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_preflight_cli_no_go_exit_nonzero(tmp_path: object) -> None:
+    """fathom preflight (demo, no attest, empty store) → exit 1 (NO-GO)."""
+    import tempfile, os
+    db_file = tempfile.mktemp(suffix=".db")
+    try:
+        with (
+            patch("cli.Settings") as mock_settings_cls,
+            patch("cli.OandaClient") as mock_client_cls,
+        ):
+            mock_settings_cls.return_value = _make_settings()
+            stub_client = _make_stub_client(reachable=True)
+            mock_client_cls.return_value = stub_client
+
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                result = cli.main(["preflight", "--db-path", db_file])
+
+        assert result == 1, "Expected NO-GO (exit 1) when store is empty and no attestation"
+        stderr_output = buf.getvalue()
+        assert "NO-GO" in stderr_output
+    finally:
+        try:
+            os.unlink(db_file)
+        except OSError:
+            pass
+
+
+def test_preflight_cli_go_exit_zero(tmp_path: object) -> None:
+    """fathom preflight --attest-track-record (demo, seeded store) → exit 0 (GO)."""
+    import tempfile, os
+    db_file = tempfile.mktemp(suffix=".db")
+    try:
+        # Seed the store first.
+        store = Store(db_file)
+        _make_store_with_state(store)
+        store.close()
+
+        with (
+            patch("cli.Settings") as mock_settings_cls,
+            patch("cli.OandaClient") as mock_client_cls,
+        ):
+            mock_settings_cls.return_value = _make_settings()
+            stub_client = _make_stub_client(reachable=True)
+            mock_client_cls.return_value = stub_client
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                result = cli.main(
+                    ["preflight", "--db-path", db_file, "--attest-track-record"]
+                )
+
+        assert result == 0, "Expected GO (exit 0) when all checks pass + attested"
+        assert "GO" in buf.getvalue()
+    finally:
+        try:
+            os.unlink(db_file)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 11. All five check names are present in the report
+# ---------------------------------------------------------------------------
+
+
+def test_report_has_all_five_checks(mem_store: Store) -> None:
+    """PreflightReport must contain exactly five named checks."""
+    _make_store_with_state(mem_store)
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+
+    check_names = {c.name for c in report.checks}
+    expected = {
+        "account_reachable",
+        "kill_switch_armed",
+        "bracket_contract_inv04",
+        "env_flag_token_consistency",
+        "track_record_attested",
+    }
+    assert expected == check_names
+
+
+# ---------------------------------------------------------------------------
+# 12. go=False if any single check fails even if attested
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "day_pl,sod_equity,as_of_offset_min",
+    [
+        # Tripped: day_pl <= -(1% * sod_equity)
+        (-200.0, 10_000.0, 0),
+        # Stale: as_of 20 min ago
+        (0.0, 10_000.0, -20),
+    ],
+)
+def test_single_failing_check_causes_no_go(
+    mem_store: Store,
+    day_pl: float,
+    sod_equity: float,
+    as_of_offset_min: int,
+) -> None:
+    """Any single failing check → go=False even when attested."""
+    as_of = datetime.now(timezone.utc) + timedelta(minutes=as_of_offset_min)
+    _make_store_with_state(
+        mem_store,
+        day_pl=day_pl,
+        start_of_day_equity=sod_equity,
+        as_of=as_of,
+    )
+    settings = _make_settings()
+    client = _make_stub_client()
+
+    report = run_preflight(settings=settings, store=mem_store, client=client, attested=True)
+    assert report.go is False


### PR DESCRIPTION
## Summary

Implements the read-only go/no-go readiness check (`fathom preflight`) the operator runs before considering a live cutover (P5-T-03). It reports mechanical readiness — it places no orders and changes no state.

**New files:**
- `execution/preflight.py` — `PreflightReport` + `run_preflight()` with five checks
- `tests/test_preflight.py` — 24 tests

**Modified:**
- `cli.py` — adds `fathom preflight [--db-path PATH] [--attest-track-record]`

**Five checks:**

| Check | GO condition | NO-GO condition |
|---|---|---|
| `account_reachable` | `client.account_summary()` succeeds | exception or no client |
| `kill_switch_armed` | account state present, fresh (≤10 min), switch not tripped | missing / stale / tripped |
| `bracket_contract_inv04` | `build_bracket` raises `ValueError` on non-positive `stop_distance` | contract broken |
| `env_flag_token_consistency` | demo always OK; live requires token + account_id + `live_trading_enabled=True` | any missing/mismatched |
| `track_record_attested` | `attested=True` (`--attest-track-record` passed by operator) | `False` → INV-07 reason |

**`go=True` only when all five pass AND `attested=True`.**

**Read-only guarantee:** `run_preflight` takes injected `settings`/`store`/`client`. No `submit_order`, no `size_position`, no state writes. A test asserts no write method is called on the store during a run.

**INV-08:** Token is never included in any `CheckResult.detail` string (tested explicitly — asserts the actual token value does not appear in any check detail).

**INV-03:** `PreflightReport.checked_at` is always UTC-aware (tested via `utcoffset() == 0`).

**INV-07:** `attested=False` → NO-GO with a detail explicitly referencing INV-07.

**Exit codes:** 0 on GO, 1 on NO-GO. Prints per-check table to stdout.

## Test plan

- [x] `fathom preflight --help` exits 0
- [x] `fathom preflight` (demo, no attest, empty/stale store) → exit 1, NO-GO printed
- [x] Kill-switch: all three NO-GO cases (missing, stale, tripped) + GO case tested
- [x] Env/flag/token: all four cases tested (live no-token, live no-account-id, live disabled, demo)
- [x] Account reachable: stub OK, stub raises, no client
- [x] INV-04 bracket contract check: PASS in correct build
- [x] Token never leaked in report details (INV-08)
- [x] UTC timestamp (INV-03)
- [x] Read-only assertion
- [x] CLI GO exit 0 (seeded store + attest)
- [x] mypy: 0 errors (89 files)
- [x] pytest: 1082 passed (24 new + 1058 pre-existing)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)