### PR TITLE
docs: half-cycle verdict + operator-acceptance resume guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Forex algorithmic trading system — OANDA-based, multi-strategy, orchestrated b
 | Doc | What's in it |
 |---|---|
 | [`docs/PLAYBOOK.md`](docs/PLAYBOOK.md) | **Start here.** Phase status (what's done / what's next) + the reproducible build method: kickoff prompt, half-cycle layers, runbook flow, orchestration pattern, copy-paste prompts |
+| [`docs/operator-acceptance.md`](docs/operator-acceptance.md) | **Resume here.** The 4 remaining operator gates (T-08 → T-11 → T-06 → T-05) as one ordered checklist with exact commands + the credentials you must supply |
+| [`docs/half-cycle-verdict.md`](docs/half-cycle-verdict.md) | Deep retrospective/verdict on the half-cycle method (efficiency, root-cause failure modes, what worked, improvements) — Fathom as the case study |
 | [`docs/product-spec.md`](docs/product-spec.md) | Scope, confirmed decisions, build phases, honest caveats |
 | [`docs/architecture-overview.md`](docs/architecture-overview.md) | Container diagram, key boundaries, data flows, repo layout, stack |
 | [`docs/invariants.md`](docs/invariants.md) | 16 non-negotiable rules (execution boundary, JSON+safe-defaults, UTC, brackets, 0.25% cap, approved-set gate, frozen `Candidate` + `Order`/`Fill`/`Position` contracts, client-order-id idempotency, broker-is-truth, …) |

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -30,20 +30,30 @@ up. Every prompt block below is copy-paste ready.
 **Health (as of last run).** `mypy .` → 0 errors (92 files, strict). `pytest` →
 1179 passed. Both are the merge gate — keep them green.
 
-### What's next (concrete)
+### What's next (concrete) — updated 2026-05-30
 
-1. **Close P2-T-08 (operator).** This is a human-in-the-loop acceptance, not a
-   coding task. The daily Hermes job is defined (`hermes_integration/`); to accept
-   it live you must: configure the Hermes agent, set a Discord webhook + Anthropic
-   API key, run the job once, and confirm a ranked watchlist narration posts to
-   Discord with **no order placed** (INV-01). Until that's done Phase 2 is
-   "code-complete, acceptance-pending."
-2. **Phase 3 kickoff (planning only).** Sizing/orders cross INV-01 — Hermes still
-   never places orders; a separate, explicitly-gated executor would. Run the
-   *Phase kickoff (planning-only)* prompt below against a freshly carved
-   `docs/phases/phase-3.md` before any code.
-3. **Standing hygiene.** Reviewers must run **`mypy .`** (whole-repo), not scoped
-   mypy — scoped runs let test-layer type-debt accumulate (that was PR #68).
+**All engineering is done.** PoC + Phases 1–5 are code-complete (`mypy .` clean, 1179
+tests green, 0 open PRs). The only remaining work is **four operator acceptance gates**
+— external services + judgment, no code. **Start at → [`operator-acceptance.md`](operator-acceptance.md)**
+(the consolidated, ordered checklist with exact commands + prerequisites).
+
+1. **Gate 1 — P2-T-08 (#59):** stand up Hermes + set `ANTHROPIC_API_KEY` and
+   `DISCORD_WEBHOOK_URL`, register `daily.md`, confirm the watchlist lands in Discord
+   over ≥5 weekday runs with no order placed.
+2. **Gate 2 — P3-T-11 (#86):** the live *demo* execution loop (`fathom execute` →
+   bracketed demo fill → monitor → alert → reconcile). *(The "Phase 3 testing" you deferred.)*
+3. **Gate 3 — P4-T-06 (#109):** run `streamlit run panel/app.py` over a sustained demo.
+4. **Gate 4 — P5-T-05 (#123):** the deliberate go-live cutover — **INV-07-blocked**
+   until gates 1–3 are closed *positive*; operator-only, never done by the agent.
+
+**Honest caveat:** gates 1–3 can pass and the system can *still* not clear the go-live
+bar if the demo edge isn't convincingly positive (the backtest was thin — 10/72).
+That's INV-07 working as designed. See [`half-cycle-verdict.md`](half-cycle-verdict.md)
+Root Cause D for why a green codebase is not evidence the edge holds.
+
+**Standing hygiene.** Reviewers run **`mypy .`** (whole-repo), not scoped. Merge only
+via `gh pr merge`. Specs should cite real `file:symbol` for what they build on (the
+biggest source of rework this project — verdict Root Cause A).
 
 ---
 

--- a/docs/half-cycle-verdict.md
+++ b/docs/half-cycle-verdict.md
@@ -1,0 +1,205 @@
+# Verdict — Half-Cycle AI, as Tested by Building Fathom
+
+A deep, honest assessment of the half-cycle method after running it end-to-end:
+PoC + 5 phases, **79 merged PRs** (50 code/scaffold, 29 docs/chore), **16.3k lines
+of source, 22.5k lines of tests, 7.7k lines of method/doc markdown**, across many
+AI sessions with several context resets. This is a verdict on the *method*, with
+Fathom as the case study — not a verdict on Fathom.
+
+---
+
+## TL;DR verdict
+
+Half-cycle AI is a **strong construction method that is easy to mis-read as a
+success method.** It is **highly efficient** at what it is actually good at —
+building a large, multi-component, invariant-critical system across many AI
+sessions with low defect-escape and near-total resumability — and **inefficient and
+over-ceremonious** for small, well-understood, single-component changes. It has two
+structural blind spots: **(1) correctness validation is back-loaded to the very last
+layer** (everything before code is prose and can't run), and **(2) it validates how
+well you built the thing, never whether the thing should exist.** For Fathom the
+method *succeeded at its job* — a coherent, safe, reviewed trading system — and that
+success is *orthogonal* to whether Fathom should ever trade live, which remains
+entirely a human judgment at the INV-07 gate.
+
+**Use it when correctness, coherence, and resumability across a fleet matter. Pair
+it with something that pressure-tests the premise — which it deliberately doesn't.**
+
+---
+
+## The numbers (efficiency, measured)
+
+| Metric | Value | Reading |
+|---|---|---|
+| Merged PRs | 79 (50 code, 29 docs/chore) | ~37% of PRs were pure process/coordination |
+| Source LOC | 16,261 | the actual product |
+| Test LOC | 22,513 | **1.38× the source** — heavy, mostly justified |
+| Doc/method markdown LOC | 7,684 | **~0.47× the source** — pure method overhead, *excluding* agent audit/review time |
+| Cross-spec audits run | 5 (Phases 1-5) | **blocking findings in 5/5** — specs were *never* clean on the first pass |
+| Reviewer send-backs (this session's code PRs) | ~5 of ~19 (~26%) | every dangerous bug was caught at review, none at spec |
+| Phases | 6 (PoC + 1-5) | fixed per-phase ceremony cost regardless of phase size |
+
+Two facts jump out. First, **every single cross-spec audit found blocking issues** —
+the spec layer was never trustworthy until the audit reconciled it with reality.
+Second, **every dangerous bug was caught at the last layer (review), not at any
+spec/audit layer** — the P&L misfire, the live-order leak holes, the null safety
+test. The process caught them, but always at the end.
+
+---
+
+## Efficiency analysis — where it pays and where it doesn't
+
+**Where it is genuinely efficient:**
+- **Resumability across context loss.** This is the killer feature for AI-driven
+  work. The build spanned many sessions and at least one full context compaction; I
+  rebuilt state from `PLAYBOOK.md` + `invariants.md` + `code-map.md` + the phase
+  results docs and resumed without losing the thread. The 7.7k lines of "overhead"
+  markdown are what *made* a multi-session AI build tractable — they are the memory
+  the model doesn't have.
+- **Defect-escape.** Across 6 phases, mypy stayed clean and the suite stayed green;
+  the bugs that mattered were caught before merge by fresh reviewers. For a
+  money-touching system that is the right trade.
+- **Architectural coherence.** Frozen-contract invariants (INV-13 `Candidate`, INV-14
+  `Order/Fill/Position`) + "lock the prerequisite hub first" eliminated the
+  downstream churn that normally plagues multi-component builds.
+
+**Where it is inefficient:**
+- **Fixed ceremony cost per phase.** Phase 5 shipped ~4 small code units but produced
+  a carve doc + 3 specs + an audit report + a taskgraph + a results doc + status
+  syncs + 4 PR reviews. The ceremony dwarfed the code. The method does not scale
+  *down* — a 4-unit phase pays nearly the same process tax as a 10-unit phase.
+- **The audit became a reconciliation step, not a coherence check.** Because specs
+  encode an *imagined* API (see Root Cause A), the audit's real job each time was
+  "make the spec match the shipped code," not "find inter-spec drift." Valuable, but
+  not what the layer was sold as — and it means the spec-first sequencing *created*
+  rework rather than saving it.
+
+**Bottom line on efficiency:** high for *correctness-critical, multi-session,
+multi-component* work; low for *small, well-understood slices*. The method has no
+"express lane."
+
+---
+
+## What went wrong — root causes (not just symptoms)
+
+**Root cause A — Specs precede ground truth.** Layer 4 specs are written before
+touching code, so they encode an imagined system. Every audit found spec-vs-shipped
+drift (a phantom `InstrumentMeta.pip_value`; a "Hermes gateway" that was never a code
+object; `kill_switch_status` with no "armed" concept; a book-risk *sum* inlined
+inside `check_limits`; `cmd_scan` that couldn't be imported without dragging in the
+order path). There is no draft-time obligation to cite real symbols, so the spec is
+untrustworthy until the audit fixes it. For a fast-feedback typed codebase, spec-first
+*created* rework instead of saving it.
+
+**Root cause B — Prose validation can't catch behaviour.** Layers 3-4 (carve, specs,
+audit) are entirely prose. The first executable check is Layer 5 (the worker's tests
++ the reviewer). So *all* correctness bugs necessarily survive to the last layer —
+and the most dangerous ones did: storing OANDA's *lifetime* P&L as "today's" (would
+have misfired the kill switch), the live-gate "safe by accident" hole, the panel
+INV-01 test that silently never ran, a `ZeroDivisionError` on negative equity. The
+method front-loads *coordination* validation and back-loads *correctness* validation
+to the very end — backwards for correctness-critical code.
+
+**Root cause C — Local-phase optimization, global-reuse blindness.** Each phase's
+specs are scoped to ship *that* phase and never model future read-only consumers, so
+logic gets inlined and every later phase pays an "extraction tax": Phase 4 had to
+extract `correlation.py`, `run_scan`, and `book_risk_sum` out of Phase 2/3 code;
+Phase 5 had to extract `kill_switch_armed`. Four refactors of shipped, tested code
+purely because the earlier phase buried reusable logic inside side-effectful
+functions. Phase isolation (great for reviewability) is a weakness for reuse — the
+method has no "design for extraction" convention.
+
+**Root cause D — It validates the build, not the bet.** The deepest one. Every layer
+asks "is this built correctly / coherently / per-invariant?" None asks "should this
+exist / does the edge hold?" On Fathom the actual value question — does a thin
+10/72-combo edge survive live costs — is untouched by all the process, yet the green
+dashboard (79 PRs, 1179 tests, clean mypy, 7 tidy results docs) manufactures
+done-ness. INV-07 (demo-first) is the only guard, and it is a human judgment the
+method cannot close. The method can drive a project *confidently* toward shipping
+something that should not ship. This is not an execution bug — it is an unadvertised
+scope boundary: half-cycle is a **construction** methodology, not a
+**validation-of-premise** methodology.
+
+**Root cause E — Lead rulings are an unaudited single point of failure.** Decisions
+routed to "the lead" (conflict policy, the INV-09 amendment, the attestation
+auto-pass) land *in the spec* and become the thing reviewers check *against* — so a
+wrong ruling is invisible to the review rigor. The clearest case: the attestation
+auto-pass was signed off as "sound *if* the runbook enforces ordering" — a process
+assumption no test enforces. The method protects against worker error, not against
+architect error.
+
+---
+
+## What genuinely worked (this is a verdict, not a hit piece)
+
+- **Fresh-reviewer-per-PR is the single highest-value practice.** It caught *every*
+  dangerous bug listed above. A reviewer with no memory of writing the code, fed the
+  diff + the spec's acceptance criteria, is worth more than any amount of pre-code
+  prose.
+- **Frozen-contract invariants + lock-the-hub-first** eliminated downstream churn —
+  the `Candidate`/`Order` contracts held across every consumer.
+- **Durable artifacts → resumability.** The reason a multi-session AI build didn't
+  collapse into incoherence. This alone may justify the method for long-horizon
+  agentic work.
+- **Invariants as a safety spine.** INV-01 (no Hermes order authority), INV-04
+  (brackets), INV-05 (0.25% cap), INV-07 (demo-first) held across all five phases —
+  no naked order, no UI/agent order surface, nothing flipped live. For a money-
+  touching system, that unbroken discipline is the method's strongest argument.
+- **The cross-spec audit, even prose-only, caught real architecture gaps** (the
+  non-existent gateway, the INV-09 violation) that would have been far more expensive
+  to discover at code time.
+
+---
+
+## The verdict
+
+Half-cycle AI **delivered exactly what it promises — a large, coherent, type-clean,
+heavily-tested, invariant-respecting system, built incrementally by an AI fleet
+across many sessions with low defect-escape — and it did so efficiently for a system
+of this size and risk profile.** Its review and invariant machinery repeatedly
+caught real, dangerous bugs.
+
+Its failures are **structural and predictable**, not incidental:
+1. correctness validation lives only at the final layer (prose can't run);
+2. specs drift from shipped reality because nothing forces a draft-time code check;
+3. it taxes reuse (no design-for-extraction);
+4. and — most importantly — **it validates construction, never premise**, so it can
+   build the wrong thing impeccably.
+
+For Fathom, the method's success and Fathom's worth are *independent variables*. The
+codebase is done and safe; whether it should ever trade real money is unknown and
+sits entirely on the human at INV-07. **That is the method working as designed — and
+also its most dangerous property, because the polish invites confidence the evidence
+does not support.**
+
+**Net: an excellent construction method, frequently mistaken for a success method.**
+
+---
+
+## Concrete improvements (if we run it again)
+
+1. **"Specs must cite shipped symbols."** Draft-time rule: every spec references the
+   real `file:symbol` for everything it builds on; the consistency-check verifies they
+   exist. Kills Root Cause A (the single biggest source of rework).
+2. **Pull one executable check earlier.** A "contract smoke" at spec time — a
+   compiling type-stub / failing test the spec must be written against — so
+   correctness isn't 100% back-loaded to Layer 5 (Root Cause B).
+3. **Design-for-extraction convention.** Layer 4 names reusable primitives up front
+   and ships them as standalone, side-effect-free functions, not inlined — paying the
+   reuse cost once instead of as a tax every later phase (Root Cause C).
+4. **A premise gate at Layer 1, re-checked each phase.** An explicit, revisited
+   "should this exist / what evidence would kill it?" separate from the build gates
+   (Root Cause D). For Fathom that would have surfaced the thin-edge risk as a
+   first-class concern, not a footnote.
+5. **Adversarial check on lead rulings.** A second agent argues the opposite of any
+   "lead ruling" before it enters a spec (Root Cause E).
+6. **Ops-reality notes in the orchestration runbook** — e.g. the editable-install /
+   git-worktree hazard that forced sequential-in-main dispatch here.
+
+---
+
+## See also
+
+- [`PLAYBOOK.md`](PLAYBOOK.md) — phase status + the reproducible method.
+- [`operator-acceptance.md`](operator-acceptance.md) — the remaining human gates (the work the method left to judgment).
+- Per-phase audit reports (`phases/phase-N-spec-audit-*.md`) — the raw evidence behind Root Causes A/B.

--- a/docs/operator-acceptance.md
+++ b/docs/operator-acceptance.md
@@ -1,0 +1,149 @@
+# Operator Acceptance — Start Here to Finish Fathom
+
+**This is the resume point.** All engineering is done: PoC + Phases 1–5 are
+code-complete (`mypy .` clean, 1179 tests green, 0 open PRs). What remains is **four
+human/operator acceptance gates** that no code can close — they require external
+services and judgment. This doc threads them into one ordered checklist with the
+exact commands and prerequisites, so you can pick up cold.
+
+> Status snapshot: see [`PLAYBOOK.md`](PLAYBOOK.md) Part 1. Method retrospective:
+> see [`half-cycle-verdict.md`](half-cycle-verdict.md).
+
+---
+
+## The 4 gates, in order
+
+| # | Gate | Issue | Blocks |
+|---|---|---|---|
+| 1 | **P2-T-08** daily watchlist → Discord | #59 | nothing (start here) |
+| 2 | **P3-T-11** live demo execution loop | #86 | the go-live track record |
+| 3 | **P4-T-06** admin-panel acceptance | #109 | the go-live track record |
+| 4 | **P5-T-05** live cutover (real money) | #123 | gates 1–3 closed **positive** (INV-07) |
+
+Gates 1–3 build the **demo track record** INV-07 requires. Gate 4 is the deliberate
+go-live decision and must not happen until 1–3 are not just *run* but *convincingly
+positive*.
+
+---
+
+## Prerequisites you must supply
+
+From the current `.env` (audited 2026-05-30):
+
+| Item | State | Needed for |
+|---|---|---|
+| `OANDA_API_TOKEN` + `OANDA_ACCOUNT_ID` + `ENV=demo` | ✅ set | everything |
+| `data/fathom.db` (seeded approved-set + watchlist) | ✅ present | everything |
+| `ANTHROPIC_API_KEY` | ❌ **you add** | gate 1 (news-risk/narration), gate 2 (pre-trade veto) |
+| `DISCORD_WEBHOOK_URL` | ❌ **you add** | gate 1 (watchlist), gate 2 (deviation alerts) |
+| a running **Hermes** instance (cron + Discord gateway) | ❌ **you set up** | gate 1 (the scheduled job) |
+| `LIVE_TRADING_ENABLED` / `LIVE_RISK_FRACTION` / live token | ❌ **gate 4 only** | the cutover — leave unset until then |
+
+**One-time setup before gate 1:** stand up Hermes, and set `ANTHROPIC_API_KEY` +
+`DISCORD_WEBHOOK_URL` in the env. (Re-seed anytime with `fathom backtest` then
+`fathom scan` if the DB goes stale.)
+
+---
+
+## Gate 1 — P2-T-08: daily watchlist → Discord (#59)
+
+**Goal:** Hermes posts a ranked, Claude-enriched watchlist to Discord on schedule,
+placing no orders (INV-01).
+
+1. Register `hermes_integration/jobs/daily.md` in Hermes; grant it the Fathom CLI
+   tools **`scan` / `watchlist` / `chart` only** (never `execute`).
+2. Wire the prompts (`hermes_integration/prompts/news_risk.md`, `narration.md`) and
+   the parsers (`parse_news_risk`, `should_use_fallback`).
+3. Schedule `0 22 * * 1-5` (or your session-close hour).
+4. **Accept when:** a coherent ranked watchlist + charts + Claude rationale lands in
+   Discord over **≥5 consecutive weekday runs**; empty days post "no candidates"; a
+   `skip` verdict vetoes; **no order is ever placed**; no secret in output.
+5. Record the run log in [`phases/phase-2-results.md`](phases/phase-2-results.md).
+
+Full procedure: `hermes_integration/jobs/daily.md → Operator runbook`.
+
+---
+
+## Gate 2 — P3-T-11: live demo execution loop (#86)
+
+**Goal:** the deterministic execution gate runs end-to-end on the **demo** account.
+*(This is the "Phase 3 testing" you deferred.)*
+
+```bash
+# with ANTHROPIC_API_KEY set (so the pre-trade veto can return proceed):
+fathom scan --db-path data/fathom.db            # refresh the watchlist
+fathom execute EUR_USD:D:BollingerReversion(20,2.0) --db-path data/fathom.db
+scripts/run_monitor.py --instruments EUR_USD --db-path data/fathom.db   # always-on, separate terminal
+fathom reconcile --db-path data/fathom.db
+```
+
+**Accept when, over a sustained demo run:** `fathom execute` places a **bracketed**
+(SL+TP) demo order through the gate; a **re-run is idempotent** (no double-fill); the
+monitor tracks the open position and a **deviation alert lands in Discord**;
+`fathom reconcile` matches broker state after a restart; the daily-loss kill switch
+halts new entries if the cap trips. No live endpoint touched (INV-07). Record in
+[`phases/phase-3-results.md`](phases/phase-3-results.md).
+
+---
+
+## Gate 3 — P4-T-06: admin-panel acceptance (#109)
+
+**Goal:** the read-only dashboard shows a coherent picture of the demo system.
+
+```bash
+streamlit run panel/app.py -- --db-path data/fathom.db
+```
+
+**Accept when:** the 5 views render real demo data — Charts (candles + entry/stop/
+target overlays + attribution), Equity curve + drawdown, Blotter (positions / P&L /
+risk-in-use vs limit), Watchlist (mirrors Discord), Deviation log — the **Refresh**
+button re-ranks with no order placed, no secret is shown, timestamps are UTC. Confirm
+over a sustained demo period. Record in [`phases/phase-4-results.md`](phases/phase-4-results.md).
+
+---
+
+## Gate 4 — P5-T-05: live cutover (real money) (#123) ⛔ INV-07-blocked
+
+**Do not start until gates 1–3 are closed AND the demo P&L is convincingly
+positive.** This is a judgment call, not a checkbox — see the honest caveat below.
+
+Follow [`go-live-runbook.md`](go-live-runbook.md) exactly. The hard ordering:
+
+1. set the live token in `.env`; `ENV=live`.
+2. `fathom preflight --attest-track-record` → **must be GO**.
+3. **only after GO**, set `LIVE_TRADING_ENABLED=true`. *(The flag IS the attestation
+   record — never set it before a passing attested preflight.)*
+4. `fathom execute <instrument>:<timeframe>:<strategy_name>` — one small candidate,
+   type the account id to confirm — sizes at `LIVE_RISK_FRACTION` (0.10%).
+5. confirm bracketed fill + `run_monitor.py` + `fathom reconcile`; record the dated
+   go/no-go decision.
+6. **Rollback any time:** `LIVE_TRADING_ENABLED=false` (instant — the gate refuses),
+   `ENV=demo`, flatten open positions; the daily-loss kill switch is the automated
+   backstop.
+
+**The agent never performs this step.** Create `phases/phase-5-results.md`'s live
+section / a go-live decision record when done.
+
+---
+
+## ⚠️ Honest caveat (read before gate 4)
+
+INV-07's bar is not "the plumbing works" — it is a **sustained, positive demo
+edge**. The backtest found a *thin* edge (10/72 combos approved, several marginal —
+see [`phases/phase-1a-results.md`](phases/phase-1a-results.md)). So gates 1–3 can run
+flawlessly and the system can **still** fail to clear the go-live bar if the demo
+P&L isn't convincingly positive. That is the system working as designed (demo-first,
+INV-07). The polish of a green, fully-built codebase is *not* evidence the edge holds
+live — keep gate 4 skeptical. (See [`half-cycle-verdict.md`](half-cycle-verdict.md)
+Root Cause D.)
+
+---
+
+## If you're an AI resuming this project
+
+Read, in order: this file → [`PLAYBOOK.md`](PLAYBOOK.md) (status + method) →
+[`invariants.md`](invariants.md) (INV-01…16) → [`architecture-overview.md`](architecture-overview.md).
+Engineering is complete; do **not** write go-live/live-token code or flip any live
+switch — gate 4 is operator-only and INV-07-blocked. If asked to "continue the
+project," the only remaining work is supporting the operator through the four gates
+above (or net-new phases the operator explicitly scopes).


### PR DESCRIPTION
## Summary

Two deliverables now that the build is complete.

### 1. `docs/half-cycle-verdict.md` — deep verdict on the method
Quantified (79 PRs · 16.3k src / 22.5k test / 7.7k doc LOC · blocking audit findings in **5/5** phases · every dangerous bug caught at review, none at spec). Root-cause analysis:
- **A** specs precede ground truth (spec-vs-shipped drift every audit)
- **B** prose validation can't catch behaviour — correctness back-loaded to the last layer
- **C** reuse/extraction tax (4 refactors of prior-phase code)
- **D** validates the build, not the bet (green dashboard ≠ the edge holds)
- **E** lead rulings are an unaudited single point of failure

**Verdict:** a strong *construction* method frequently mistaken for a *success* method — excellent for correctness, coherence, and multi-session resumability; structurally blind to premise. Plus 6 concrete improvements.

### 2. `docs/operator-acceptance.md` — the RESUME-HERE guide
The 4 remaining operator gates (T-08 → T-11 → T-06 → T-05) as one ordered checklist with exact commands, the credentials you must supply (`ANTHROPIC_API_KEY`, `DISCORD_WEBHOOK_URL`, Hermes — OANDA/DB already set), the INV-07 honest caveat, and an "if you're an AI resuming" section (engineering done; never flip live; gate 4 operator-only).

### Also
Refreshed the stale PLAYBOOK "What's next" (was written at Phase 2) and registered both docs in CLAUDE.md. **Docs only — no code touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)