### PR TITLE
fix(execution): client-order-id uses UTC date so re-runs dedup (INV-15)

### DIFF
--- a/docs/features/order-model-and-brackets.md
+++ b/docs/features/order-model-and-brackets.md
@@ -38,9 +38,12 @@ Not a CLI surface; consumed by other Phase 3 modules.
   (DRIFT-07).
 
 **`client_order_id` derivation (DRIFT-03 / INV-15).** `build_bracket` computes
-`client_order_id = sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date}").hexdigest()[:32]`
-from the `Candidate` fields + the injected `execution_date`. The same formula is
-stated in [[order-placement]] and [[execution-cli]].
+`client_order_id = sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date.date().isoformat()}").hexdigest()[:32]`
+from the `Candidate` fields + the injected `execution_date`. Only the **UTC date**
+(`YYYY-MM-DD`) of `execution_date` enters the payload — never the full timestamp —
+so a same-day operator re-run dedups (INV-15) while the next day yields a distinct
+id. `Order.created_at` still carries the full `execution_date` timestamp. The same
+formula is stated in [[order-placement]] and [[execution-cli]].
 
 **`candidate_ref` (DRIFT-04).** A string `f"{instrument}:{timeframe}:{strategy_name}"`
 — the same value `fathom execute` ([[execution-cli]]) accepts as its argument and

--- a/docs/features/order-placement.md
+++ b/docs/features/order-placement.md
@@ -78,9 +78,10 @@ client extension *and* a pre-submit store check — belt and suspenders against
 double-fills. Unit tests mock v20 with `responses`; no live HTTP in tests. → opus.
 
 **Idempotency key (DRIFT-03 — pinned, INV-15).** `client_order_id =
-sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date}").hexdigest()[:32]`,
+sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:{execution_date.date().isoformat()}").hexdigest()[:32]`,
 computed by `build_bracket()` in [[order-model-and-brackets]] from the `Candidate`
 fields plus an injected `execution_date` (UTC date of the `fathom execute` run).
+Only the UTC date (`YYYY-MM-DD`) is interpolated, never the full timestamp.
 The same approved candidate retried the same day dedups; a genuine re-approval the
 next day yields a distinct id. `order-model`, this spec, and [[execution-cli]] all
 state this one formula.

--- a/execution/models.py
+++ b/execution/models.py
@@ -417,11 +417,21 @@ def _client_order_id(candidate: Candidate, execution_date: datetime) -> str:
     ``sha256(f"{instrument}:{strategy_name}:{timeframe}:{generated_at}:"
     f"{execution_date}").hexdigest()[:32]`` over the candidate fields plus the
     injected ``execution_date``.  ``generated_at`` is already the candidate's
-    RFC-3339 string; ``execution_date`` is interpolated via the f-string as the
-    spec states.  Pure: identical inputs always yield the identical id.
+    RFC-3339 string.
+
+    Per ``docs/features/order-placement.md``, ``execution_date`` is the **UTC
+    date** of the ``fathom execute`` run, so it is interpolated as
+    ``execution_date.date().isoformat()`` (``YYYY-MM-DD``), never the full
+    timestamp: "The same approved candidate retried the same day dedups; a
+    genuine re-approval the next day yields a distinct id."  Interpolating the
+    microsecond-precision datetime would give every operator re-run a fresh id
+    and place a duplicate broker order (INV-15 violation).
+
+    ``Order.created_at`` keeps the full timestamp; only the id is date-grained.
+    Pure: identical inputs always yield the identical id.
     """
     payload = (
         f"{candidate.instrument}:{candidate.strategy_name}:{candidate.timeframe}:"
-        f"{candidate.generated_at}:{execution_date}"
+        f"{candidate.generated_at}:{execution_date.date().isoformat()}"
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]

--- a/tests/test_order_model.py
+++ b/tests/test_order_model.py
@@ -29,6 +29,7 @@ from execution.models import (
     FillStatus,
     Order,
     Position,
+    _client_order_id,
     build_bracket,
 )
 from signals.ranker import Candidate
@@ -414,6 +415,31 @@ def test_client_order_id_deterministic() -> None:
     assert a.client_order_id != ""
 
 
+def test_client_order_id_stable_across_same_utc_day_reruns() -> None:
+    """INV-15: an operator re-run on the same UTC day dedups (same id)."""
+    c = _candidate()
+    morning = datetime(2026, 8, 31, 9, 15, 3, 123456, tzinfo=UTC)
+    evening = datetime(2026, 8, 31, 17, 42, 59, 999999, tzinfo=UTC)
+    assert _client_order_id(c, morning) == _client_order_id(c, evening)
+    a = build_bracket(c, 1000, execution_date=morning, precision=5)
+    b = build_bracket(c, 1000, execution_date=evening, precision=5)
+    assert a.client_order_id == b.client_order_id
+    # created_at keeps full timestamp resolution.
+    assert a.created_at == morning
+    assert b.created_at == evening
+
+
+def test_client_order_id_distinct_on_next_utc_day() -> None:
+    """A genuine re-approval the next day yields a distinct id."""
+    c = _candidate()
+    day1 = datetime(2026, 8, 31, 23, 59, 59, tzinfo=UTC)
+    day2 = datetime(2026, 9, 1, 0, 0, 1, tzinfo=UTC)
+    assert _client_order_id(c, day1) != _client_order_id(c, day2)
+    a = build_bracket(c, 1000, execution_date=day1, precision=5)
+    b = build_bracket(c, 1000, execution_date=day2, precision=5)
+    assert a.client_order_id != b.client_order_id
+
+
 def test_client_order_id_changes_with_execution_date() -> None:
     c = _candidate()
     a = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)
@@ -433,7 +459,7 @@ def test_client_order_id_matches_formula() -> None:
     c = _candidate()
     payload = (
         f"{c.instrument}:{c.strategy_name}:{c.timeframe}:"
-        f"{c.generated_at}:{EXEC_DATE}"
+        f"{c.generated_at}:{EXEC_DATE.date().isoformat()}"
     )
     expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
     order = build_bracket(c, 1000, execution_date=EXEC_DATE, precision=5)


### PR DESCRIPTION
Closes #134

## Problem (CRITICAL — real money)
`execution/models.py::_client_order_id` interpolated the full microsecond-precision `execution_date` into the sha256 payload. `cli.py` passes `datetime.now(UTC)`, so **every** `fathom execute` invocation produced a fresh `client_order_id` — a same-day operator re-run placed a **duplicate broker order**, violating INV-15's exact stated guarantee.

## Fix
Interpolate `execution_date.date().isoformat()` (`YYYY-MM-DD`), per `docs/features/order-placement.md`: "an injected `execution_date` (UTC date of the `fathom execute` run) … The same approved candidate retried the same day dedups; a genuine re-approval the next day yields a distinct id."

`Order.created_at` is **unchanged** — it still carries the full `execution_date` timestamp. Only the idempotency key is date-grained.

## Acceptance criteria
- [x] Same candidate, two `execution_date`s on the same UTC day (09:15:03.123456Z / 17:42:59.999999Z on 2026-08-31) → identical `_client_order_id` and identical `Order.client_order_id` from `build_bracket`.
- [x] Next UTC day (2026-08-31T23:59:59Z vs 2026-09-01T00:00:01Z) → distinct ids.
- [x] `Order.created_at` retains full timestamp resolution (asserted in the same-day test).
- [x] Existing pin `test_client_order_id_changes_with_execution_date` (timedelta(days=1)) passes unchanged.
- [x] TDD: same-day test verified RED before the fix (`assert 'dfb3a252…' == 'b90c83af…'`).

## Invariants touched
- **INV-15** (client-order-id idempotency) — restored; this is the fix.
- **INV-14** (frozen `Order` contract) — unchanged: no field added/removed/retyped; `created_at` semantics preserved.
- **INV-03** (UTC) — `.date()` is taken from a validator-enforced tz-aware UTC datetime, so the date is a UTC date.

## Spec amendments (land with the fix — sweep rule)
Both specs spelled the formula with the full datetime interpolation while the prose said "UTC date". Formula text corrected in:
- `docs/features/order-placement.md` (DRIFT-03 pin)
- `docs/features/order-model-and-brackets.md` (DRIFT-03 / INV-15 pin)

## Gate results
`.venv/bin/python -m pytest -q`
```
FAILED tests/test_execution_cli.py::TestCliHelp::test_fathom_help_lists_all_subcommands
FAILED tests/test_panel_data.py::TestReadOnlyBoundary::test_panel_data_does_not_import_forbidden_modules
FAILED tests/test_stream.py::TestPriceStreamReconnect::test_reconnect_on_heartbeat_timeout
FAILED tests/test_stream.py::TestPriceStreamReconnect::test_backoff_called_on_reconnect
4 failed, 1176 passed, 1 skipped, 85 warnings in 55.28s
```
All four are pre-existing baseline: the first two are the hardcoded-path failures fixed by #141; the two `test_stream.py` reconnect failures are the known flake — `pytest -q tests/test_stream.py` in isolation gives `32 passed`. **No new failures.**

`.venv/bin/python -m mypy .`
```
data/store.py:1640: error: Unused "type: ignore" comment  [unused-ignore]
data/store.py:1695: error: Unused "type: ignore" comment  [unused-ignore]
Found 2 errors in 1 file (checked 92 source files)
```
Both pre-existing, fixed by #141.

`tests/test_order_model.py`: 33 passed.

## For the reviewer to probe
- `test_client_order_id_matches_formula` was updated to `EXEC_DATE.date().isoformat()` — it is a pin on the spec formula, so it had to move with the spec amendment. Confirm the new formula is the one you want pinned.
- Any already-persisted `orders` rows keyed with the old timestamp-grained ids will not collide with new date-grained ids; no migration is included because no demo track record exists yet (INV-07-blocked). Flag if a backfill is wanted.