### PR TITLE
fix: portable tests, locked deps, CI merge gate (#141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Run mypy
+        run: python -m mypy .

--- a/data/store.py
+++ b/data/store.py
@@ -1637,7 +1637,7 @@ class Store:
 
             day_df = df[df["time"].dt.date == date].copy()
             table = pa.Table.from_pandas(day_df, preserve_index=False)
-            pq.write_table(table, path)  # type: ignore[no-untyped-call]
+            pq.write_table(table, path)
 
     def load_parquet(
         self,
@@ -1692,7 +1692,7 @@ class Store:
         while current <= end_date:
             path = self._parquet_path(instrument, granularity, current.strftime("%Y-%m-%d"))
             if path.exists():
-                day_df = pq.read_table(path).to_pandas()  # type: ignore[no-untyped-call]
+                day_df = pq.read_table(path).to_pandas()
                 # Ensure the time column is datetime64[ns, UTC] (pyarrow
                 # reads back with tz info but may use us resolution).
                 day_df["time"] = pd.to_datetime(

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,83 @@
+# requirements-lock.txt — pinned, resolved dependency set for reproducible installs.
+#
+# Generated with: VIRTUAL_ENV=$PWD/.venv uv pip freeze (editable `fathom` line excluded)
+#
+# To refresh after changing pyproject.toml:
+#   uv venv .venv -p 3.11
+#   VIRTUAL_ENV=$PWD/.venv uv pip install -e '.[dev]'
+#   VIRTUAL_ENV=$PWD/.venv uv pip freeze | grep -v '^-e \|^fathom' > requirements-lock.txt
+#
+# This file is informational (records exact versions actually installed and
+# tested); pyproject.toml remains the source of truth for version ranges.
+altair==6.2.2
+annotated-types==0.8.0
+anthropic==1.2.0
+anyio==4.14.2
+ast-serialize==0.8.0
+attrs==26.1.0
+blinker==1.9.0
+certifi==2026.7.22
+charset-normalizer==3.5.1
+click==8.5.0
+contourpy==1.3.3
+cycler==0.12.1
+docstring-parser==0.18.0
+fonttools==4.64.0
+h11==0.16.0
+httpcore==1.0.9
+httpcore2==2.12.0
+httptools==0.8.0
+httpx==0.28.1
+httpx2==2.12.0
+hypothesis==6.167.1
+idna==3.19
+iniconfig==2.3.0
+itsdangerous==2.2.0
+jinja2==3.1.6
+jiter==0.16.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+kiwisolver==1.5.1
+librt==0.15.0
+markupsafe==3.0.3
+matplotlib==3.11.1
+mypy==2.3.1
+mypy-extensions==1.1.0
+narwhals==2.25.0
+numpy==2.4.6
+oandapyv20==0.7.2
+packaging==26.3
+pandas==3.0.5
+pathspec==1.1.1
+pillow==12.3.0
+pluggy==1.6.0
+protobuf==7.36.1
+pyarrow==25.0.1
+pydantic==2.13.5
+pydantic-core==2.46.5
+pydantic-settings==2.15.0
+pydeck==0.9.3
+pygments==2.21.0
+pyparsing==3.3.2
+pytest==9.1.1
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.3
+python-multipart==0.0.32
+pyyaml==6.0.3
+referencing==0.37.0
+requests==2.34.2
+responses==0.26.3
+rpds-py==2026.6.3
+six==1.17.0
+sniffio==1.3.1
+sortedcontainers==2.4.0
+starlette==1.6.0
+streamlit==1.62.0
+streamlit-lightweight-charts==0.7.20
+toml==0.10.2
+truststore==0.10.4
+typing-extensions==4.16.0
+typing-inspection==0.4.4
+urllib3==2.7.0
+uvicorn==0.52.4
+websockets==16.1.1

--- a/tests/test_execution_cli.py
+++ b/tests/test_execution_cli.py
@@ -805,11 +805,15 @@ class TestCliHelp:
     def test_fathom_help_lists_all_subcommands(self, capsys: object) -> None:
         """fathom --help lists execute/positions/reconcile alongside backtest/scan."""
         import subprocess
+        import sys
+        from pathlib import Path
+
+        repo_root = str(Path(__file__).parent.parent)
         result = subprocess.run(
-            [".venv/bin/fathom", "--help"],
+            [sys.executable, str(Path(repo_root) / "cli.py"), "--help"],
             capture_output=True,
             text=True,
-            cwd="/home/sam-baby/development/fathom",
+            cwd=repo_root,
         )
         output = result.stdout + result.stderr
         assert "execute" in output

--- a/tests/test_panel_data.py
+++ b/tests/test_panel_data.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -893,14 +894,15 @@ if violations:
 else:
     print("OK: no forbidden imports or names in panel.data source")
     sys.exit(0)
-""".format(root="/home/sam-baby/development/fathom")
+""".format(root=str(Path(__file__).parent.parent))
 
     def test_panel_data_does_not_import_forbidden_modules(self) -> None:
+        repo_root = str(Path(__file__).parent.parent)
         result = subprocess.run(
             [sys.executable, "-c", self._PROBE],
             capture_output=True,
             text=True,
-            cwd="/home/sam-baby/development/fathom",
+            cwd=repo_root,
         )
         output = result.stdout.strip() + result.stderr.strip()
         assert result.returncode == 0, (

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -382,6 +382,13 @@ class TestPriceStreamReconnect:
     def test_reconnect_on_heartbeat_timeout(self) -> None:
         """Heartbeat timeout must cause a reconnect (attempt counter increments)."""
         attempts_seen: list[int] = []
+        # Signals when the background thread has reached the second attempt
+        # and set the stop event itself.  Waiting on this (instead of racing
+        # start()/stop() back-to-back) removes a timing margin that was too
+        # tight under full-suite load: without it, the main thread could call
+        # stop() — and set _stop_event — before the background thread had even
+        # entered its loop, starving it of any attempts.
+        reached_second_attempt = threading.Event()
 
         def mock_stream_once(
             self_inner: PriceStream, gap_on_next: bool, attempt: int
@@ -390,6 +397,7 @@ class TestPriceStreamReconnect:
             if attempt >= 1:
                 # On second attempt, shut down cleanly.
                 self_inner._stop_event.set()
+                reached_second_attempt.set()
                 return False
             # First attempt: return True to simulate timeout/disconnect.
             return True
@@ -400,6 +408,10 @@ class TestPriceStreamReconnect:
         with patch("data.stream._backoff_delay", return_value=0.0):
             with patch.object(PriceStream, "_stream_once", mock_stream_once):
                 stream.start()
+                assert reached_second_attempt.wait(timeout=5.0), (
+                    "background stream thread did not reach the second "
+                    "attempt in time"
+                )
                 stream.stop()
 
         assert 0 in attempts_seen


### PR DESCRIPTION
## Summary
- Fixed hardcoded machine paths in `tests/test_execution_cli.py` and `tests/test_panel_data.py` — both now derive the repo root from `pathlib.Path(__file__).parent.parent` and invoke the CLI via `sys.executable cli.py --help` instead of a `.venv/bin/fathom` binary path that only existed on the original build machine.
- Removed 2 unused `# type: ignore` comments in `data/store.py` (lines 1640, 1695) — mypy now reports 0 errors.
- Deflaked `tests/test_stream.py::TestPriceStreamReconnect::test_reconnect_on_heartbeat_timeout`: the test previously raced `stream.start()` immediately followed by `stream.stop()`, which under full-suite load could set `_stop_event` before the background thread ever entered its loop, starving it of attempts. Fixed by waiting on a `threading.Event` the mock sets once it reaches the second attempt, before calling `stop()`.
- Added `requirements-lock.txt` (pinned `uv pip freeze` output, editable `fathom` line excluded) with a header comment documenting the refresh procedure.
- Added `.github/workflows/ci.yml`: runs on `pull_request` and `push` to `main`, `ubuntu-latest`, Python 3.11, `pip install -e '.[dev]'`, then `python -m pytest -q` and `python -m mypy .` as separate steps.

## Acceptance criteria
- [x] `tests/test_execution_cli.py::TestCliHelp::test_fathom_help_lists_all_subcommands` passes without machine-specific paths.
- [x] `tests/test_panel_data.py::TestReadOnlyBoundary::test_panel_data_does_not_import_forbidden_modules` passes without machine-specific paths.
- [x] `mypy .` — 0 errors.
- [x] `test_reconnect_on_heartbeat_timeout` passes reliably across repeated full-suite runs.
- [x] `requirements-lock.txt` added and committed with refresh instructions.
- [x] `.github/workflows/ci.yml` added as a merge gate (pytest + mypy).

## Gate output (verbatim)

Full suite, run 1:
```
1178 passed, 1 skipped, 83 warnings in 51.62s
```

Full suite, run 2 (deflake confirmation):
```
1178 passed, 1 skipped, 83 warnings in 40.10s
```

mypy:
```
Success: no issues found in 92 source files
```

Closes #141