### PR TITLE
WS0-T09: freeze Candidate/Order/Fill/Position (INV-13/14)

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -135,7 +135,7 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 
 **Reason:** `Candidate` is consumed by `portfolio.py`, `charts.py`, `cli.py`, `narration.py`, and the Hermes daily job. Once shipped, a silent field rename ripples across all of them and breaks the Discord watchlist. Freezing the contract (as INV-11 freezes the `Signal` stop/target derivation) makes the dependency explicit and reviewable. Note: `timeframe` is the same dimension the approved-set/DB calls `granularity`; the INV-10 gate join is `signal.timeframe == approved_set.granularity`.
 
-**Enforcement:** The field table lives in `docs/features/signal-ranker.md`; `cli-commands`, `chart-generation`, and `watchlist-narration` reference it rather than re-listing fields. A serialisation round-trip test pins the JSON shape. Reviewer checks any `Candidate` field change against this invariant.
+**Enforcement:** The field table lives in `docs/features/signal-ranker.md`; `cli-commands`, `chart-generation`, and `watchlist-narration` reference it rather than re-listing fields. A serialisation round-trip test pins the JSON shape. `Candidate` sets `model_config = {"frozen": True}` (pydantic v2), so in-process field assignment raises `ValidationError` at runtime, not just at review time; a test (`tests/test_ranker.py::test_candidate_is_frozen`) pins this. Reviewer checks any `Candidate` field change against this invariant.
 
 ---
 
@@ -145,7 +145,7 @@ Each invariant has a name, the rule, and the reason — the reason is what lets 
 
 **Reason:** like `Candidate` (INV-13), these models are consumed by many modules; a silent rename ripples across sizing, placement, reconciliation, and monitoring. Freezing them makes the dependency explicit and reviewable. This is the execution-side analogue of INV-13.
 
-**Enforcement:** a serialisation round-trip test pins each model's JSON shape; the field tables live in `docs/features/order-model-and-brackets.md` (and the persisted column lists in `order-placement.md`), and consumers reference them rather than re-listing fields. Reviewer checks any field change against this invariant.
+**Enforcement:** a serialisation round-trip test pins each model's JSON shape; the field tables live in `docs/features/order-model-and-brackets.md` (and the persisted column lists in `order-placement.md`), and consumers reference them rather than re-listing fields. `Order`, `Fill`, and `Position` each set `model_config = {"frozen": True}` (pydantic v2), so in-process field assignment raises `ValidationError` at runtime; tests (`tests/test_order_model.py::test_order_is_frozen`, `test_fill_is_frozen`, `test_position_is_frozen`) pin this. Reviewer checks any field change against this invariant.
 
 ---
 

--- a/execution/models.py
+++ b/execution/models.py
@@ -126,6 +126,8 @@ class Order(BaseModel):
     created_at        : UTC-aware order-creation time (INV-03).
     """
 
+    model_config = {"frozen": True}
+
     client_order_id: str
     instrument: str
     direction: Direction
@@ -183,6 +185,8 @@ class Fill(BaseModel):
     status          : ``filled`` | ``partial`` | ``rejected``.
     """
 
+    model_config = {"frozen": True}
+
     client_order_id: str
     broker_trade_id: str
     fill_price: float
@@ -236,6 +240,8 @@ class Position(BaseModel):
     realized_pl       : realised PnL, written on close (``None`` until then).
     candidate_ref     : provenance ``f"{instrument}:{timeframe}:{strategy_name}"``.
     """
+
+    model_config = {"frozen": True}
 
     broker_trade_id: str
     instrument: str

--- a/signals/ranker.py
+++ b/signals/ranker.py
@@ -108,6 +108,8 @@ class Candidate(BaseModel):
     generated_at    : UTC RFC-3339 string — the signal bar's close time (INV-03).
     """
 
+    model_config = {"frozen": True}
+
     instrument: str
     timeframe: str
     strategy_name: str

--- a/tests/test_order_model.py
+++ b/tests/test_order_model.py
@@ -391,6 +391,44 @@ def test_position_json_roundtrip_pins_shape() -> None:
     }
 
 
+def test_order_is_frozen() -> None:
+    order = build_bracket(_candidate(), 1000, execution_date=EXEC_DATE, precision=5)
+    with pytest.raises(ValidationError):
+        order.stop_loss_price = 0.0  # type: ignore[misc]
+
+
+def test_fill_is_frozen() -> None:
+    fill = Fill(
+        client_order_id="x" * 32,
+        broker_trade_id="t1",
+        fill_price=1.10,
+        units_filled=1000,
+        slippage=0.00012,
+        filled_at=EXEC_DATE,
+        status=FillStatus.FILLED,
+    )
+    with pytest.raises(ValidationError):
+        fill.fill_price = 0.0  # type: ignore[misc]
+
+
+def test_position_is_frozen() -> None:
+    pos = Position(
+        broker_trade_id="t1",
+        instrument="EUR_USD",
+        units=1000,
+        entry_price=1.10,
+        stop_loss_price=1.098,
+        take_profit_price=1.103,
+        opened_at=EXEC_DATE,
+        unrealized_pl=0.0,
+        closed_at=None,
+        realized_pl=None,
+        candidate_ref="EUR_USD:H1:macrossover",
+    )
+    with pytest.raises(ValidationError):
+        pos.unrealized_pl = 1.0  # type: ignore[misc]
+
+
 def test_candidate_ref_format() -> None:
     order = build_bracket(
         _candidate(instrument="EUR_USD", timeframe="H1", strategy_name="donchian_20"),

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 
 import pandas as pd
+import pydantic
 import pytest
 
 from data.calendar import CalendarEvent, Impact
@@ -517,6 +518,15 @@ def test_candidate_serialisation_round_trip() -> None:
     # generated_at is a UTC RFC-3339 ...Z string (INV-03).
     assert payload["generated_at"].endswith("Z")
     assert payload["direction"] in ("LONG", "SHORT")
+
+
+def test_candidate_is_frozen() -> None:
+    approved = [_row("s1", "EUR_USD", "H1", 1.0)]
+    spec = {("s1", "EUR_USD", "H1"): (Direction.LONG, 0.5)}
+    candidate = make_ranker(approved, spec).rank(NOW)[0]
+
+    with pytest.raises(pydantic.ValidationError):
+        candidate.stop_distance = 0.0  # type: ignore[misc]
 
 
 def test_generated_at_carries_signal_bar_close_time() -> None:


### PR DESCRIPTION
## Summary
- `Candidate` (signals/ranker.py) and `Order`/`Fill`/`Position` (execution/models.py) are documented as "frozen" wire contracts (INV-13/INV-14) but had no pydantic `frozen` config — in-process mutation was silently allowed.
- Adds `model_config = {"frozen": True}` to each model so field assignment raises `pydantic.ValidationError` at runtime.
- Amends INV-13 and INV-14 "Enforcement" lines to state the runtime-frozen config and the new pinning tests.
- No in-process mutation call sites found in production code (grepped for `.field =` assignments on these models) — no fixes needed there.

## Acceptance criteria
- [x] Constructing a `Candidate` then assigning any field raises `ValidationError` (`tests/test_ranker.py::test_candidate_is_frozen`)
- [x] Same for `Order`, `Fill`, `Position` (`tests/test_order_model.py::test_order_is_frozen`, `test_fill_is_frozen`, `test_position_is_frozen`)
- [x] All 4 new tests verified RED before the config change, GREEN after
- [x] INV-13/INV-14 enforcement lines updated in the same PR

## Gate output
`pytest -q` (full suite): 1181 passed, 1 skipped, 3 failed — all 3 pre-existing/known-flaky and unrelated to this change:
- `tests/test_execution_cli.py::TestCliHelp::test_fathom_help_lists_all_subcommands` (hardcoded path `/home/sam-baby/development/fathom`)
- `tests/test_panel_data.py::TestReadOnlyBoundary::test_panel_data_does_not_import_forbidden_modules` (hardcoded path)
- `tests/test_stream.py::TestPriceStreamReconnect::test_reconnect_on_heartbeat_timeout` (documented stream flake)

`mypy .`: 2 errors, both pre-existing baseline noted in the task brief:
- `data/store.py:1640: error: Unused "type: ignore" comment`
- `data/store.py:1695: error: Unused "type: ignore" comment`

Closes #142