### PR TITLE
fix(cli): refuse sizing when quote->account conversion rate missing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1614,13 +1614,16 @@ def cmd_execute(args: argparse.Namespace) -> int:
         return 1
 
     # quote_to_account_rate: for pairs where the quote currency is USD
-    # (e.g. EUR_USD) rate = 1.0; for others (e.g. USD_JPY) rate = 1/mid.
-    # Simple heuristic: if instrument ends in "_USD", rate = 1.0; otherwise
-    # load the latest close_mid from the candle store as the proxy rate.
-    # If unavailable, fall back to 1.0 with a warning (safe — sizing still runs,
-    # may reject on the minimum-trade-size floor if the rate is very wrong).
+    # (e.g. EUR_USD) rate = 1.0; for others (e.g. USD_JPY) rate = 1/mid,
+    # derived from the latest cached close_mid in the candle store.
+    #
+    # There is deliberately NO 1.0 fallback: for a JPY-quoted pair, rate = 1.0
+    # understates per-unit risk by the JPY mid (~150x), so the position would be
+    # sized ~150x the 0.25% risk intent (INV-05).  If the rate cannot be
+    # derived, we refuse to size and place no order — never guess (WS0-T02).
     rate: float = 1.0
     if not candidate.instrument.endswith("_USD"):
+        resolved_rate: Optional[float] = None
         store3 = Store(db_path)
         try:
             end_dt = datetime.now(tz=timezone.utc)
@@ -1631,19 +1634,44 @@ def cmd_execute(args: argparse.Namespace) -> int:
                 start=start_dt,
                 end=end_dt,
             )
-            if not candles.empty and "close_mid" in candles.columns:
-                last_mid = float(candles["close_mid"].iloc[-1])
+            if not candles.empty:
+                # ``load_candles`` returns bid/ask columns only — the mid is
+                # derived here.  (A ``close_mid`` column is honoured if a
+                # future loader adds one.)
+                if "close_mid" in candles.columns:
+                    last_mid = float(candles["close_mid"].iloc[-1])
+                elif {"close_bid", "close_ask"} <= set(candles.columns):
+                    last_mid = (
+                        float(candles["close_bid"].iloc[-1])
+                        + float(candles["close_ask"].iloc[-1])
+                    ) / 2.0
+                else:
+                    last_mid = 0.0
                 if last_mid > 0:
-                    rate = 1.0 / last_mid
+                    resolved_rate = 1.0 / last_mid
         except Exception as exc:  # noqa: BLE001
-            _log.warning(
-                "execute: could not derive quote→account rate for %s "
-                "(using 1.0 fallback): %s",
+            _log.error(
+                "execute: could not derive quote→account rate for %s: %s",
                 candidate.instrument,
                 exc,
             )
         finally:
             store3.close()
+
+        if resolved_rate is None:
+            _log.error(
+                "execute: SIZING REFUSED — no quote→account conversion rate "
+                "for %s; refusing to size rather than assume 1.0.",
+                candidate.instrument,
+            )
+            print(
+                "SIZING REFUSED: no quote->account conversion rate for "
+                f"{candidate.instrument} — refresh candles (fathom scan) and "
+                "retry. No order placed.",
+                file=sys.stderr,
+            )
+            return 1
+        rate = resolved_rate
 
     sizing_result = size_position(
         candidate,

--- a/docs/features/execution-cli.md
+++ b/docs/features/execution-cli.md
@@ -35,6 +35,11 @@ fathom execute <candidate-ref> [--db-path PATH] [--dry-run] [--yes]
    operator-initiated and infrequent, so it must not trust a stale `day_pl`).
 3. **Pre-trade check** ([[pretrade-check]]) → `block` aborts (exit non-zero, reason printed).
 4. **Sizing** ([[position-sizing]], using the freshly-fetched equity) → reject (size 0) aborts with the reason.
+   For a non-account-quote instrument (e.g. `USD_JPY` on a USD account) the CLI first
+   resolves `quote_to_account_rate` from the latest cached candle mid. If that rate
+   cannot be resolved, the CLI **refuses to size** (`SIZING REFUSED: no quote->account
+   conversion rate for <pair>`, exit 1, no order, applies to `--dry-run` too) — it never
+   assumes 1.0, which would mis-size a JPY-quoted pair by ~150x against the INV-05 cap.
 5. **Limits / kill switch** ([[risk-limits-kill-switch]], reading the fresh `account_state`) → reject aborts with the reason.
 6. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
 7. `--dry-run` runs steps 1–5 and prints what *would* be submitted without placing

--- a/docs/features/position-sizing.md
+++ b/docs/features/position-sizing.md
@@ -85,6 +85,14 @@ cached candle mid** for the conversion pair; `equity` is the live account-summar
 value fetched once by [[execution-cli]]. The freshness mismatch (cached rate vs live
 equity) is accepted — it perturbs the 0.25% cap by less than intraday rate drift.
 
+**Amended (WS0-T02):** the rate is *required*, never defaulted. If no recent cached
+mid exists for the conversion pair, [[execution-cli]] refuses to size — it prints
+`SIZING REFUSED: no quote->account conversion rate for <pair>`, exits non-zero, and
+places no order (also under `--dry-run`). Assuming `rate = 1.0` for a JPY-quoted pair
+understates per-unit risk by the JPY mid (~150x), sizing the position ~150x the 0.25%
+intent, so guessing is never acceptable. The mid is derived from the cached
+`close_bid`/`close_ask` of the instrument's own timeframe within the last 3 days.
+
 ## Out of scope
 
 - Book-level limits ([[risk-limits-kill-switch]]), submission ([[order-placement]]).

--- a/tests/test_execution_cli.py
+++ b/tests/test_execution_cli.py
@@ -40,7 +40,7 @@ import pytest
 
 import cli
 from data.store import Store
-from data.oanda_client import InstrumentMeta
+from data.oanda_client import CandleRow, InstrumentMeta
 from signals.ranker import Candidate
 from execution.models import Fill, FillStatus, Position
 from execution.reconcile import ReconcileReport
@@ -362,6 +362,177 @@ class TestExecuteSizingReject:
 
 
 # ---------------------------------------------------------------------------
+# 3b. Missing quote→account conversion rate → refuse (WS0-T02, INV-05)
+# ---------------------------------------------------------------------------
+
+
+def _make_jpy_candle(
+    close_mid: float = 157.0,
+    when: Optional[datetime] = None,
+) -> CandleRow:
+    """One complete USD_JPY H1 candle whose mid close is ``close_mid``."""
+    ts = when if when is not None else datetime.now(tz=timezone.utc)
+    spread = 0.01
+    bid = close_mid - spread / 2
+    ask = close_mid + spread / 2
+    return CandleRow(
+        instrument="USD_JPY",
+        granularity="H1",
+        time=ts,
+        open_bid=bid, high_bid=bid, low_bid=bid, close_bid=bid,
+        open_ask=ask, high_ask=ask, low_ask=ask, close_ask=ask,
+        open_mid=close_mid, high_mid=close_mid,
+        low_mid=close_mid, close_mid=close_mid,
+        volume=100,
+        complete=True,
+    )
+
+
+class TestExecuteConversionRateRequired:
+    """A non-USD-quoted instrument must never be sized with a guessed rate.
+
+    Falling back to ``rate = 1.0`` for USD_JPY overstates per-unit risk by the
+    JPY mid (~150x), so the position is sized ~150x the 0.25% INV-05 intent.
+    The gate must refuse instead of guessing.
+    """
+
+    @staticmethod
+    def _seed(db_path: str, *, with_candles: bool) -> Candidate:
+        candidate = _make_candidate(
+            instrument="USD_JPY",
+            timeframe="H1",
+            entry_ref=157.00,
+            stop_distance=0.20,
+            target_distance=0.30,
+        )
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        meta = _make_instrument_meta("USD_JPY").model_copy(
+            update={"pip_location": -2, "display_precision": 3}
+        )
+        store.upsert_instruments([meta])
+        if with_candles:
+            store.upsert([_make_jpy_candle()])
+        store.close()
+        return candidate
+
+    def test_missing_rate_refuses_before_any_order_work(
+        self, tmp_path: object
+    ) -> None:
+        """No cached mid → exit ≠ 0, clear stderr refusal, no sizing/limits/submit."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        self._seed(db_path, with_candles=False)
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+
+        size_spy = MagicMock()
+        bracket_spy = MagicMock()
+        limits_spy = MagicMock()
+        submit_spy = MagicMock()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=_make_reconcile_report()),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", size_spy),
+            patch("cli.build_bracket", bracket_spy),
+            patch("cli.check_limits", limits_spy),
+            patch("cli.submit_order", submit_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="USD_JPY:H1:macrossover_10_50",
+                dry_run=False,
+                yes=True,
+            )
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err), redirect_stdout(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert code == 1, "Missing conversion rate must exit non-zero"
+        err = buf_err.getvalue()
+        assert "SIZING REFUSED" in err, err
+        assert "conversion rate" in err, err
+        assert "USD_JPY" in err, err
+        size_spy.assert_not_called()
+        bracket_spy.assert_not_called()
+        limits_spy.assert_not_called()
+        submit_spy.assert_not_called()
+
+    def test_missing_rate_refuses_under_dry_run(self, tmp_path: object) -> None:
+        """--dry-run must refuse too: a silently mis-sized preview misleads."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        self._seed(db_path, with_candles=False)
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        size_spy = MagicMock()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=_make_reconcile_report()),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", size_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="USD_JPY:H1:macrossover_10_50",
+                dry_run=True,
+            )
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err), redirect_stdout(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert code == 1
+        assert "SIZING REFUSED" in buf_err.getvalue()
+        size_spy.assert_not_called()
+
+    def test_cached_rate_present_sizing_proceeds(self, tmp_path: object) -> None:
+        """Guard against over-refusing: a fresh cached mid → rate = 1/mid, sizing runs."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        self._seed(db_path, with_candles=True)
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+        from risk.sizing import SizingResult
+
+        proceed_verdict = PretradeVerdict(decision="proceed", reason="ok")
+        captured: dict[str, object] = {}
+
+        def spy_size_position(candidate, equity, **kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            return SizingResult(units=0, risk_amount=0.0, reason="spy stop")
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", return_value=_make_reconcile_report()),
+            patch("cli.pretrade_check", return_value=proceed_verdict),
+            patch("cli.size_position", side_effect=spy_size_position),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="USD_JPY:H1:macrossover_10_50",
+                dry_run=True,
+            )
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err), redirect_stdout(io.StringIO()):
+                cli.cmd_execute(args)
+
+        assert "SIZING REFUSED" not in buf_err.getvalue()
+        assert "rate" in captured, "size_position was not called"
+        assert captured["rate"] == pytest.approx(1.0 / 157.0)
+
+
+# ---------------------------------------------------------------------------
 # 4. Limits reject — kill switch active
 # ---------------------------------------------------------------------------
 
@@ -580,7 +751,11 @@ class TestExecuteSuccess:
             patch("cli.size_position", return_value=sizing_ok),
             patch("cli.submit_order", return_value=fill),
         ):
-            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            args = _make_namespace(
+                db_path=db_path,
+                dry_run=False,
+                yes=True,
+            )
             buf_out = io.StringIO()
             with redirect_stdout(buf_out):
                 code = cli.cmd_execute(args)
@@ -624,7 +799,11 @@ class TestExecuteSuccess:
             patch("cli.size_position", return_value=sizing_ok),
             patch("cli.submit_order", side_effect=reject_order),
         ):
-            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            args = _make_namespace(
+                db_path=db_path,
+                dry_run=False,
+                yes=True,
+            )
             buf_err = io.StringIO()
             with redirect_stderr(buf_err):
                 code = cli.cmd_execute(args)
@@ -880,7 +1059,11 @@ class TestGateOrdering:
             patch("cli.check_limits", side_effect=track_check_limits),
             patch("cli.submit_order", side_effect=track_submit),
         ):
-            args = _make_namespace(db_path=db_path, dry_run=False, yes=True)
+            args = _make_namespace(
+                db_path=db_path,
+                dry_run=False,
+                yes=True,
+            )
             with redirect_stdout(io.StringIO()):
                 code = cli.cmd_execute(args)
 


### PR DESCRIPTION
## What

`cmd_execute`'s sizing step fell back to `quote_to_account_rate = 1.0` with a warning when no cached mid existed for a non-account-quote instrument. For `USD_JPY` (quote JPY, USD account) that understates per-unit risk by the JPY mid — the position is sized ~150x the 0.25% INV-05 risk intent. Real money.

Now the gate refuses rather than guessing.

## Second bug found while implementing

`Store.load_candles` returns **bid/ask columns only** — there is no `close_mid` column. The old lookup guarded on `"close_mid" in candles.columns`, so it could *never* succeed: every non-USD-quoted pair silently took the 1.0 fallback, always. A pure refusal-on-missing-rate change would therefore have refused 100% of JPY/CHF/CAD-quoted trades. This PR also derives the mid from `close_bid`/`close_ask`, so the happy path actually works (and the "cached rate present" test pins it).

## Acceptance criteria

- [x] No cached mid for the conversion pair → exit 1, stderr `SIZING REFUSED: no quote->account conversion rate for USD_JPY — refresh candles (fathom scan) and retry. No order placed.`
- [x] `size_position`, `build_bracket`, `check_limits`, `submit_order` all asserted **not called** on the refusal path.
- [x] `--dry-run` refuses identically (a silently mis-sized preview misleads the operator).
- [x] Blast-radius other side: a fresh cached candle → sizing proceeds with `rate == 1/157.0` (guards against over-refusing).
- [x] EUR_USD / `_USD`-quoted happy path unchanged (`rate = 1.0`, no store read).
- [x] Spec sweep: `docs/features/position-sizing.md` (AMBIGUOUS-02 amended — rate is required, never defaulted) and `docs/features/execution-cli.md` (step 4 states the refusal semantics).

## Invariants touched

- **INV-05** (0.25% risk cap) — preserved: an unresolvable rate can no longer produce a size that violates the cap; the trade is refused instead.
- **INV-01** (execution boundary) — untouched; refusal happens inside `cmd_execute`, no Hermes surface changes.

## Gate

```
1212 passed, 1 skipped, 83 warnings in 39.35s
Success: no issues found in 92 source files
```

## For the reviewer to probe

The mid-derivation fix widens the change beyond the issue text. Confirm you agree that deriving the mid from bid/ask is the right resolution rather than refusing everything non-USD-quoted — the alternative reading of #135 makes the CLI unable to trade any JPY pair.

Closes #135