### PR TITLE
WS0-T04: candidate freshness TTL in the execute gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ LIVE_TRADING_ENABLED=false
 # Default 0.001 (0.10%). Validated at startup; a value outside the range raises immediately.
 LIVE_RISK_FRACTION=0.001
 
+# Candidate freshness TTL (WS0-T04): a watchlist candidate expires after this
+# many bars of its OWN timeframe (H1=1h, H4=4h, D=24h). `fathom execute`
+# refuses stale candidates before any downstream gate step. Default 1.0.
+MAX_CANDIDATE_AGE_BARS=1.0
+
 # Pre-trade veto LLM (provider-agnostic, OpenAI-compatible chat completions).
 # Leave blank to run without a veto client — the gate then fails closed to "block" (INV-02).
 # INV-08: never commit the real key — this is a placeholder only.

--- a/cli.py
+++ b/cli.py
@@ -212,6 +212,14 @@ WINDOW_CONFIG: dict[str, WindowConfig] = {
     "D": WindowConfig(train_months=24, test_months=6),
 }
 
+#: Bar length per timeframe, used for the candidate freshness TTL check
+#: (WS0-T04) in ``cmd_execute``. Keys must match ``Candidate.timeframe``.
+TIMEFRAME_BAR_LENGTH: dict[str, timedelta] = {
+    "H1": timedelta(hours=1),
+    "H4": timedelta(hours=4),
+    "D": timedelta(hours=24),
+}
+
 #: History to fetch/scan per timeframe must comfortably exceed the longest
 #: train+test span so at least one window forms. The default below (3 years)
 #: covers D (24m+6m = 30m) with margin; overridable via --history-years.
@@ -1415,6 +1423,48 @@ def _load_candidate(
     return (candidate, None)
 
 
+def _candidate_staleness_error(
+    candidate: object,
+    max_candidate_age_bars: float,
+    *,
+    now: datetime,
+) -> Optional[str]:
+    """Return a refusal message if ``candidate`` is stale, else ``None``.
+
+    WS0-T04: a candidate loaded from the watchlist carries an ``entry_ref``
+    (and derived stop/target) anchored to the signal bar's close time
+    (``generated_at``, INV-03 UTC). If too much time has elapsed since then,
+    that anchor is no longer representative and realized R:R drifts with
+    every hour of delay. Staleness is measured in units of the candidate's
+    OWN timeframe bar length (H1=1h, H4=4h, D=24h) so the limit scales
+    naturally across timeframes.
+    """
+    timeframe = candidate.timeframe  # type: ignore[attr-defined]
+    bar_length = TIMEFRAME_BAR_LENGTH.get(timeframe)
+    if bar_length is None:
+        # Unknown timeframe: nothing to compare against — let downstream
+        # gates handle it (should not happen for a watchlist-persisted ref).
+        return None
+
+    generated_at_raw = candidate.generated_at  # type: ignore[attr-defined]
+    s = str(generated_at_raw).rstrip("Z")
+    generated_at = datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+    age = now - generated_at
+    limit = bar_length * max_candidate_age_bars
+    if age <= limit:
+        return None
+
+    age_hours = age.total_seconds() / 3600.0
+    limit_hours = limit.total_seconds() / 3600.0
+    ref = f"{candidate.instrument}:{timeframe}:{candidate.strategy_name}"  # type: ignore[attr-defined]
+    return (
+        f"STALE CANDIDATE REFUSED: {ref} is {age_hours:.1f}h old "
+        f"(limit {limit_hours:.1f}h = {max_candidate_age_bars:g} x {timeframe} bar). "
+        "Re-run fathom scan. No order placed."
+    )
+
+
 def cmd_execute(args: argparse.Namespace) -> int:
     """Execute the ``fathom execute <candidate-ref>`` command.
 
@@ -1466,11 +1516,31 @@ def cmd_execute(args: argparse.Namespace) -> int:
     )
 
     # ------------------------------------------------------------------
+    # Step 1.5: Candidate freshness TTL (WS0-T04). Refuse a stale watchlist
+    # entry BEFORE any downstream gate step (reconcile/pretrade/sizing/
+    # limits/submit) runs — a stale entry_ref must never reach an order.
+    # ------------------------------------------------------------------
+    settings = Settings()
+    try:
+        max_candidate_age_bars = float(settings.max_candidate_age_bars)
+    except (TypeError, ValueError, AttributeError):
+        # Defensive fallback (e.g. Settings mocked/faked without this
+        # attribute configured in tests) — the documented default.
+        max_candidate_age_bars = 1.0
+
+    staleness_error = _candidate_staleness_error(
+        candidate, max_candidate_age_bars, now=run_dt
+    )
+    if staleness_error is not None:
+        _log.error("execute: %s", staleness_error)
+        print(f"ERROR: {staleness_error}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
     # Step 2: Fresh reconcile BEFORE limits (AMBIGUOUS-03).
     # Refresh account_state (day_pl, start_of_day_equity) and open
     # positions from the broker so the kill switch reads current data.
     # ------------------------------------------------------------------
-    settings = Settings()
     _log.info("execute: connecting to OANDA (env=%s).", settings.env)  # INV-08: no token
     client = OandaClient(settings)
     store = Store(db_path)

--- a/config/settings.py
+++ b/config/settings.py
@@ -68,6 +68,21 @@ class Settings(BaseSettings):
         ),
     )
 
+    #: Candidate freshness TTL, in units of the candidate's OWN timeframe bar
+    #: length (H1=1h, H4=4h, D=24h). A candidate older than this many bars
+    #: (measured against ``Candidate.generated_at``, the signal bar's close
+    #: time) is refused at ``fathom execute`` load time (WS0-T04) — its
+    #: entry_ref/stop/target were anchored to a scan that is no longer
+    #: representative of the current market. Default 1.0 = one full bar.
+    max_candidate_age_bars: float = Field(
+        default=1.0,
+        gt=0.0,
+        description=(
+            "Candidate expires after this many bars of its own timeframe "
+            "(e.g. 1.0 x H4 = 4h). Enforced at fathom execute load time."
+        ),
+    )
+
     # --- Pre-trade veto LLM (provider-agnostic, OpenAI-compatible) ---------
     #: API key for the OpenAI-compatible endpoint backing the pre-trade veto.
     #: Optional: absent → the veto has no client and fails closed to ``block``

--- a/docs/features/execution-cli.md
+++ b/docs/features/execution-cli.md
@@ -29,20 +29,29 @@ fathom execute <candidate-ref> [--db-path PATH] [--dry-run] [--yes]
    run; error if it isn't on the latest watchlist (no executing arbitrary input).
    The full `Candidate` row (incl. `generated_at`) is loaded so the
    `client_order_id` (INV-15) is reconstructible.
-2. **Fresh reconcile** ([[reconciliation]]): fetch account summary + broker open
+2. **Candidate freshness TTL** (WS0-T04): refuse the candidate if it is older
+   than `max_candidate_age_bars` (`.env` `MAX_CANDIDATE_AGE_BARS`, default
+   `1.0`) bars of its **own** timeframe (H1=1h, H4=4h, D=24h), measured
+   against `Candidate.generated_at` (the signal bar's close time, INV-03
+   UTC) vs. now. This runs immediately after load and **before reconcile** —
+   a stale scan-time `entry_ref` must never reach an order (its realized
+   R:R drifts with every hour of delay). Refusal prints `STALE CANDIDATE
+   REFUSED: <ref> is <Xh> old (limit <Yh> = N x <TF> bar)` to stderr, exit
+   1, no downstream gate step runs; applies to `--dry-run` too.
+3. **Fresh reconcile** ([[reconciliation]]): fetch account summary + broker open
    trades and refresh the `account_state` (`day_pl`, `start_of_day_equity`) and
    `positions` *before* the limits check (AMBIGUOUS-03 — `fathom execute` is
    operator-initiated and infrequent, so it must not trust a stale `day_pl`).
-3. **Pre-trade check** ([[pretrade-check]]) → `block` aborts (exit non-zero, reason printed).
-4. **Sizing** ([[position-sizing]], using the freshly-fetched equity) → reject (size 0) aborts with the reason.
+4. **Pre-trade check** ([[pretrade-check]]) → `block` aborts (exit non-zero, reason printed).
+5. **Sizing** ([[position-sizing]], using the freshly-fetched equity) → reject (size 0) aborts with the reason.
    For a non-account-quote instrument (e.g. `USD_JPY` on a USD account) the CLI first
    resolves `quote_to_account_rate` from the latest cached candle mid. If that rate
    cannot be resolved, the CLI **refuses to size** (`SIZING REFUSED: no quote->account
    conversion rate for <pair>`, exit 1, no order, applies to `--dry-run` too) — it never
    assumes 1.0, which would mis-size a JPY-quoted pair by ~150x against the INV-05 cap.
-5. **Limits / kill switch** ([[risk-limits-kill-switch]], reading the fresh `account_state`) → reject aborts with the reason.
-6. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
-7. `--dry-run` runs steps 1–5 and prints what *would* be submitted without placing
+6. **Limits / kill switch** ([[risk-limits-kill-switch]], reading the fresh `account_state`) → reject aborts with the reason.
+7. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
+8. `--dry-run` runs steps 1–6 and prints what *would* be submitted without placing
    an order (safe rehearsal). `--yes` skips an interactive confirm.
 
 Read-only helpers: `fathom positions` (print open `Position[]` JSON), `fathom
@@ -51,7 +60,8 @@ reconcile` (run [[reconciliation]] once, print the report).
 ## Acceptance criteria
 
 - [ ] `fathom execute` only accepts a candidate present on the persisted watchlist; an unknown ref errors without side effects (no executing off-watchlist input).
-- [ ] The gate order is exactly pretrade-check → sizing → limits → submit; **any** stage's rejection aborts with a clear reason and a non-zero exit, and no order is placed.
+- [ ] The gate order is exactly candidate-freshness → reconcile → pretrade-check → sizing → limits → submit; **any** stage's rejection aborts with a clear reason and a non-zero exit, and no order is placed.
+- [ ] A candidate older than `max_candidate_age_bars` bars of its own timeframe is refused before reconcile runs (WS0-T04); the limit is per-timeframe (H1=1h, H4=4h, D=24h).
 - [ ] `--dry-run` performs checks 1–5 and prints the would-be order **without** any v20 submission (verified — no order endpoint called).
 - [ ] A successful run prints the `Fill` (fill price, units, slippage, trade id) and persists state; re-running the same execute is idempotent (no double-fill, via [[order-placement]]).
 - [ ] When the kill switch is active, `fathom execute` refuses and reports the kill-switch status.

--- a/tests/test_execution_cli.py
+++ b/tests/test_execution_cli.py
@@ -32,7 +32,7 @@ import io
 import json
 import sys
 from contextlib import redirect_stdout, redirect_stderr
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from unittest.mock import MagicMock, patch, call
 
@@ -64,7 +64,13 @@ def _make_candidate(
     entry_ref: float = 1.1050,
     stop_distance: float = 0.0020,
     target_distance: float = 0.0030,
+    generated_at: Optional[str] = None,
 ) -> Candidate:
+    # Default to "just now" (RFC-3339 UTC) so the freshness (TTL) check
+    # doesn't refuse candidates in tests that aren't specifically exercising
+    # staleness. Tests that DO care about age pass an explicit generated_at.
+    if generated_at is None:
+        generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return Candidate(
         instrument=instrument,
         timeframe=timeframe,
@@ -79,7 +85,7 @@ def _make_candidate(
         spread_ok=True,
         session_ok=True,
         news_flag=False,
-        generated_at="2026-04-10T12:00:00Z",
+        generated_at=generated_at,
     )
 
 
@@ -1145,6 +1151,195 @@ class TestGateOrdering:
 
         assert code != 0
         limits_mock.assert_not_called()  # check_limits must NOT be called after sizing reject
+
+
+# ---------------------------------------------------------------------------
+# Candidate freshness TTL (WS0-T04): stale watchlist entries are refused
+# immediately after load, BEFORE reconcile/pretrade/sizing/limits run.
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateFreshnessTTL:
+    """A candidate older than ``max_candidate_age_bars`` × its own bar length
+    must be refused before any downstream gate step (reconcile, pretrade,
+    sizing, limits, submit) runs — order/stop/target must never be anchored
+    to a stale scan-time entry_ref.
+    """
+
+    @staticmethod
+    def _age_offset_generated_at(hours: float) -> str:
+        gen_dt = datetime.now(tz=timezone.utc) - timedelta(hours=hours)
+        return gen_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @staticmethod
+    def _spies() -> "tuple[MagicMock, MagicMock, MagicMock, MagicMock]":
+        return (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+    def test_stale_h4_candidate_refused_before_reconcile(
+        self, tmp_path: object
+    ) -> None:
+        """An H4 candidate 5h old (limit 4h) is refused; no gate step runs."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate(
+            timeframe="H4",
+            generated_at=self._age_offset_generated_at(5.0),
+        )
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        reconcile_spy, pretrade_spy, sizing_spy, limits_spy = self._spies()
+        submit_spy = MagicMock()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", reconcile_spy),
+            patch("cli.pretrade_check", pretrade_spy),
+            patch("cli.size_position", sizing_spy),
+            patch("cli.check_limits", limits_spy),
+            patch("cli.submit_order", submit_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="EUR_USD:H4:macrossover_10_50",
+                dry_run=False,
+                yes=True,
+            )
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err), redirect_stdout(io.StringIO()):
+                code = cli.cmd_execute(args)
+
+        assert code != 0, "Stale candidate must exit non-zero"
+        err = buf_err.getvalue()
+        assert "STALE CANDIDATE REFUSED" in err, err
+        assert "H4" in err, err
+        assert "4.0h" in err or "4h" in err, err
+        reconcile_spy.assert_not_called()
+        pretrade_spy.assert_not_called()
+        sizing_spy.assert_not_called()
+        limits_spy.assert_not_called()
+        submit_spy.assert_not_called()
+
+    def test_fresh_h4_candidate_proceeds_past_age_check(
+        self, tmp_path: object
+    ) -> None:
+        """A 3h-old H4 candidate (within the 4h limit) proceeds to reconcile."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate(
+            timeframe="H4",
+            generated_at=self._age_offset_generated_at(3.0),
+        )
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+
+        reconcile_spy = MagicMock(return_value=_make_reconcile_report())
+        pretrade_spy = MagicMock(
+            return_value=PretradeVerdict(decision="block", reason="stop here")
+        )
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", reconcile_spy),
+            patch("cli.pretrade_check", pretrade_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="EUR_USD:H4:macrossover_10_50",
+                dry_run=True,
+            )
+            with redirect_stderr(io.StringIO()):
+                cli.cmd_execute(args)
+
+        reconcile_spy.assert_called_once()
+        pretrade_spy.assert_called_once()
+
+    def test_stale_refusal_applies_under_dry_run(self, tmp_path: object) -> None:
+        """--dry-run must also refuse a stale candidate (no misleading preview)."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate(
+            timeframe="H4",
+            generated_at=self._age_offset_generated_at(5.0),
+        )
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        reconcile_spy = MagicMock()
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", reconcile_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="EUR_USD:H4:macrossover_10_50",
+                dry_run=True,
+            )
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                code = cli.cmd_execute(args)
+
+        assert code != 0
+        assert "STALE CANDIDATE REFUSED" in buf_err.getvalue()
+        reconcile_spy.assert_not_called()
+
+    def test_stale_limit_is_per_timeframe_daily_candidate_proceeds(
+        self, tmp_path: object
+    ) -> None:
+        """A D-timeframe candidate 20h old (limit 24h) proceeds — per-timeframe limit."""
+        from pathlib import Path
+        db_path = str(Path(str(tmp_path)) / "test.db")
+        candidate = _make_candidate(
+            timeframe="D",
+            generated_at=self._age_offset_generated_at(20.0),
+        )
+
+        store = Store(db_path)
+        _seed_watchlist(store, candidate)
+        _seed_account_state(store, start_of_day_equity=100_000.0)
+        store.upsert_instruments([_make_instrument_meta()])
+        store.close()
+
+        from hermes_integration.pretrade_check import PretradeVerdict
+
+        reconcile_spy = MagicMock(return_value=_make_reconcile_report())
+        pretrade_spy = MagicMock(
+            return_value=PretradeVerdict(decision="block", reason="stop here")
+        )
+
+        with (
+            patch("cli.Settings"),
+            patch("cli.OandaClient"),
+            patch("cli.reconcile", reconcile_spy),
+            patch("cli.pretrade_check", pretrade_spy),
+        ):
+            args = _make_namespace(
+                db_path=db_path,
+                candidate_ref="EUR_USD:D:macrossover_10_50",
+                dry_run=True,
+            )
+            with redirect_stderr(io.StringIO()):
+                cli.cmd_execute(args)
+
+        reconcile_spy.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_live_gate.py
+++ b/tests/test_live_gate.py
@@ -309,6 +309,9 @@ def _utc(y: int, m: int, d: int, h: int = 0, mi: int = 0) -> datetime:
 
 
 def _make_candidate() -> Candidate:
+    # generated_at defaults to "just now" so this candidate is never refused
+    # by the WS0-T04 freshness TTL check in tests that aren't exercising it.
+    generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return Candidate(
         instrument="EUR_USD",
         timeframe="H1",
@@ -323,7 +326,7 @@ def _make_candidate() -> Candidate:
         spread_ok=True,
         session_ok=True,
         news_flag=False,
-        generated_at="2026-04-10T12:00:00Z",
+        generated_at=generated_at,
     )
 
 


### PR DESCRIPTION
## Summary
- `cmd_execute` previously loaded a watchlist candidate with no age check — an H4 candidate could execute 24h+ after its bar closed, with the order's stop/target anchored to the stale scan-time `entry_ref`.
- Adds `Settings.max_candidate_age_bars` (default `1.0`, per-timeframe bar length: H1=1h, H4=4h, D=24h) and a freshness check that runs in `cmd_execute` immediately after candidate load, **before** reconcile/pretrade/sizing/limits/submit.
- Stale refusal: `STALE CANDIDATE REFUSED: <ref> is <Xh> old (limit <Yh> = N x <TF> bar). Re-run fathom scan. No order placed.` — exit 1, applies under `--dry-run` too.

## Acceptance criteria
- [x] H4 candidate 5h old (limit 4h) → non-zero exit, refusal naming age+limit on stderr, no reconcile/pretrade/sizing/limits/submit call.
- [x] 3h-old H4 candidate proceeds past the age check.
- [x] Refusal also applies under `--dry-run`.
- [x] D-timeframe candidate 20h old (limit 24h) proceeds — limit is per-timeframe.
- [x] `.env.example` updated; drift-guard test `test_env_example_keys_match_settings_fields` passes.
- [x] `docs/features/execution-cli.md` gate-step list + AC updated.

## Test plan / gates
- `pytest tests/test_execution_cli.py -q` → 32 passed
- Full suite: `pytest -q` → 1216 passed, 1 skipped (one unrelated flaky stream-reconnect test passed standalone and on rerun)
- `mypy .` → Success: no issues found in 92 source files
- Also fixed a regression the new check exposed in `tests/test_live_gate.py`'s fixed `generated_at` fixture (now dynamic "just now" like `test_execution_cli.py`'s `_make_candidate`).

## Context delta
- New Settings field `max_candidate_age_bars` (config/settings.py) + `.env.example` entry `MAX_CANDIDATE_AGE_BARS`.
- New `cli.TIMEFRAME_BAR_LENGTH` mapping and `cli._candidate_staleness_error` helper.
- `docs/features/execution-cli.md` gate step numbering shifted (freshness check inserted as step 2).

Closes #137