### PR TITLE
docs(ws0-t07): reconcile operator docs with code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ fathom chart <instrument>     # render candidate chart PNG, print path (Hermes t
 
 # Phase 3 (current) — P3-T-10 — INV-01 gate (operator-only, NEVER Hermes tools)
 fathom execute <candidate-ref>  # run full Phase 3 gate (pretrade → sizing → limits → submit)
-#   fathom execute EUR_USD:H1:macrossover_10_50 [--db-path PATH] [--dry-run] [--yes]
+#   fathom execute "EUR_USD:D:BollingerReversion(20,2.0)" [--db-path PATH] [--dry-run] [--yes]
 #   candidate-ref format: instrument:timeframe:strategy_name (must be on latest watchlist)
 #   --dry-run: runs gate steps 1-5, prints would-be order without any v20 submission
 #   --yes: skip the interactive confirm prompt

--- a/cli.py
+++ b/cli.py
@@ -861,7 +861,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "candidate_ref",
         help=(
             "Candidate reference: instrument:timeframe:strategy_name, "
-            "e.g. EUR_USD:H1:macrossover_10_50_eur_usd_h1. "
+            "e.g. EUR_USD:D:BollingerReversion(20,2.0). "
             "Must be present on the latest persisted watchlist (INV-13)."
         ),
     )
@@ -1391,7 +1391,7 @@ def _load_candidate(
             (
                 f"Invalid candidate ref {candidate_ref!r}: expected "
                 "instrument:timeframe:strategy_name "
-                "(e.g. EUR_USD:H1:macrossover_10_50).",
+                "(e.g. EUR_USD:D:BollingerReversion(20,2.0)).",
                 2,
             ),
         )
@@ -1814,10 +1814,13 @@ def cmd_execute(args: argparse.Namespace) -> int:
     # (e.g. EUR_USD) rate = 1.0; for others (e.g. USD_JPY) rate = 1/mid,
     # derived from the latest cached close_mid in the candle store.
     #
-    # There is deliberately NO 1.0 fallback: for a JPY-quoted pair, rate = 1.0
-    # understates per-unit risk by the JPY mid (~150x), so the position would be
-    # sized ~150x the 0.25% risk intent (INV-05).  If the rate cannot be
-    # derived, we refuse to size and place no order — never guess (WS0-T02).
+    # There is deliberately NO 1.0 fallback: assuming rate = 1.0 mis-sizes in
+    # both directions depending on the quote currency. For a JPY-quoted pair
+    # it understates per-unit risk by the JPY mid (~157x), under-sizing the
+    # position; for a quote currency stronger than USD (e.g. GBP-quoted,
+    # ~27%) it overstates per-unit risk, over-sizing the position relative to
+    # the 0.25% risk intent (INV-05). If the rate cannot be derived, we
+    # refuse to size and place no order — never guess (WS0-T02).
     rate: float = 1.0
     if not candidate.instrument.endswith("_USD"):
         resolved_rate: Optional[float] = None

--- a/docs/features/execution-cli.md
+++ b/docs/features/execution-cli.md
@@ -48,7 +48,9 @@ fathom execute <candidate-ref> [--db-path PATH] [--dry-run] [--yes]
    resolves `quote_to_account_rate` from the latest cached candle mid. If that rate
    cannot be resolved, the CLI **refuses to size** (`SIZING REFUSED: no quote->account
    conversion rate for <pair>`, exit 1, no order, applies to `--dry-run` too) — it never
-   assumes 1.0, which would mis-size a JPY-quoted pair by ~150x against the INV-05 cap.
+   assumes 1.0, which would understate risk (under-size) by ~157x for a JPY-quoted
+   pair, or overstate risk (over-size) for a quote currency stronger than USD (e.g.
+   GBP-quoted, ~27%), against the INV-05 cap.
 6. **Limits / kill switch** ([[risk-limits-kill-switch]], reading the fresh `account_state`) → reject aborts with the reason.
 7. **Submit** ([[order-placement]]) the bracketed, idempotent order; print the `Fill`.
 8. `--dry-run` runs steps 1–6 and prints what *would* be submitted without placing

--- a/docs/features/position-sizing.md
+++ b/docs/features/position-sizing.md
@@ -88,10 +88,18 @@ equity) is accepted — it perturbs the 0.25% cap by less than intraday rate dri
 **Amended (WS0-T02):** the rate is *required*, never defaulted. If no recent cached
 mid exists for the conversion pair, [[execution-cli]] refuses to size — it prints
 `SIZING REFUSED: no quote->account conversion rate for <pair>`, exits non-zero, and
-places no order (also under `--dry-run`). Assuming `rate = 1.0` for a JPY-quoted pair
-understates per-unit risk by the JPY mid (~150x), sizing the position ~150x the 0.25%
-intent, so guessing is never acceptable. The mid is derived from the cached
+places no order (also under `--dry-run`). Assuming `rate = 1.0` mis-sizes in both
+directions depending on the quote currency: for a JPY-quoted pair it *understates*
+per-unit risk by the JPY mid (~157x), under-sizing the position to ~1/157th of the
+0.25% intent; for a quote currency stronger than USD (e.g. GBP-quoted, ~27%) it
+*overstates* per-unit risk, over-sizing the position relative to the 0.25% cap. Either
+way guessing is never acceptable. The mid is derived from the cached
 `close_bid`/`close_ask` of the instrument's own timeframe within the last 3 days.
+
+For cross pairs (e.g. `EUR_JPY` on a USD account), the conversion is approximated
+using the instrument's own mid rather than a true cross-rate computation; this is a
+bounded approximation (~10% error) and is accepted as-is (no separate cross-rate
+lookup is performed).
 
 ## Out of scope
 

--- a/docs/go-live-runbook.md
+++ b/docs/go-live-runbook.md
@@ -179,7 +179,7 @@ subcommand takes a single positional `candidate_ref` in the form
 ```bash
 fathom execute <instrument>:<timeframe>:<strategy_name>
 # e.g.
-fathom execute EUR_USD:H1:macrossover_10_50_eur_usd_h1
+fathom execute "EUR_USD:D:BollingerReversion(20,2.0)"
 ```
 
 Optional flags: `--db-path PATH` (default `data/fathom.db`), `--dry-run`

--- a/docs/operator-acceptance.md
+++ b/docs/operator-acceptance.md
@@ -75,8 +75,8 @@ Full procedure: `hermes_integration/jobs/daily.md → Operator runbook`.
 # with LLM_API_KEY set (so the pre-trade veto can return proceed;
 # LLM_BASE_URL/LLM_MODEL default to https://api.openai.com/v1 + gpt-5-nano):
 fathom scan --db-path data/fathom.db            # refresh the watchlist
-fathom execute EUR_USD:D:BollingerReversion(20,2.0) --db-path data/fathom.db
-scripts/run_monitor.py --instruments EUR_USD --db-path data/fathom.db   # always-on, separate terminal
+fathom execute "EUR_USD:D:BollingerReversion(20,2.0)" --db-path data/fathom.db
+python scripts/run_monitor.py --instruments EUR_USD --db-path data/fathom.db   # always-on, separate terminal
 fathom reconcile --db-path data/fathom.db
 ```
 

--- a/hermes_integration/__init__.py
+++ b/hermes_integration/__init__.py
@@ -8,7 +8,8 @@ Modules:
         (Phase 2, Hermes-side; no anthropic SDK dependency here).
     pretrade_check: PretradeVerdict model + parse_pretrade_verdict() +
         pretrade_check() — INV-02 in-process Claude veto before order
-        submission (Phase 3).  Uses the anthropic SDK via an injectable
+        submission (Phase 3).  Uses an OpenAI-compatible adapter (any
+        provider via LLM_API_KEY/LLM_BASE_URL/LLM_MODEL) via an injectable
         _LiveClient adapter; fully testable offline.
     narration: fallback_narration() — cosmetic watchlist one-liner (Phase 2).
 """

--- a/hermes_integration/jobs/daily.md
+++ b/hermes_integration/jobs/daily.md
@@ -229,7 +229,10 @@ Before registering this job, ensure the following are available:
    candle cache before the first Hermes run.
 4. **Discord webhook or bot token** — a Discord channel where the watchlist
    will be posted.
-5. **Anthropic API key** — for Hermes' Claude calls (news-risk + narration).
+5. **Hermes-side Anthropic API key** — for Hermes' own Claude calls (news-risk +
+   narration). Distinct from the Fathom-side `LLM_API_KEY` used by the in-process
+   pre-trade veto (any OpenAI-compatible provider) — that key is not needed for
+   this job, since order execution is out of scope here (INV-01).
 
 ### Credentials and secrets (INV-08)
 
@@ -242,9 +245,9 @@ DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
 # (or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID for bot approach)
 
 # Fathom-side (if Hermes calls fathom scan live — not --dry-run)
-OANDA_API_KEY=...
+OANDA_API_TOKEN=...
 OANDA_ACCOUNT_ID=...
-OANDA_ENV=practice
+ENV=demo
 ```
 
 Hermes passes these to its tool calls via environment injection — never as

--- a/tests/test_docs_lint.py
+++ b/tests/test_docs_lint.py
@@ -1,0 +1,52 @@
+"""Doc-lint guard (WS0-T07): dead names must never reappear in operator docs.
+
+Plain file-content assertions — no markdown parsing needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class TestNoDeadEnvVarNames:
+    """OANDA_API_KEY / OANDA_ENV were renamed to OANDA_API_TOKEN / ENV."""
+
+    def test_hermes_jobs_docs_do_not_use_dead_env_var_names(self) -> None:
+        jobs_dir = REPO_ROOT / "hermes_integration" / "jobs"
+        for md_path in jobs_dir.glob("*.md"):
+            text = _read(md_path)
+            assert "OANDA_API_KEY" not in text, (
+                f"{md_path} still references dead env var OANDA_API_KEY "
+                "(use OANDA_API_TOKEN)"
+            )
+            assert "OANDA_ENV" not in text, (
+                f"{md_path} still references dead env var OANDA_ENV "
+                "(use ENV)"
+            )
+
+    def test_operator_acceptance_does_not_use_dead_env_var_names(self) -> None:
+        text = _read(REPO_ROOT / "docs" / "operator-acceptance.md")
+        assert "OANDA_API_KEY" not in text
+        assert "OANDA_ENV" not in text
+
+
+class TestNoInventedCandidateRefFormat:
+    """The real candidate-ref format is instrument:timeframe:StrategyName(params)."""
+
+    def test_claude_md_does_not_use_invented_candidate_ref(self) -> None:
+        text = _read(REPO_ROOT / "CLAUDE.md")
+        assert "macrossover_10_50" not in text
+
+    def test_go_live_runbook_does_not_use_invented_candidate_ref(self) -> None:
+        text = _read(REPO_ROOT / "docs" / "go-live-runbook.md")
+        assert "macrossover_10_50" not in text
+
+    def test_cli_does_not_use_invented_candidate_ref(self) -> None:
+        text = _read(REPO_ROOT / "cli.py")
+        assert "macrossover_10_50" not in text

--- a/tests/test_execution_cli.py
+++ b/tests/test_execution_cli.py
@@ -397,9 +397,9 @@ def _make_jpy_candle(
 class TestExecuteConversionRateRequired:
     """A non-USD-quoted instrument must never be sized with a guessed rate.
 
-    Falling back to ``rate = 1.0`` for USD_JPY overstates per-unit risk by the
-    JPY mid (~150x), so the position is sized ~150x the 0.25% INV-05 intent.
-    The gate must refuse instead of guessing.
+    Falling back to ``rate = 1.0`` for USD_JPY understates per-unit risk by
+    the JPY mid (~157x), so the position would be under-sized relative to
+    the 0.25% INV-05 intent. The gate must refuse instead of guessing.
     """
 
     @staticmethod
@@ -987,7 +987,7 @@ class TestInv01Boundary:
 
 
 class TestCliHelp:
-    def test_fathom_help_lists_all_subcommands(self, capsys: object) -> None:
+    def test_fathom_help_lists_all_subcommands(self) -> None:
         """fathom --help lists execute/positions/reconcile alongside backtest/scan."""
         import subprocess
         import sys
@@ -1008,6 +1008,7 @@ class TestCliHelp:
         assert "scan" in output
         assert "watchlist" in output
         assert "chart" in output
+        assert "preflight" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #140

## Work-list checklist

**A. Issue body**
- [x] A1: `hermes_integration/jobs/daily.md` env-var names OANDA_API_KEY→OANDA_API_TOKEN, OANDA_ENV→ENV; distinguished Hermes-side ANTHROPIC_API_KEY vs Fathom-side LLM_API_KEY. tests/test_hermes_job.py did not pin the old names — no test amendment needed.
- [x] A2: docs/operator-acceptance.md — quoted the parenthesised candidate-ref (Gate 2, `fathom execute "EUR_USD:D:BollingerReversion(20,2.0)"`); lines 31-37 already correctly stated OANDA_API_TOKEN/ENV=demo/LLM_API_KEY (pre-fixed).
- [x] A3: replaced invented `macrossover_10_50` forms with `EUR_USD:D:BollingerReversion(20,2.0)` in CLAUDE.md, docs/go-live-runbook.md, and cli.py help/error text (2 sites).
- [x] A4: docs/operator-acceptance.md ~line 79 now `python scripts/run_monitor.py ...`.

**B. Review-comment follow-ups**
- [x] B5 (PR #146 review): added `assert "preflight" in output`, dropped dead `capsys: object` param in tests/test_execution_cli.py::test_fathom_help_lists_all_subcommands.
- [x] B6 (PR #147 review): hermes_integration/__init__.py docstring now describes the OpenAI-compatible adapter instead of "the anthropic SDK".
- [x] B7 (PR #150 review): corrected inverted "~150x over-risk" wording — rate=1.0 *under*-sizes JPY-quoted pairs (~157x), *over*-sizes quote currencies stronger than USD (~27% GBP-quoted) — in docs/features/position-sizing.md, docs/features/execution-cli.md, cli.py sizing comment, and TestExecuteConversionRateRequired docstring.
- [x] B8 (PR #150 review): added a one-line doc note (position-sizing.md) on cross-pair (e.g. EUR_JPY, USD account) conversion using the instrument's own mid as a bounded (~10%) approximation — verified this matches the actual `rate = 1.0 / last_mid` logic in cli.py; documentation only, no behavior change.

**C. Doc-lint guard**
- [x] Added `tests/test_docs_lint.py` — plain grep-style assertions that "OANDA_API_KEY"/"OANDA_ENV" don't appear in `hermes_integration/jobs/*.md` or `docs/operator-acceptance.md`, and "macrossover_10_50" doesn't appear in CLAUDE.md, docs/go-live-runbook.md, or cli.py. Verified RED against the pre-fix tree (grep confirmed occurrences before edits), GREEN after.

## Gate results

```
.venv/bin/python -m pytest -q
1233 passed, 1 skipped, 83 warnings in 38.74s

.venv/bin/python -m mypy .
Success: no issues found in 93 source files
```