### PR TITLE
docs(phases): scope phases 07-10 — standalone AI trading platform restructure

### DIFF
--- a/docs/phases/phase-07/phase.md
+++ b/docs/phases/phase-07/phase.md
@@ -1,0 +1,156 @@
+# phase-07 — Standalone platform: de-Hermes, on-demand AI analyze, Pine output
+
+**Status:** not_started
+**Commitment level:** Phase N — restructures the operator's daily workflow; ships to the operator immediately.
+**Time horizon:** open — next phase after phase-06 close
+**Depends on:** [`phase-06`](../phase-06/phase.md) (LLM provider adapter merged — WS1; CI merge gate)
+**Unlocks:** [`phase-08`](../phase-08/phase.md) (companion commands reuse the in-process AI call pattern), [`phase-09`](../phase-09/phase.md)
+
+## Purpose
+
+Fathom stops being a Hermes-agent helper and becomes a standalone CLI trading platform.
+The external Hermes orchestrator, its cron job, and Discord delivery are removed; the
+LLM analysis that Hermes performed (news-risk veto, narration) moves in-process onto the
+already-merged OpenAI-compatible adapter. Analysis happens **on demand at trade time**
+via one command — `fathom analyze` — instead of on a nightly schedule. The presentation
+layer changes from PNG charts (operator-confirmed: unused) to a **generated Pine Script**
+the operator pastes into TradingView, so candidates render on the charts they actually look at.
+
+Riskiest assumption tested: **the generated-Pine paste workflow is a usable daily surface.**
+There is no TradingView write API (settled decision — see
+[`implementation-plan.md`](../../implementation-plan.md) Workstream 2: TradingView MCPs are
+ToS-violating scrapers; nothing TradingView-derived enters the automated pipeline; Pine
+*output* is the clean inversion). If the paste-per-update loop is too much friction in
+practice, the presentation thesis fails — so Pine generation is built and operator-tested
+**first**, before the LLM pipeline work.
+
+## In scope
+
+1. **Pine Script generation** — `fathom pine`: render the latest persisted watchlist as a
+   Pine v6 indicator (entry/stop/target lines, direction marker, strategy label,
+   news/reduce-size flag per candidate), print to stdout + copy to clipboard. Built first
+   (riskiest-assumption probe).
+2. **`ai/` package** — rename `hermes_integration/` → `ai/`; move the news-risk and
+   narration LLM calls in-process using `OpenAICompatClient`
+   ([pretrade_check.py:231](../../../hermes_integration/pretrade_check.py)); the INV-02
+   parse boundaries (`parse_news_risk`, `parse_pretrade_verdict`) and safe defaults are
+   unchanged.
+3. **`fathom analyze`** — the on-demand trade-time pipeline: scan → per-candidate LLM
+   news-risk veto (INV-02 skip default) → regime tag → market brief → session
+   ("skip-the-day") verdict → narration → Pine generation. All advisory output is text to
+   the terminal; the LLM vetoes/flags/explains and never picks entries, sizes, or targets
+   (INV-01/INV-02 unchanged).
+4. **Hermes/Discord teardown** — delete `hermes_integration/jobs/daily.md`, the `fathom
+   chart` PNG command and `signals/chart` rendering path, and the Discord watchlist
+   delivery contract; retire the T-08 live-Discord operator gate (superseded by an
+   analyze/Pine acceptance walk).
+5. **Docs re-baseline** — Layer-2 [`architecture.md`](../../product/architecture.md)
+   redrawn without Hermes/Discord nodes; `CLAUDE.md` commands; feature INDEX;
+   [`operator-acceptance.md`](../../operator-acceptance.md) gate list updated.
+6. **`fathom execute` untouched** except the `hermes_integration` → `ai` import path; the
+   pre-trade veto and the whole Phase-3 gate remain as merged.
+
+## Out of scope
+
+- `fathom review`, `journal`, `ask`, deviation-log explainer — [`phase-08`](../phase-08/phase.md).
+- Counterfactual veto ledger (recording what blocked trades would have done) — [`phase-09`](../phase-09/phase.md).
+- AI research loop, trial ledger, deflation gate — [`phase-10`](../phase-10/phase.md).
+- Watcher server / bar-close scanning / demo autopilot — implementation-plan Workstream 3; unaffected here.
+- Any scheduler inside Fathom — analyze is on-demand only (operator decision, this scoping session).
+- TradingView read integrations (MCP scrapers, alert webhooks) — settled out of scope in Workstream 2; webhook intake stays deferred.
+- The Streamlit panel — stays as merged this phase; whether Pine+terminal obsoletes any views is a later Layer-3 decision.
+- Monitoring's Discord **alerter** (`monitoring/alerts.py`, deviation alerts) — scoping assumption — verify at spec time: it posts via plain webhook with no Hermes dependency, so teardown does not touch it.
+- Live trading — still INV-07-blocked; phase-05 gates unchanged.
+
+## Done when
+
+- [ ] `fathom analyze` runs the full pipeline end-to-end against the demo store with a live
+      `LLM_*` key: candidates ranked, ≥1 news-risk verdict per candidate, regime tag +
+      market brief + session verdict + narration printed, Pine script emitted — and with
+      `LLM_API_KEY` unset every LLM step falls back to its INV-02 safe default
+      (news-risk → skip) or deterministic fallback (narration), never crashing.
+- [ ] Operator pastes generated Pine into TradingView and confirms levels render correctly
+      on ≥3 candidates across ≥2 instruments (the riskiest-assumption acceptance walk).
+- [ ] `grep -ri hermes` over code + operator docs returns nothing but historical
+      phase/results docs; `fathom chart` is gone from the CLI; the test suite and doc-lint
+      pass green in CI.
+- [ ] `fathom execute --dry-run` still walks the full gate (proof the boundary code
+      survived the rename).
+- [ ] Layer-2 architecture diagram redrawn; phase diagrams 00–06 untouched (historical).
+
+## Architecture (this phase)
+
+Strict subset of the **post-phase-07** [`architecture.md`](../../product/architecture.md)
+(this phase is the one that redraws it — Hermes/Discord removed, `ai/` added):
+
+```mermaid
+graph TD
+    subgraph ext["External Systems"]
+        OANDA["OANDA v20 API"]
+        LLM_API["LLM provider\nOpenAI-compatible (LLM_* env)"]
+        CALENDAR["Economic Calendar"]
+        TV["TradingView\nhuman dashboard — Pine paste (manual)"]
+    end
+
+    subgraph fathom["Fathom — standalone CLI"]
+        CLI["cli.py\nfathom analyze | pine | scan | watchlist | execute …"]
+
+        subgraph signal_layer["Signal Pipeline"]
+            RANKER["ranker.py"]
+            PORTFOLIO["portfolio.py"]
+        end
+
+        subgraph ai_layer["AI Analysis (ai/, was hermes_integration/)"]
+            NEWSRISK["news_risk.py\nin-process LLM call + INV-02 parse"]
+            BRIEF["brief.py\nmarket brief · regime tag · session verdict"]
+            NARRATE["narration.py"]
+            PRETRADE["pretrade_check.py\nunchanged"]
+        end
+
+        PINE["pine.py\nwatchlist → Pine v6 indicator"]
+        STORE["store.py\nSQLite + Parquet"]
+    end
+
+    CLI --> RANKER --> PORTFOLIO --> NEWSRISK
+    NEWSRISK --> BRIEF --> NARRATE
+    NEWSRISK -- "verdicts" --> STORE
+    CLI --> PINE
+    STORE --> PINE
+    PINE -. "clipboard paste (human)" .-> TV
+    NEWSRISK & BRIEF & NARRATE & PRETRADE --> LLM_API
+    RANKER --> STORE
+    CLI --> OANDA
+    CALENDAR --> NEWSRISK
+```
+
+## Anticipated specs
+
+| Feature | Hint |
+|---|---|
+| pine-generation | Watchlist → Pine v6 indicator; level lines + labels; clipboard; stdout; deterministic, no LLM |
+| ai-package-migration | `hermes_integration/`→`ai/`; in-process news-risk call on `OpenAICompatClient`; parsers/prompts unchanged; import sweep |
+| analyze-command | Pipeline orchestration, per-candidate loop, offline fail-safe path, terminal output format |
+| market-brief | Brief + regime tag + session verdict: prompt templates, pydantic response models, INV-02 posture (advisory ⇒ fallback-text, not veto) |
+| hermes-teardown | Delete chart/PNG + daily job + Discord contract; retire T-08; docs re-baseline + doc-lint update |
+
+## Scoping assumptions
+
+- Verified: the pre-trade veto is already in-process and provider-agnostic
+  ([pretrade_check.py:231-309](../../../hermes_integration/pretrade_check.py)); news-risk and
+  narration are parser/fallback-only with the LLM call Hermes-side
+  ([news_risk.py:16](../../../hermes_integration/news_risk.py),
+  [narration.py:23](../../../hermes_integration/narration.py)); the daily job exists only as
+  a plain-English Hermes job doc ([daily.md](../../../hermes_integration/jobs/daily.md)) —
+  no Hermes runtime lives in this repo.
+- scoping assumption — verify at spec time: `fathom chart` / its rendering module is not
+  imported by the Streamlit panel's Charts view (the panel is believed to render via
+  `streamlit-lightweight-charts` directly from the store; if it does import the chart
+  module, teardown must leave the shared code and delete only the CLI command).
+- scoping assumption — verify at spec time: `monitoring/alerts.py` posts to Discord via a
+  plain webhook with no Hermes dependency, so it survives teardown untouched.
+- scoping assumption — verify at spec time: Pine v6 supports enough drawing primitives from
+  a single pasted indicator (lines at absolute price levels, labels, colors per instrument
+  scoped by `syminfo.ticker`) to render the full watchlist from one script.
+- scoping assumption — verify at spec time: the T-08 operator gate can be retired without
+  breaking phase-02's recorded results (T-08 was acceptance for a delivery channel this
+  phase deletes; the replacement is the Pine acceptance walk above).

--- a/docs/phases/phase-08/phase.md
+++ b/docs/phases/phase-08/phase.md
@@ -1,0 +1,129 @@
+# phase-08 — Trader companion commands: review, journal, ask, deviation explainer
+
+**Status:** not_started
+**Commitment level:** Phase N — additive operator tooling on the phase-07 platform.
+**Time horizon:** open — after phase-07
+**Depends on:** [`phase-07`](../phase-07/phase.md) (`ai/` package + in-process LLM call pattern + prompt-template convention)
+**Unlocks:** nothing hard — [`phase-09`](../phase-09/phase.md) is independent but shares the AI surface
+
+## Purpose
+
+Round out the "AI-supported trader" loop with four read-only companion commands. Each one
+takes data Fathom already persists (positions, reconcile reports, deviation log, executed
+trades, watchlist history), hands it to the LLM with a purpose-built prompt, and prints
+advisory text. Nothing here gains order authority: every command is INV-01-safe read-only
+analysis; a total LLM outage degrades each command to "no analysis available", never to a
+wrong action.
+
+Riskiest assumption tested: **LLM commentary over the store's own data is useful enough
+that the operator keeps running these commands** — the cheap test of the whole
+"AI-supported trader" thesis before phase-09/10 invest in heavier machinery.
+
+## In scope
+
+1. **`fathom review`** — open positions + latest reconcile report + deviation log → LLM
+   flags anomalies (position near a calendar event, unusual stop distance, unexplained
+   broker-vs-db deviation) with a "worth investigating?" flag each.
+2. **`fathom journal`** — auto-append a journal entry on every `fathom execute` outcome
+   (candidate facts, verdicts, operator decision, dry-run/submitted); `fathom journal
+   show|summarize` renders entries and LLM-summarizes patterns over time.
+3. **`fathom ask "<question>"`** — freeform Q&A grounded strictly in store data
+   (watchlist, approved set, backtest metrics, positions); refuses questions needing data
+   it does not hold rather than speculating.
+4. **Deviation-log explainer** — folded into `fathom review` (or `fathom review
+   --deviations`): plain-English diagnosis per deviation entry.
+5. **Shared plumbing** — one `ai/companion.py` call-shape (context-pack builder + prompt
+   template + bounded response) so all four commands are the same pattern, testable
+   offline with injected stub clients.
+
+## Out of scope
+
+- Any write path to broker, risk, or execution modules — these commands import store
+  readers only; the AST forbidden-import boundary test pattern extends to them.
+- Counterfactual veto tracking — [`phase-09`](../phase-09/phase.md).
+- Research loop / strategy proposal — [`phase-10`](../phase-10/phase.md).
+- Journal entries feeding sizing, ranking, or any automated decision — journal is a
+  record + narrative summary only.
+- Scheduled/digest modes for these commands — on-demand only, same operator decision as phase-07.
+- Panel views for journal/review — CLI only this phase.
+- New data capture (no new market data, no broker endpoints beyond what reconcile already reads).
+
+## Done when
+
+- [ ] All four commands run green against the demo store with a live `LLM_*` key and print
+      grounded, non-empty analysis; with `LLM_API_KEY` unset each prints its deterministic
+      fallback ("analysis unavailable" + raw data tables) and exits 0.
+- [ ] `fathom execute` (both dry-run and demo submit) appends a journal row; a repeated
+      execute of the same candidate does not duplicate it (idempotent on client-order-id).
+- [ ] `fathom ask` answers ≥3 operator questions correctly from store data and visibly
+      declines one out-of-scope question without fabricating.
+- [ ] AST boundary test proves none of the companion modules can import order/risk/execution.
+- [ ] CI green; CLAUDE.md commands + feature INDEX updated.
+
+## Architecture (this phase)
+
+Superset of the phase-07 diagram — adds the companion layer (dashed = new this phase):
+
+```mermaid
+graph TD
+    subgraph ext["External Systems"]
+        OANDA["OANDA v20 API"]
+        LLM_API["LLM provider\nOpenAI-compatible"]
+        CALENDAR["Economic Calendar"]
+        TV["TradingView (Pine paste)"]
+    end
+
+    subgraph fathom["Fathom — standalone CLI"]
+        CLI["cli.py\nanalyze | pine | review | journal | ask | execute …"]
+
+        subgraph signal_layer["Signal Pipeline"]
+            RANKER["ranker.py"]
+            PORTFOLIO["portfolio.py"]
+        end
+
+        subgraph ai_layer["AI Analysis (ai/)"]
+            NEWSRISK["news_risk.py"]
+            BRIEF["brief.py"]
+            NARRATE["narration.py"]
+            PRETRADE["pretrade_check.py"]
+            COMPANION["companion.py\nreview · journal · ask · deviation explainer"]
+        end
+
+        PINE["pine.py"]
+        STORE["store.py\n+ journal table"]
+        RECONCILE["reconcile.py"]
+    end
+
+    CLI --> RANKER --> PORTFOLIO --> NEWSRISK --> BRIEF --> NARRATE
+    CLI --> PINE
+    STORE --> PINE
+    PINE -. paste .-> TV
+    CLI --> COMPANION
+    STORE --> COMPANION
+    RECONCILE --> COMPANION
+    NEWSRISK & BRIEF & NARRATE & PRETRADE & COMPANION --> LLM_API
+    CLI --> OANDA
+    CALENDAR --> NEWSRISK
+    RANKER --> STORE
+    style COMPANION stroke-dasharray: 5 5
+```
+
+## Anticipated specs
+
+| Feature | Hint |
+|---|---|
+| companion-core | Context-pack builder + shared call shape + offline fallbacks + AST boundary test |
+| review-command | Positions/reconcile/deviation context; anomaly-flag response model; deviation explainer flag |
+| journal | Journal table schema, execute-hook append (idempotent), show/summarize subcommands |
+| ask-command | Grounding contract (store-data-only), refusal behavior, question → context routing |
+
+## Scoping assumptions
+
+- Verified this scoping session: reconcile reports, positions, and a deviation log are
+  persisted and readable (`fathom positions`, `fathom reconcile`; panel Deviation Log view
+  per [`CLAUDE.md`](../../../CLAUDE.md)).
+- scoping assumption — verify at spec time: the deviation log's stored fields carry enough
+  context (expected vs actual, timestamps, instrument) for a per-entry explanation without
+  new capture.
+- scoping assumption — verify at spec time: `fathom execute` has a single post-gate exit
+  point where a journal append hook can attach without touching gate logic.

--- a/docs/phases/phase-09/phase.md
+++ b/docs/phases/phase-09/phase.md
@@ -1,0 +1,136 @@
+# phase-09 — Counterfactual veto ledger
+
+**Status:** not_started
+**Commitment level:** Phase N — evaluation infrastructure; ships to the operator as `fathom veto-report`.
+**Time horizon:** open — after phase-07 (phase-08 not required)
+**Depends on:** [`phase-07`](../phase-07/phase.md) (`ai/` package; analyze pipeline producing news-risk verdicts worth auditing)
+**Unlocks:** [`phase-10`](../phase-10/phase.md) Phase E (shadow-mode evaluation of the veto reuses this ledger — see [`implementation-plan.md`](../../implementation-plan.md) Workstream 4)
+
+## Purpose
+
+Every LLM veto is currently unfalsifiable: when the news-risk gate skips a candidate or the
+pre-trade gate blocks an order, nobody learns whether the veto saved money or cost an
+opportunity. This phase records every veto verdict (both gates) with the full candidate
+snapshot, then tracks the counterfactual — what the bracket-order trade would have done —
+from subsequent candle data. `fathom veto-report` aggregates: veto hit-rate, opportunity
+cost, and whether the AI gates earn their keep. This is the honest measurement that
+phase-10's tiered-autonomy ladder later requires before the LLM gains any authority.
+
+Riskiest assumption tested: **the counterfactual can be computed honestly from candle data
+alone** — a would-be trade's outcome (entry fill, stop/target hit ordering within a bar)
+must reuse the backtest engine's conservative fill rules, or the report is fiction.
+
+## In scope
+
+1. **Veto ledger table** — append-only: verdict source (news-risk | pretrade), full
+   `Candidate` snapshot, verdict JSON, prompt/template version, model id, timestamp (UTC).
+   Written on every verdict — proceed and block alike (proceeds are the baseline).
+2. **Counterfactual tracker** — `fathom veto-report --refresh`: for each ledger entry past
+   its trade horizon, replay the would-be bracket order over stored candles using the
+   backtest engine's fill/cost rules; persist outcome (target/stop/timeout, R-multiple).
+3. **`fathom veto-report`** — aggregate view: per-gate block rate, counterfactual win/loss
+   of blocked trades, net R saved/cost, broken down by instrument/timeframe/strategy.
+4. **Execute-gate + analyze-pipeline recording hooks** — minimal, behind their own spec
+   and fresh review (this touches INV-01/INV-02 boundary code; recording must be
+   side-effect-only and unable to alter any verdict).
+
+## Out of scope
+
+- Acting on the report — no automatic threshold that re-enables or disables a gate;
+  interpretation stays with the operator until phase-10 Phase E's champion-challenger
+  machinery.
+- Changing either veto's behavior, prompts, or safe defaults — measurement only.
+- Counterfactuals for trades the *operator* declined at the confirm prompt — scoping
+  assumption below; if cheap, it rides along, else deferred to phase-10 Phase E.
+- Live-account anything — demo/dry-run verdicts only until INV-07 clears.
+- New market-data capture — the tracker uses candles the store already fetches; if a
+  candidate's timeframe candles lapse, the outcome is recorded `unknown`, not fetched ad hoc.
+- Panel view for the report — CLI table/JSON only this phase.
+
+## Done when
+
+- [ ] Every `fathom analyze` news-risk verdict and every `fathom execute` pretrade verdict
+      (dry-run included) lands one ledger row; rows are append-only (no update path exists)
+      and never mutate gate behavior — proven by tests that diff gate outputs with the
+      ledger disabled vs enabled.
+- [ ] `fathom veto-report --refresh` resolves outcomes for all due entries against stored
+      candles, using engine fill rules (stop-before-target within-bar convention identical
+      to the backtester); re-running is idempotent.
+- [ ] `fathom veto-report` prints the aggregate with ≥10 resolved counterfactuals from demo
+      operation, including the explicit `unknown` bucket.
+- [ ] Boundary review: fresh reviewer confirms the recording hooks cannot raise into, or
+      change control flow of, either gate (a ledger write failure logs WARNING and the
+      trade path proceeds as if the ledger did not exist).
+- [ ] CI green; CLAUDE.md + feature INDEX updated.
+
+## Architecture (this phase)
+
+Superset of the phase-08 diagram — adds the ledger + tracker (dashed = new this phase;
+companion layer collapsed for legibility):
+
+```mermaid
+graph TD
+    subgraph ext["External Systems"]
+        OANDA["OANDA v20 API"]
+        LLM_API["LLM provider"]
+        TV["TradingView (Pine paste)"]
+    end
+
+    subgraph fathom["Fathom — standalone CLI"]
+        CLI["cli.py\n… | veto-report"]
+
+        subgraph ai_layer["AI Analysis (ai/)"]
+            NEWSRISK["news_risk.py"]
+            PRETRADE["pretrade_check.py"]
+            COMPANION["companion.py (phase-08)"]
+        end
+
+        subgraph eval_layer["Veto Evaluation"]
+            LEDGER["veto_ledger.py\nappend-only verdict rows"]
+            TRACKER["counterfactual.py\nreplay via backtest fill rules"]
+        end
+
+        ENGINE["backtest/engine.py\nfill + cost rules (reused)"]
+        EXECUTE["execution gate\n(fathom execute — unchanged flow)"]
+        PINE["pine.py"]
+        STORE["store.py\n+ veto_ledger table"]
+    end
+
+    NEWSRISK -- "verdict (side-effect write)" --> LEDGER
+    PRETRADE -- "verdict (side-effect write)" --> LEDGER
+    EXECUTE --> PRETRADE
+    LEDGER --> STORE
+    CLI --> TRACKER
+    STORE --> TRACKER
+    TRACKER --> ENGINE
+    TRACKER -- outcomes --> STORE
+    NEWSRISK & PRETRADE & COMPANION --> LLM_API
+    CLI --> PINE -. paste .-> TV
+    CLI --> OANDA
+    style LEDGER stroke-dasharray: 5 5
+    style TRACKER stroke-dasharray: 5 5
+```
+
+## Anticipated specs
+
+| Feature | Hint |
+|---|---|
+| veto-ledger | Schema, append-only guarantee, recording hooks in both gates, failure-isolation contract |
+| counterfactual-tracker | Bracket replay reusing engine fill rules; horizon/timeout policy; idempotent refresh; `unknown` bucket |
+| veto-report | Aggregation, breakdowns, output format (table + JSON) |
+
+## Scoping assumptions
+
+- Verified this scoping session: both verdicts are typed pydantic models with a single
+  parse boundary each ([news_risk.py:46](../../../hermes_integration/news_risk.py),
+  [pretrade_check.py:88](../../../hermes_integration/pretrade_check.py)) — recording can
+  wrap the parse-boundary return without touching gate internals.
+- scoping assumption — verify at spec time: the backtest engine's fill logic is callable
+  on a single synthetic bracket order without dragging in the full walk-forward harness
+  (if not, extract a `simulate_bracket()` helper as part of the tracker spec).
+- scoping assumption — verify at spec time: candle retention covers each candidate's
+  timeframe horizon long enough to resolve most counterfactuals (H1 brackets may need
+  days of H1 history after the verdict).
+- scoping assumption — verify at spec time: operator-declined trades (gate passed, human
+  said no at the confirm prompt) are visible at a single point in `cli.py` where a
+  `declined` ledger row could be written cheaply.

--- a/docs/phases/phase-10/phase.md
+++ b/docs/phases/phase-10/phase.md
@@ -1,0 +1,137 @@
+# phase-10 — AI quant research loop (Workstream 4, Phases A–E)
+
+**Status:** not_started
+**Commitment level:** Phase N — research infrastructure; each epic ships operator-usable tooling.
+**Time horizon:** open — the long game; starts after phase-07 (phase-08/09 desirable first: 09's ledger is Phase E's substrate)
+**Depends on:** [`phase-06`](../phase-06/phase.md) (#143 real-data fixture — the verification ladder's rung 1), [`phase-07`](../phase-07/phase.md) (`ai/` adapter), [`phase-09`](../phase-09/phase.md) (veto ledger, for epic E)
+**Unlocks:** AI-proposed strategies entering `approved_set` through an honest statistical gate
+
+## Purpose
+
+Let AI expand the strategy set without self-deception. The full design, rationale, and
+literature anchors live in [`implementation-plan.md`](../../implementation-plan.md)
+Workstream 4 and are not duplicated here: LLM research loops amplify multiple-testing bias
+and carry memorized market history, so the load-bearing mechanisms are an **append-only
+trial ledger** (honest trial count N — INV-17), a **deflation-gated promotion path**
+(Deflated Sharpe / PBO / MinTRL — INV-18, frozen eval config INV-19), and a **constrained
+proposal DSL** with post-training-cutoff-only clean evidence.
+
+Riskiest assumption tested: **a deflation-corrected gate still lets *anything* through** —
+if honest statistics reject every AI-proposed variant (as the cited 2026 research suggests
+they usually should), the loop's value is proving that cheaply rather than trading fiction.
+
+This phase is deliberately registered as one phase with five epics. Per
+`/halfcycle:phase-rescope`, each epic gets its own `phase-10.E/phase.md` + strict-subset
+diagram at kickoff; the epic split below is the settled seam (it mirrors Workstream 4's
+lettered phases, which are sequenced and load-bearing in the implementation plan).
+
+## In scope (as epics)
+
+1. **phase-10.1 — Trial ledger + `run_trial()`** (WS4 Phase A remainder): append-only
+   `trial_log` populated inside the single backtest entry point; `backtest/trials.py`.
+2. **phase-10.2 — Statistics gate** (Phase B): `backtest/deflation.py` — PSR, DSR, PBO/CSCV,
+   MinTRL; `fathom verify <combo>`; promotion to `approved_set` requires the full ladder.
+3. **phase-10.3 — Research MCP server** (Phase C): `propose_trial` (StrategySpec DSL v1),
+   `run_backtest`, `get_result`, `list_trials`, `get_stats`; hard session budgets.
+4. **phase-10.4 — Research agent + contamination controls** (Phase D): pre-register →
+   propose → backtest → diagnose loop; post-cutoff clean-evidence rule; date-blind prompting.
+5. **phase-10.5 — Tiered autonomy + evaluating the AI** (Phase E): Observe → Advise →
+   Act-with-approval → bounded-autonomous-demo ladder; champion-challenger on the pretrade
+   veto over the phase-09 ledger.
+
+## Out of scope
+
+- Any relaxation of INV-01: live execution remains operator-only at every autonomy tier;
+  "bounded-autonomous" is demo-only.
+- LLM-decided entries, exits, sizing, or numeric forecasts; free-form agent-authored
+  Python (DSL v1 only) — settled in implementation-plan "Out of scope".
+- Raising risk caps or trading AI-proposed strategies live before INV-07 + MinTRL are
+  satisfied on the demo track record.
+- Multi-agent debate as a signal source.
+- Workstream 3 (watcher, exit management, new hand-built sleeves) — parallel track, not
+  part of this phase; its sleeves do climb the same phase-10.2 ladder once it exists.
+- Treating pre-cutoff OOS windows as clean evidence for agent-proposed strategies.
+
+## Done when
+
+- [ ] Every backtest run in the repo — human- or agent-initiated — lands trial-ledger rows
+      by construction (INV-17 test: no code path reaches the engine without logging).
+- [ ] `fathom verify` reproduces the pinned real-data fixture's DSR by hand-computed value
+      (validated against `pypbo`) and gates `approved_set` promotion (INV-18).
+- [ ] The research agent completes a budgeted session end-to-end: N proposals, all ledgered,
+      ≥0 survivors of the deflation gate, and a session report stating the honest N.
+- [ ] Date-sensitivity diagnostic shows the agent's proposals are not exploiting memorized
+      history (four-arm test per the plan).
+- [ ] Champion-challenger report on the pretrade veto exists with trial-corrected
+      incremental value, before any autonomy-tier promotion.
+- [ ] New invariants INV-17/18/19 recorded in [`invariants.md`](../../product/invariants.md).
+
+## Architecture (this phase)
+
+Superset of the phase-09 diagram — adds the research loop (dashed = new; earlier layers
+collapsed; the epic docs carry per-epic subsets):
+
+```mermaid
+graph TD
+    subgraph ext["External Systems"]
+        OANDA["OANDA v20 API"]
+        LLM_API["LLM provider"]
+        AGENT["Research agent\n(any model via adapter)"]
+    end
+
+    subgraph fathom["Fathom — standalone CLI"]
+        CLI["cli.py\n… | verify"]
+
+        subgraph research["Research Loop"]
+            MCP["mcp research server\npropose_trial · run_backtest · get_stats"]
+            DSL["StrategySpec DSL v1\nvalidated compositions only"]
+            TRIALS["backtest/trials.py\nrun_trial() + trial_log (INV-17)"]
+            DEFLATE["backtest/deflation.py\nPSR · DSR · PBO · MinTRL (INV-18)"]
+        end
+
+        ENGINE["backtest/engine.py"]
+        APPROVED["approved_set\n(promotion via full ladder only)"]
+        LEDGER["veto_ledger (phase-09)\n→ champion-challenger (epic E)"]
+        STORE["store.py\n+ trial_log table"]
+    end
+
+    AGENT --> MCP --> DSL --> TRIALS --> ENGINE
+    TRIALS --> STORE
+    CLI --> DEFLATE
+    STORE --> DEFLATE
+    DEFLATE --> APPROVED
+    LEDGER --> DEFLATE
+    AGENT --> LLM_API
+    ENGINE --> OANDA
+    style MCP stroke-dasharray: 5 5
+    style DSL stroke-dasharray: 5 5
+    style TRIALS stroke-dasharray: 5 5
+    style DEFLATE stroke-dasharray: 5 5
+```
+
+## Anticipated specs
+
+Per-epic; authored at each epic's kickoff, not now (Layer 4 details only the current phase):
+
+| Epic | Spec seeds |
+|---|---|
+| phase-10.1 | trial-ledger schema + INV-17 by-construction test; run_trial extraction from `cli._run_combo` |
+| phase-10.2 | deflation module (validated vs pypbo + hand-computed fixture); `fathom verify`; INV-18/19 |
+| phase-10.3 | StrategySpec DSL v1 grammar; MCP tool surface; session budgets |
+| phase-10.4 | agent loop harness; clean-evidence rule; date-blind prompting; four-arm diagnostic |
+| phase-10.5 | autonomy ladder + promotion gates; champion-challenger over the veto ledger |
+
+## Scoping assumptions
+
+- Verified: Workstream 4's design, sequencing, formulas, and out-of-scope list are already
+  settled in [`implementation-plan.md`](../../implementation-plan.md) (Workstream 4 section);
+  this doc adds phase ids and gates, not new design.
+- scoping assumption — verify at spec time: `cli._run_combo` is still the single backtest
+  entry point suitable for promotion into `run_trial()` (the plan asserts it; re-anchor at
+  phase-10.1 spec time).
+- scoping assumption — verify at spec time: `pypbo` is maintained and installable on the
+  pinned Python version; otherwise the validation reference becomes hand-computed fixtures
+  only.
+- scoping assumption — verify at spec time: phase-06 #143 (real-data fixture) has landed —
+  it is rung 1 of the verification ladder and a hard prerequisite for phase-10.2's
+  hand-computed DSR check.

--- a/docs/phases/phases-manifest.json
+++ b/docs/phases/phases-manifest.json
@@ -82,6 +82,34 @@
       "open_items": [
         "#143 real-OANDA-data fixture — blocked on human (OANDA practice token or candle-db export)"
       ]
+    },
+    {
+      "id": "phase-07",
+      "name": "Standalone platform — de-Hermes, on-demand AI analyze, Pine output",
+      "commitment": "Phase N",
+      "status": "not_started",
+      "doc": "phase-07/phase.md"
+    },
+    {
+      "id": "phase-08",
+      "name": "Trader companion commands — review, journal, ask, deviation explainer",
+      "commitment": "Phase N",
+      "status": "not_started",
+      "doc": "phase-08/phase.md"
+    },
+    {
+      "id": "phase-09",
+      "name": "Counterfactual veto ledger — record every veto, replay the would-be trade, veto-report",
+      "commitment": "Phase N",
+      "status": "not_started",
+      "doc": "phase-09/phase.md"
+    },
+    {
+      "id": "phase-10",
+      "name": "AI quant research loop (WS4 A-E as epics 10.1-10.5) — trial ledger, deflation gate, DSL, agent, tiered autonomy",
+      "commitment": "Phase N",
+      "status": "not_started",
+      "doc": "phase-10/phase.md"
     }
   ]
 }

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -112,6 +112,52 @@ graph TD
 
 ---
 
+## Architecture Decision Records
+
+Load-bearing decisions, numbered and dated. Status: **accepted** (in force) or
+**accepted — lands in phase-NN** (decided, implementation scheduled). A decision here
+overrides any older prose elsewhere in this doc or in [spec.md](spec.md) that says
+otherwise; the prose is redrawn when the implementing phase lands.
+
+### ADR-001 — Standalone CLI platform; Hermes orchestrator removed
+**Date:** 2026-09-01 · **Status:** accepted — lands in [phase-07](../phases/phase-07/phase.md)
+Fathom becomes a self-contained CLI trading platform. The external Hermes Agent (cron
+orchestration, Claude calls, Discord gateway) is removed; the LLM analysis it performed
+(news-risk veto, narration) moves in-process onto the ADR-002 adapter, and the daily
+scheduled watchlist is replaced by on-demand analysis (ADR-004). INV-01 is unchanged in
+substance — order authority stays behind the operator-only `fathom execute` gate; the
+"Hermes must not place orders" boundary becomes "no AI/analysis surface may import or
+invoke execution". **Supersedes** spec.md Confirmed Decision #1 (Discord-via-Hermes
+delivery) and the Hermes half of Decision #2 and #6.
+
+### ADR-002 — Provider-agnostic OpenAI-compatible LLM adapter
+**Date:** 2026-08-31 · **Status:** accepted (implemented in phase-06 / Workstream 1)
+All LLM calls go through one `OpenAICompatClient` speaking the OpenAI chat-completions
+wire format over httpx, selected via `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL`
+(OpenAI, Groq, NIM, OpenRouter, Ollama, …). No `anthropic` SDK dependency; no
+per-provider code paths. INV-02 parse boundaries with fail-closed safe defaults wrap
+every call.
+
+### ADR-003 — TradingView posture: Pine Script out, nothing TradingView-derived in
+**Date:** 2026-09-01 · **Status:** accepted — Pine output lands in [phase-07](../phases/phase-07/phase.md)
+TradingView has no retail write API; third-party "TradingView MCP" servers are
+ToS-violating scrapers. Therefore **no TradingView-derived data ever enters the automated
+pipeline** (settled in [implementation-plan.md](../implementation-plan.md) Workstream 2),
+and the one sanctioned TradingView surface is *outbound*: Fathom generates a Pine v6
+indicator from the persisted watchlist which the operator manually pastes into their own
+charts. This replaces PNG chart rendering as the presentation layer (operator-confirmed
+unused). Execution and market data stay on OANDA v20 exclusively.
+
+### ADR-004 — On-demand analysis at trade time; no built-in scheduler
+**Date:** 2026-09-01 · **Status:** accepted — lands in [phase-07](../phases/phase-07/phase.md)
+Analysis runs when the operator sits down to trade — one `fathom analyze` command (scan →
+news-risk → regime tag → market brief → session verdict → narration → Pine) — not on a
+cron schedule, and with no scheduler daemon inside Fathom. Discord watchlist delivery is
+retired with the Hermes job (ADR-001); terminal + TradingView is the delivery surface.
+(The deviation *monitor's* webhook alerting is a separate concern and keeps its channel.)
+
+---
+
 ## Key Boundaries
 
 ### The Hermes Boundary

--- a/docs/product/spec.md
+++ b/docs/product/spec.md
@@ -25,12 +25,12 @@ Fathom is a Python forex algorithmic trading system that:
 
 | # | Decision | Value |
 |---|---|---|
-| 1 | Alert & delivery channel | Discord, via Hermes' Discord gateway |
-| 2 | Hosting | Own private server (always-on; runs Hermes, monitor, panel) |
+| 1 | Alert & delivery channel | ~~Discord, via Hermes' Discord gateway~~ **Superseded** by [ADR-001/ADR-004](architecture.md#architecture-decision-records): terminal + TradingView Pine paste; Hermes and Discord watchlist delivery removed (phase-07) |
+| 2 | Hosting | Own private server (always-on; runs monitor, panel — ~~Hermes~~ removed per [ADR-001](architecture.md#architecture-decision-records)) |
 | 3 | Admin panel | Streamlit + TradingView Lightweight Charts (Apache 2.0) to start; FastAPI + JS/React later |
 | 4 | Pair universe | All FX pairs OANDA offers in region; scan everything, rank naturally filters illiquid exotics |
 | 5 | Per-trade risk | ~0.25% of equity, plus daily loss cap; revisit only after positive demo track record |
-| 6 | Intraday cadence | Start swing/daily; add intraday Hermes run once a strategy earns it |
+| 6 | Intraday cadence | Start swing/daily; ~~add intraday Hermes run once a strategy earns it~~ intraday capture is the watcher server (implementation-plan Workstream 3); analysis itself is on-demand per [ADR-004](architecture.md#architecture-decision-records) |
 
 ---
 


### PR DESCRIPTION
## Summary

Layer-3 phase scoping for the de-Hermes restructure and the AI-supported-trader feature set (12 features grouped into 4 phases), following the canonical halfcycle layout:

- **phase-07** — Standalone platform: `hermes_integration/` → `ai/` with news-risk + narration in-process on the WS1 OpenAI-compatible adapter; on-demand `fathom analyze` (news-risk veto, regime tag, market brief, session verdict, narration); **Pine Script output** replacing PNG charts; teardown of the Hermes daily job and Discord watchlist delivery. Riskiest assumption (Pine paste workflow usability) is probed first.
- **phase-08** — Companion commands: `fathom review`, `fathom journal`, `fathom ask`, deviation-log explainer. Read-only, AST-boundary-guarded.
- **phase-09** — Counterfactual veto ledger: append-only verdict recording in both LLM gates, bracket replay via the backtest engine's fill rules, `fathom veto-report`.
- **phase-10** — AI quant research loop: Workstream 4 Phases A–E registered as epics 10.1–10.5 (trial ledger/INV-17, deflation gate/INV-18-19, StrategySpec DSL + research MCP, agent + contamination controls, tiered autonomy).

All four registered `not_started` in `phases-manifest.json`; ids validated with `phase.py list`; every unverified claim tagged `scoping assumption — verify at spec time`; doc-lint suite green.

Also merges latest `main` (docs restructure) into the worktree branch.

## Test plan
- [x] `pytest tests/test_docs_lint.py` — 5 passed
- [x] `phase.py list` accepts all canonical ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)